### PR TITLE
Prepare aws-lc-fips-sys v0.13.1

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.13.0"
-links = "aws_lc_fips_0_13_0"
+version = "0.13.1"
+links = "aws_lc_fips_0_13_1"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-fips-sys/builder/sys_bindgen.rs
+++ b/aws-lc-fips-sys/builder/sys_bindgen.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::{get_rust_include_path, BindingOptions, COPYRIGHT};
+use crate::{get_rust_include_path, BindingOptions, COPYRIGHT, PRELUDE};
 use bindgen::callbacks::{ItemInfo, ParseCallbacks};
 use std::fmt::Debug;
 use std::path::Path;
@@ -31,29 +31,6 @@ impl ParseCallbacks for StripPrefixCallback {
     }
 }
 
-const PRELUDE: &str = r"
-#![allow(
-    clippy::cast_lossless,
-    clippy::cast_possible_truncation,
-    clippy::default_trait_access,
-    clippy::must_use_candidate,
-    clippy::not_unsafe_ptr_arg_deref,
-    clippy::ptr_as_ptr,
-    clippy::pub_underscore_fields,
-    clippy::semicolon_if_nothing_returned,
-    clippy::too_many_lines,
-    clippy::unreadable_literal,
-    clippy::used_underscore_binding,
-    clippy::useless_transmute,
-    dead_code,
-    improper_ctypes,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals,
-    unused_imports,
-)]
-";
-
 fn prepare_bindings_builder(manifest_dir: &Path, options: &BindingOptions) -> bindgen::Builder {
     let clang_args = crate::prepare_clang_args(manifest_dir, options);
 
@@ -62,7 +39,7 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: &BindingOptions) -> bi
         .derive_debug(true)
         .derive_default(true)
         .derive_eq(true)
-        .allowlist_file(r".*(/|\\)openssl(/|\\)[^/\\]+\.h")
+        .allowlist_file(r".*(/|\\)openssl((/|\\)[^/\\]+)+\.h")
         .allowlist_file(r".*(/|\\)rust_wrapper\.h")
         .rustified_enum(r"point_conversion_form_t")
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
@@ -17,7 +17,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_H	
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_13_0
+#define BORINGSSL_PREFIX aws_lc_fips_0_13_1
 #endif // BORINGSSL_PREFIX
 
 

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
@@ -20,7 +20,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_ASM_H
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_13_0
+#define BORINGSSL_PREFIX aws_lc_fips_0_13_1
 #endif // BORINGSSL_PREFIX
 
 // On iOS and macOS, we need to treat assembly symbols differently from other

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
@@ -17,7 +17,7 @@
 %define BORINGSSL_PREFIX_SYMBOLS_NASM_INC
 
 %ifndef BORINGSSL_PREFIX
-%define BORINGSSL_PREFIX aws_lc_fips_0_13_0
+%define BORINGSSL_PREFIX aws_lc_fips_0_13_1
 %endif ; BORINGSSL_PREFIX
 
 ; 32-bit Windows adds underscores to C functions, while 64-bit Windows does not.

--- a/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -4550,7 +4553,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4558,7 +4561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4566,15 +4569,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4586,7 +4589,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4595,7 +4598,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4606,7 +4609,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4617,7 +4620,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4629,7 +4632,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4639,7 +4642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4649,7 +4652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4660,7 +4663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5207,27 +5210,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5235,29 +5238,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5265,7 +5268,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5273,11 +5276,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5285,15 +5288,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5380,11 +5383,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5392,19 +5395,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5412,19 +5415,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5522,11 +5525,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5534,19 +5537,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5554,15 +5557,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5660,11 +5663,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5672,19 +5675,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5692,42 +5695,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_calloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5735,62 +5738,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isalpha"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isalnum"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isspace"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5798,7 +5801,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5807,7 +5810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5816,7 +5819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5824,7 +5827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5832,21 +5835,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5854,7 +5857,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5862,7 +5865,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5870,7 +5873,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5879,7 +5882,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5887,11 +5890,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5918,45 +5921,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5969,7 +5972,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5983,7 +5986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5994,29 +5997,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6072,7 +6075,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6083,7 +6086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6096,7 +6099,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6108,7 +6111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6117,7 +6120,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6128,7 +6131,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6138,38 +6141,38 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_armv8_disable_dit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_armv8_disable_dit"]
     pub fn armv8_disable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_armv8_enable_dit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_armv8_enable_dit"]
     pub fn armv8_enable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6179,105 +6182,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6286,18 +6289,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6306,18 +6309,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6326,7 +6329,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6334,11 +6337,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6349,57 +6352,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6409,15 +6412,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6467,27 +6470,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6495,11 +6498,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6507,7 +6510,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6515,18 +6518,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6535,7 +6538,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6544,45 +6547,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6593,7 +6596,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6653,7 +6656,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6724,23 +6727,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6748,7 +6751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6757,7 +6760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6765,7 +6768,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6773,7 +6776,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6782,7 +6785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6790,15 +6793,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6807,7 +6810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6815,7 +6818,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6824,71 +6827,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_method_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6911,7 +6914,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6919,68 +6922,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6988,7 +6991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6996,7 +6999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7005,11 +7008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7018,15 +7021,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7034,11 +7037,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7046,22 +7049,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7069,30 +7072,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7100,89 +7103,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7191,34 +7194,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7227,13 +7230,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7242,13 +7245,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7261,7 +7264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7274,7 +7277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7287,7 +7290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7299,7 +7302,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7313,7 +7316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7326,7 +7329,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7339,7 +7342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7351,23 +7354,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7377,7 +7380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7385,30 +7388,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7420,7 +7423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7431,11 +7434,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_secmem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7801,197 +7804,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8000,15 +8003,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8018,11 +8021,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8030,47 +8033,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8078,11 +8081,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8090,43 +8093,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8135,7 +8138,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8145,7 +8148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8154,7 +8157,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8164,7 +8167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8173,7 +8176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8183,7 +8186,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8192,7 +8195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8202,7 +8205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8211,7 +8214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8220,7 +8223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8228,7 +8231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8237,7 +8240,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8246,7 +8249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8255,11 +8258,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8267,7 +8270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8395,15 +8398,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8417,7 +8420,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8425,11 +8428,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8444,7 +8447,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8454,7 +8457,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8465,7 +8468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8475,7 +8478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8484,7 +8487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8493,7 +8496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8502,7 +8505,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8512,7 +8515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8522,23 +8525,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8547,7 +8550,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8556,7 +8559,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8566,7 +8569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8575,7 +8578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8585,7 +8588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8596,7 +8599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8607,7 +8610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_set_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8621,15 +8624,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8640,7 +8643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8653,11 +8656,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8665,7 +8668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8673,15 +8676,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8841,15 +8844,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8873,15 +8876,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8890,7 +8893,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8898,7 +8901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8906,14 +8909,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8921,7 +8924,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8929,7 +8932,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8937,7 +8940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8945,7 +8948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8953,14 +8956,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8968,7 +8971,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8976,22 +8979,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9067,54 +9070,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9122,7 +9125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9130,79 +9133,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9210,7 +9213,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9218,7 +9221,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9226,7 +9229,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9234,7 +9237,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9242,7 +9245,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9250,7 +9253,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9258,7 +9261,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9266,7 +9269,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9274,117 +9277,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9392,14 +9395,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9409,7 +9412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9421,7 +9424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9431,7 +9434,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9441,15 +9444,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9457,26 +9460,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9484,23 +9487,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9508,14 +9511,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9523,25 +9526,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9549,7 +9552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9557,14 +9560,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9593,19 +9596,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9613,11 +9616,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9625,54 +9628,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9680,59 +9683,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9740,23 +9743,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9765,26 +9768,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9792,29 +9795,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9823,22 +9826,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9846,15 +9849,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9863,15 +9866,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9880,52 +9883,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9933,11 +9936,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9962,7 +9965,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9972,11 +9975,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9984,11 +9987,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9996,7 +9999,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10330,15 +10333,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10346,19 +10349,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10366,7 +10369,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10374,12 +10377,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10387,14 +10390,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10402,33 +10405,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10436,7 +10439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10444,19 +10447,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10464,7 +10467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10472,7 +10475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10482,7 +10485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10492,11 +10495,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10504,15 +10507,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10520,52 +10523,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11164,7 +11167,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11189,19 +11192,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11211,19 +11214,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11233,7 +11236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11241,11 +11244,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11255,7 +11258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11263,7 +11266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11422,11 +11425,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11434,11 +11437,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11493,19 +11496,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11514,7 +11517,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11575,23 +11578,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11599,86 +11602,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11686,7 +11689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11694,11 +11697,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11706,7 +11709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11715,7 +11718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11726,22 +11729,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11750,7 +11753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11759,7 +11762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11768,7 +11771,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11777,37 +11780,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11815,7 +11818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11823,7 +11826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12130,23 +12133,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12154,40 +12157,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12195,15 +12198,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12211,55 +12214,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12267,11 +12270,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12279,7 +12282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12287,11 +12290,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12299,11 +12302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12314,122 +12317,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12440,7 +12443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12450,7 +12453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12460,7 +12463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12470,7 +12473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12478,7 +12481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12488,7 +12491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12496,7 +12499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12506,7 +12509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12514,47 +12517,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12563,49 +12566,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12618,23 +12621,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12644,7 +12647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12653,7 +12656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12662,7 +12665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12670,7 +12673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12678,7 +12681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12686,7 +12689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12695,127 +12698,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13055,7 +13058,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13065,19 +13068,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13087,15 +13090,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13103,7 +13106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13194,15 +13197,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13210,7 +13213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13218,14 +13221,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13233,7 +13236,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13241,31 +13244,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_unload"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13273,11 +13276,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13286,7 +13289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13296,15 +13299,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13312,15 +13315,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13329,7 +13332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13338,7 +13341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13349,7 +13352,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13359,11 +13362,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13374,7 +13377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13447,33 +13450,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_is_weak_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_set_key_unchecked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_key_sched"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13482,7 +13485,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13493,7 +13496,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13504,7 +13507,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13517,7 +13520,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13529,47 +13532,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_new_by_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13577,7 +13580,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13585,7 +13588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13594,7 +13597,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13603,44 +13606,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13649,11 +13652,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13661,7 +13664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13672,19 +13675,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13692,19 +13695,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13719,7 +13722,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13727,14 +13730,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13742,130 +13745,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_shake128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_shake256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13873,11 +13876,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13885,7 +13888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13893,7 +13896,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13901,7 +13904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13912,63 +13915,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13976,15 +13979,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14093,39 +14096,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14133,7 +14136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14141,31 +14144,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14173,7 +14176,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14182,7 +14185,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14190,7 +14193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14199,7 +14202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14211,11 +14214,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14269,28 +14272,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14299,7 +14302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14309,7 +14312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14320,7 +14323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14331,7 +14334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14342,47 +14345,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14392,7 +14395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14400,14 +14403,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14415,11 +14418,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14427,11 +14430,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14439,11 +14442,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14451,7 +14454,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14462,31 +14465,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p521"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_secp256k1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14494,19 +14497,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14514,7 +14517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14524,53 +14527,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14578,7 +14581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14587,7 +14590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14597,7 +14600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14607,7 +14610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14617,7 +14620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14627,7 +14630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14638,7 +14641,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14648,7 +14651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14658,7 +14661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14668,7 +14671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14678,7 +14681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14687,7 +14690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14695,7 +14698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14706,7 +14709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14717,7 +14720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14728,15 +14731,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14745,7 +14748,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14754,7 +14757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_point2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14764,7 +14767,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_bn2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14773,7 +14776,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14831,28 +14834,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14860,15 +14863,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECPKParameters_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14882,122 +14885,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_set_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_get_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_set_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_get_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15005,7 +15008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15014,15 +15017,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15030,11 +15033,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15042,22 +15045,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15067,7 +15070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15075,14 +15078,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15090,11 +15093,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15102,19 +15105,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15122,38 +15125,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15180,7 +15183,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15190,18 +15193,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15218,7 +15221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15227,7 +15230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15238,7 +15241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15249,7 +15252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15303,23 +15306,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15327,7 +15330,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15335,7 +15338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15343,7 +15346,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15352,19 +15355,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15372,11 +15375,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15386,7 +15389,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15394,83 +15397,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15608,11 +15611,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15621,11 +15624,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15636,11 +15639,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15655,7 +15658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15670,7 +15673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15688,7 +15691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15703,70 +15706,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15777,7 +15780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15785,7 +15788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15794,7 +15797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15802,70 +15805,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_get_undef"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15874,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15882,7 +15885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15890,7 +15893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15971,7 +15974,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15981,163 +15984,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16146,7 +16149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16155,7 +16158,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16163,7 +16166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16171,7 +16174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16181,7 +16184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16189,7 +16192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16197,7 +16200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16207,7 +16210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16217,7 +16220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16225,7 +16228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16233,7 +16236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16243,7 +16246,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16251,11 +16254,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16263,7 +16266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16272,7 +16275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16280,11 +16283,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16292,7 +16295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16301,7 +16304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16310,7 +16313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16319,7 +16322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16328,7 +16331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16341,7 +16344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16353,7 +16356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16368,31 +16371,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16402,11 +16405,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16416,11 +16419,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16430,11 +16433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16444,11 +16447,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16458,18 +16461,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16477,18 +16480,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16498,7 +16501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16508,102 +16511,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16611,28 +16614,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16640,7 +16643,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16648,7 +16651,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16658,33 +16661,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16692,7 +16695,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16703,15 +16706,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16725,7 +16728,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16739,7 +16742,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_do_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16753,15 +16756,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16770,7 +16773,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16778,7 +16781,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16787,14 +16790,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16802,40 +16805,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16843,11 +16846,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16855,11 +16858,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16867,11 +16870,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16879,7 +16882,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16887,7 +16890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16896,45 +16899,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16944,26 +16947,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16977,7 +16980,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16989,7 +16992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17001,11 +17004,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17013,15 +17016,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17108,7 +17111,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17120,27 +17123,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17150,7 +17153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17158,7 +17161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17166,27 +17169,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17194,7 +17197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17203,7 +17206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17212,7 +17215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17388,86 +17391,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17476,18 +17479,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17496,7 +17499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17505,23 +17508,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17537,7 +17540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17555,7 +17558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17568,7 +17571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17584,7 +17587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17602,7 +17605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17617,7 +17620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17630,7 +17633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17643,7 +17646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17653,19 +17656,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17924,7 +17927,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17932,7 +17935,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17941,7 +17944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17950,18 +17953,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17977,7 +17980,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSKDF_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17989,7 +17992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSKDF_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18003,7 +18006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18015,21 +18018,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18037,7 +18040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18045,7 +18048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18053,11 +18056,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18065,15 +18068,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18175,7 +18178,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18183,47 +18186,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18491,15 +18494,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18507,26 +18510,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18534,26 +18537,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18561,14 +18564,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18616,37 +18619,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18655,46 +18658,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_signer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_content_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_set_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_set_content"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18703,31 +18706,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18753,15 +18756,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18769,18 +18772,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18788,31 +18791,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18825,59 +18828,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18886,11 +18889,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18899,7 +18902,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18908,12 +18911,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18922,44 +18925,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18974,7 +18977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18989,7 +18992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -19004,7 +19007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19019,14 +19022,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19042,7 +19045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19051,7 +19054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19059,7 +19062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19071,7 +19074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19083,7 +19086,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19093,7 +19096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19103,7 +19106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19114,7 +19117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19128,7 +19131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19140,7 +19143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19151,7 +19154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19164,7 +19167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19176,7 +19179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19186,7 +19189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19196,31 +19199,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19231,7 +19234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19242,7 +19245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19255,7 +19258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS1_MGF1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19265,7 +19268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19276,19 +19279,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19296,19 +19299,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19316,7 +19319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19324,15 +19327,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19345,7 +19348,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19355,7 +19358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19363,34 +19366,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19400,7 +19403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19409,7 +19412,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19417,11 +19420,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19429,11 +19432,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19443,7 +19446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19453,7 +19456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19464,7 +19467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19472,7 +19475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19480,11 +19483,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_method_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19503,27 +19506,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19531,62 +19534,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19594,27 +19597,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19640,11 +19643,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19653,15 +19656,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19669,7 +19672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19677,7 +19680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19685,11 +19688,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19698,11 +19701,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_signature_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19712,7 +19715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19720,84 +19723,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19805,7 +19808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19815,7 +19818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19823,25 +19826,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19849,11 +19852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19861,7 +19864,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19869,7 +19872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19877,33 +19880,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19943,23 +19946,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19967,27 +19970,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19995,7 +19998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20003,19 +20006,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20023,7 +20026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20031,7 +20034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20039,11 +20042,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20052,7 +20055,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20060,70 +20063,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20131,7 +20134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20141,7 +20144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20149,25 +20152,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20175,26 +20178,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20202,45 +20205,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20248,7 +20251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20256,7 +20259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20264,21 +20267,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20286,7 +20289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20295,7 +20298,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20305,19 +20308,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20325,45 +20328,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20371,7 +20374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20379,15 +20382,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20395,55 +20398,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20453,7 +20456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20463,7 +20466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20473,7 +20476,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20481,14 +20484,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20496,22 +20499,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20561,19 +20564,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20581,19 +20584,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20601,15 +20604,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20617,7 +20620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20625,21 +20628,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20648,7 +20651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20660,7 +20663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20672,7 +20675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20684,19 +20687,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20704,33 +20707,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20739,11 +20742,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20753,7 +20756,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20763,7 +20766,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20773,19 +20776,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20793,23 +20796,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20820,7 +20823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20830,23 +20833,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20854,18 +20857,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20874,7 +20877,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20883,33 +20886,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20933,11 +20936,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20945,18 +20948,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20964,7 +20967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20972,7 +20975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20980,21 +20983,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21337,15 +21340,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21353,23 +21356,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21377,27 +21380,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21405,14 +21408,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21420,7 +21423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21449,23 +21452,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21473,11 +21476,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21486,7 +21489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21495,11 +21498,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21524,23 +21527,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21548,14 +21551,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21563,7 +21566,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21573,7 +21576,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21583,7 +21586,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21593,14 +21596,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21609,7 +21612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21618,89 +21621,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21709,92 +21712,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21802,7 +21805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21810,95 +21813,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21906,7 +21909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21914,14 +21917,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21929,7 +21932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21937,21 +21940,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22019,19 +22022,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22039,43 +22042,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22133,19 +22136,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22153,14 +22156,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22247,19 +22250,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22267,26 +22270,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22294,34 +22297,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22329,11 +22332,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22341,7 +22344,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22349,7 +22352,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22358,7 +22361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22367,23 +22370,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22392,15 +22395,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22409,7 +22412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22417,7 +22420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22425,7 +22428,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22434,7 +22437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22442,7 +22445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22450,7 +22453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22459,7 +22462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22468,7 +22471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22478,11 +22481,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22491,7 +22494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22500,7 +22503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22509,7 +22512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22518,7 +22521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22527,259 +22530,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22787,23 +22790,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22811,7 +22814,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22820,40 +22823,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22863,7 +22866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22871,14 +22874,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22888,7 +22891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22896,14 +22899,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22913,7 +22916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22921,14 +22924,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22938,7 +22941,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22948,7 +22951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22958,7 +22961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22970,7 +22973,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22981,26 +22984,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23010,7 +23013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23019,7 +23022,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23028,7 +23031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23036,7 +23039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23044,7 +23047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23052,7 +23055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23213,7 +23216,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23311,7 +23314,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23322,11 +23325,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23335,7 +23338,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23344,7 +23347,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23353,7 +23356,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23362,7 +23365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23371,7 +23374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23380,7 +23383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23389,7 +23392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23398,14 +23401,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23413,32 +23416,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23446,7 +23449,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23454,43 +23457,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23499,7 +23502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23508,31 +23511,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23542,7 +23545,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23554,7 +23557,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23568,15 +23571,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23756,74 +23759,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23848,7 +23851,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23856,7 +23859,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23864,79 +23867,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_lock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_unlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23945,7 +23948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23955,7 +23958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23963,7 +23966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23971,7 +23974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23979,7 +23982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23987,7 +23990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25431,15 +25434,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25447,26 +25450,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25474,26 +25477,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25501,26 +25504,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25528,26 +25531,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25555,26 +25558,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25582,26 +25585,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25609,26 +25612,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25636,26 +25639,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25663,26 +25666,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25690,26 +25693,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25717,26 +25720,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25744,33 +25747,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25778,26 +25781,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25805,77 +25808,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25885,19 +25888,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25906,14 +25909,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25921,7 +25924,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25931,43 +25934,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26134,15 +26137,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26150,26 +26153,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26177,26 +26180,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26204,26 +26207,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26231,26 +26234,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26258,41 +26261,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26300,7 +26303,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_sendreq_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26309,26 +26312,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26336,14 +26339,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26351,7 +26354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26359,15 +26362,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_add0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26375,7 +26378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26383,48 +26386,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_check_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_copy_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26435,23 +26438,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_single_get0_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26461,7 +26464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26469,7 +26472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_find_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26481,7 +26484,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_check_validity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26490,7 +26493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26499,7 +26502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26508,7 +26511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_cert_id_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26517,7 +26520,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_cert_to_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26525,7 +26528,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_parse_url"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26535,18 +26538,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_id_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_id_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26556,14 +26559,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26575,7 +26578,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26586,36 +26589,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_cert_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26623,7 +26626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26631,7 +26634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26639,21 +26642,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26661,11 +26664,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26680,14 +26683,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26697,7 +26700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26707,7 +26710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26717,7 +26720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26729,7 +26732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26740,7 +26743,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26754,7 +26757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26763,7 +26766,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26772,7 +26775,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26782,7 +26785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26792,7 +26795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26803,7 +26806,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26817,7 +26820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26826,7 +26829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26835,7 +26838,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26844,15 +26847,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26861,7 +26864,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26870,15 +26873,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26887,7 +26890,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26896,23 +26899,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26921,7 +26924,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26930,15 +26933,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26947,7 +26950,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26956,15 +26959,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26973,7 +26976,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26982,15 +26985,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26999,7 +27002,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27008,21 +27011,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27031,7 +27034,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27040,7 +27043,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27052,7 +27055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27064,7 +27067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27073,7 +27076,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27082,15 +27085,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27099,7 +27102,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27108,15 +27111,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27125,7 +27128,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27134,7 +27137,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27146,7 +27149,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27158,7 +27161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27167,7 +27170,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27176,15 +27179,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27193,7 +27196,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27202,15 +27205,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27219,7 +27222,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27228,7 +27231,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27240,7 +27243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27252,7 +27255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27261,7 +27264,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27270,15 +27273,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27287,7 +27290,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27296,15 +27299,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27313,7 +27316,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27322,7 +27325,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27334,7 +27337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27346,7 +27349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27355,7 +27358,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27364,15 +27367,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27384,7 +27387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27396,7 +27399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27408,7 +27411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27420,7 +27423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27429,7 +27432,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27441,7 +27444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27453,7 +27456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27465,7 +27468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27474,7 +27477,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27486,15 +27489,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27503,14 +27506,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27522,7 +27525,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27535,7 +27538,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27549,7 +27552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27557,7 +27560,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27565,7 +27568,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27574,11 +27577,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27586,27 +27589,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27616,7 +27619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27624,7 +27627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27639,93 +27642,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_priv_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_write_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_egd_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27826,23 +27829,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27907,11 +27910,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27998,11 +28001,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28010,50 +28013,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28128,15 +28131,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28149,7 +28152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28164,18 +28167,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28184,14 +28187,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28200,7 +28203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28211,7 +28214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28220,7 +28223,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28232,7 +28235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28244,18 +28247,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28263,14 +28266,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28278,7 +28281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28292,7 +28295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28305,7 +28308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28320,7 +28323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28332,15 +28335,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -4496,7 +4499,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4504,7 +4507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4512,15 +4515,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4532,7 +4535,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4541,7 +4544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4552,7 +4555,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4563,7 +4566,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4575,7 +4578,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4585,7 +4588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4595,7 +4598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4606,7 +4609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5192,27 +5195,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5220,29 +5223,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5250,7 +5253,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5258,11 +5261,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5270,15 +5273,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5365,11 +5368,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5377,19 +5380,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5397,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5507,11 +5510,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5519,19 +5522,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5539,15 +5542,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5645,11 +5648,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5657,19 +5660,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5677,42 +5680,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5720,62 +5723,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5783,7 +5786,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5792,7 +5795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5801,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5809,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5817,21 +5820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5839,7 +5842,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5847,7 +5850,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5855,7 +5858,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5864,7 +5867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5872,11 +5875,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5903,27 +5906,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 #[repr(C)]
@@ -5979,19 +5982,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6004,7 +6007,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6018,7 +6021,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6029,29 +6032,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6107,7 +6110,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6118,7 +6121,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6131,7 +6134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6143,7 +6146,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6152,7 +6155,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6163,7 +6166,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6173,38 +6176,38 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_armv8_disable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_armv8_disable_dit"]
     pub fn armv8_disable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_armv8_enable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_armv8_enable_dit"]
     pub fn armv8_enable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6214,105 +6217,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6321,18 +6324,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6341,18 +6344,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6361,7 +6364,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6369,11 +6372,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6384,57 +6387,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6444,15 +6447,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6502,27 +6505,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6530,11 +6533,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6542,7 +6545,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6550,18 +6553,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6570,7 +6573,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6579,45 +6582,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6628,7 +6631,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6688,7 +6691,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6759,23 +6762,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6783,7 +6786,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6792,7 +6795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6800,7 +6803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6808,7 +6811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6817,7 +6820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6825,15 +6828,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6842,7 +6845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6850,7 +6853,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6859,71 +6862,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6946,7 +6949,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6954,68 +6957,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7023,7 +7026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7031,7 +7034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7040,11 +7043,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7053,15 +7056,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7069,11 +7072,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7081,22 +7084,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7104,30 +7107,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7135,89 +7138,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7226,34 +7229,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7262,13 +7265,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7277,13 +7280,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7296,7 +7299,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7309,7 +7312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7322,7 +7325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7334,7 +7337,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7348,7 +7351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7361,7 +7364,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7374,7 +7377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7386,23 +7389,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7412,7 +7415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7420,30 +7423,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7455,7 +7458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7466,11 +7469,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7836,197 +7839,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8035,15 +8038,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8053,11 +8056,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8065,47 +8068,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8113,11 +8116,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8125,43 +8128,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8170,7 +8173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8180,7 +8183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8189,7 +8192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8199,7 +8202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8208,7 +8211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8218,7 +8221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8227,7 +8230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8237,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8246,7 +8249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8255,7 +8258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8263,7 +8266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8272,7 +8275,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8281,7 +8284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8290,11 +8293,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8302,7 +8305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8430,15 +8433,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8452,7 +8455,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8460,11 +8463,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8479,7 +8482,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8489,7 +8492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8500,7 +8503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8510,7 +8513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8519,7 +8522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8528,7 +8531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8537,7 +8540,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8547,7 +8550,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8557,23 +8560,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8582,7 +8585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8591,7 +8594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8601,7 +8604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8610,7 +8613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8620,7 +8623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8631,7 +8634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8642,7 +8645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8656,15 +8659,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8675,7 +8678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8688,11 +8691,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8700,7 +8703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8708,15 +8711,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8876,15 +8879,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8908,15 +8911,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8925,7 +8928,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8933,7 +8936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8941,14 +8944,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8956,7 +8959,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8964,7 +8967,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8972,7 +8975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8980,7 +8983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8988,14 +8991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -9003,7 +9006,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -9011,22 +9014,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9102,54 +9105,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9157,7 +9160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9165,79 +9168,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9245,7 +9248,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9253,7 +9256,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9261,7 +9264,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9269,7 +9272,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9277,7 +9280,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9285,7 +9288,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9293,7 +9296,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9301,7 +9304,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9309,117 +9312,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9427,14 +9430,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9444,7 +9447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9456,7 +9459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9466,7 +9469,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9476,15 +9479,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9492,26 +9495,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9519,23 +9522,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9543,14 +9546,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9558,25 +9561,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9584,7 +9587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9592,14 +9595,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9628,19 +9631,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9648,11 +9651,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9660,54 +9663,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9715,59 +9718,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9775,23 +9778,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9800,26 +9803,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9827,29 +9830,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9858,22 +9861,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9881,15 +9884,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9898,15 +9901,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9915,52 +9918,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9968,11 +9971,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9997,7 +10000,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -10007,11 +10010,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10019,11 +10022,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10031,7 +10034,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10365,15 +10368,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10381,19 +10384,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10401,7 +10404,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10409,12 +10412,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10422,14 +10425,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10437,33 +10440,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10471,7 +10474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10479,19 +10482,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10499,7 +10502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10507,7 +10510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10517,7 +10520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10527,11 +10530,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10539,15 +10542,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10555,52 +10558,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11199,7 +11202,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11224,19 +11227,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11246,19 +11249,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11268,7 +11271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11276,11 +11279,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11290,7 +11293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11298,7 +11301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11457,11 +11460,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11469,11 +11472,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11528,19 +11531,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11549,7 +11552,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11610,23 +11613,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11634,86 +11637,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11721,7 +11724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11729,11 +11732,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11741,7 +11744,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11750,7 +11753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11761,22 +11764,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11785,7 +11788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11794,7 +11797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11803,7 +11806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11812,37 +11815,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11850,7 +11853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11858,7 +11861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12165,23 +12168,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12189,40 +12192,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12230,15 +12233,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12246,55 +12249,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12302,11 +12305,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12314,7 +12317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12322,11 +12325,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12334,11 +12337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12349,122 +12352,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12475,7 +12478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12485,7 +12488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12495,7 +12498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12505,7 +12508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12513,7 +12516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12523,7 +12526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12531,7 +12534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12541,7 +12544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12549,47 +12552,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12598,49 +12601,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12653,23 +12656,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12679,7 +12682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12688,7 +12691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12697,7 +12700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12705,7 +12708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12713,7 +12716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12721,7 +12724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12730,127 +12733,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13090,7 +13093,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13100,19 +13103,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13122,15 +13125,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13138,7 +13141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13229,15 +13232,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13245,7 +13248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13253,14 +13256,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13268,7 +13271,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13276,31 +13279,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13308,11 +13311,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13321,7 +13324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13331,15 +13334,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13347,15 +13350,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13364,7 +13367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13373,7 +13376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13384,7 +13387,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13394,11 +13397,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13409,7 +13412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13482,33 +13485,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13517,7 +13520,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13528,7 +13531,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13539,7 +13542,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13552,7 +13555,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13564,47 +13567,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13612,7 +13615,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13620,7 +13623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13629,7 +13632,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13638,44 +13641,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13684,11 +13687,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13696,7 +13699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13707,19 +13710,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13727,19 +13730,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13754,7 +13757,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13762,14 +13765,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13777,130 +13780,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13908,11 +13911,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13920,7 +13923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13928,7 +13931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13936,7 +13939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13947,63 +13950,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14011,15 +14014,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14128,39 +14131,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14168,7 +14171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14176,31 +14179,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14208,7 +14211,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14217,7 +14220,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14225,7 +14228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14234,7 +14237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14246,11 +14249,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14304,28 +14307,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14334,7 +14337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14344,7 +14347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14355,7 +14358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14366,7 +14369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14377,47 +14380,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14427,7 +14430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14435,14 +14438,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14450,11 +14453,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14462,11 +14465,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14474,11 +14477,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14486,7 +14489,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14497,31 +14500,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14529,19 +14532,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14549,7 +14552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14559,53 +14562,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14613,7 +14616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14622,7 +14625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14632,7 +14635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14642,7 +14645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14652,7 +14655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14662,7 +14665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14673,7 +14676,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14683,7 +14686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14693,7 +14696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14703,7 +14706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14713,7 +14716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14722,7 +14725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14730,7 +14733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14741,7 +14744,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14752,7 +14755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14763,15 +14766,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14780,7 +14783,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14789,7 +14792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14799,7 +14802,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14808,7 +14811,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14866,28 +14869,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14895,15 +14898,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14917,122 +14920,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15040,7 +15043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15049,15 +15052,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15065,11 +15068,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15077,22 +15080,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15102,7 +15105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15110,14 +15113,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15125,11 +15128,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15137,19 +15140,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15157,38 +15160,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15215,7 +15218,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15225,18 +15228,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15253,7 +15256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15262,7 +15265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15273,7 +15276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15284,7 +15287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15338,23 +15341,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15362,7 +15365,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15370,7 +15373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15378,7 +15381,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15387,19 +15390,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15407,11 +15410,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15421,7 +15424,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15429,83 +15432,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15643,11 +15646,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15656,11 +15659,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15671,11 +15674,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15690,7 +15693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15705,7 +15708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15723,7 +15726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15738,70 +15741,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15812,7 +15815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15820,7 +15823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15829,7 +15832,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15837,70 +15840,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15909,7 +15912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15917,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15925,7 +15928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -16006,7 +16009,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -16016,163 +16019,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16181,7 +16184,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16190,7 +16193,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16198,7 +16201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16206,7 +16209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16216,7 +16219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16224,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16232,7 +16235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16242,7 +16245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16252,7 +16255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16260,7 +16263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16268,7 +16271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16278,7 +16281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16286,11 +16289,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16298,7 +16301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16307,7 +16310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16315,11 +16318,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16327,7 +16330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16336,7 +16339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16345,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16354,7 +16357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16363,7 +16366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16376,7 +16379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16388,7 +16391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16403,31 +16406,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16437,11 +16440,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16451,11 +16454,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16465,11 +16468,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16479,11 +16482,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16493,18 +16496,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16512,18 +16515,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16533,7 +16536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16543,102 +16546,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16646,28 +16649,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16675,7 +16678,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16683,7 +16686,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16693,33 +16696,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16727,7 +16730,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16738,15 +16741,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16760,7 +16763,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16774,7 +16777,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16788,15 +16791,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16805,7 +16808,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16813,7 +16816,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16822,14 +16825,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16837,40 +16840,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16878,11 +16881,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16890,11 +16893,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16902,11 +16905,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16914,7 +16917,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16922,7 +16925,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16931,45 +16934,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16979,26 +16982,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17012,7 +17015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17024,7 +17027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17036,11 +17039,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17048,15 +17051,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17143,7 +17146,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17155,27 +17158,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17185,7 +17188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17193,7 +17196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17201,27 +17204,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17229,7 +17232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17238,7 +17241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17247,7 +17250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17423,86 +17426,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17511,18 +17514,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17531,7 +17534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17540,23 +17543,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17572,7 +17575,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17590,7 +17593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17603,7 +17606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17619,7 +17622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17637,7 +17640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17652,7 +17655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17665,7 +17668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17678,7 +17681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17688,19 +17691,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17959,7 +17962,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17967,7 +17970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17976,7 +17979,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17985,18 +17988,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -18012,7 +18015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -18024,7 +18027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18038,7 +18041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18050,21 +18053,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18072,7 +18075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18080,7 +18083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18088,11 +18091,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18100,15 +18103,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18210,7 +18213,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18218,47 +18221,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18526,15 +18529,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18542,26 +18545,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18569,26 +18572,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18596,14 +18599,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18651,37 +18654,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18690,46 +18693,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18738,31 +18741,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18788,15 +18791,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18804,18 +18807,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18823,31 +18826,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18860,59 +18863,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18921,11 +18924,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18934,7 +18937,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18943,12 +18946,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18957,44 +18960,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -19009,7 +19012,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -19024,7 +19027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -19039,7 +19042,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19054,14 +19057,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19077,7 +19080,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19086,7 +19089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19094,7 +19097,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19106,7 +19109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19118,7 +19121,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19128,7 +19131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19138,7 +19141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19149,7 +19152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19163,7 +19166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19175,7 +19178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19186,7 +19189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19199,7 +19202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19211,7 +19214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19221,7 +19224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19231,31 +19234,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19266,7 +19269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19277,7 +19280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19290,7 +19293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19300,7 +19303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19311,19 +19314,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19331,19 +19334,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19351,7 +19354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19359,15 +19362,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19380,7 +19383,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19390,7 +19393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19398,34 +19401,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19435,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19444,7 +19447,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19452,11 +19455,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19464,11 +19467,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19478,7 +19481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19488,7 +19491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19499,7 +19502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19507,7 +19510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19515,11 +19518,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19538,27 +19541,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19566,62 +19569,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19629,27 +19632,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19675,11 +19678,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19688,15 +19691,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19704,7 +19707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19712,7 +19715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19720,11 +19723,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19733,11 +19736,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19747,7 +19750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19755,84 +19758,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19840,7 +19843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19850,7 +19853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19858,25 +19861,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19884,11 +19887,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19896,7 +19899,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19904,7 +19907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19912,33 +19915,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19978,23 +19981,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20002,27 +20005,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20030,7 +20033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20038,19 +20041,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20058,7 +20061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20066,7 +20069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20074,11 +20077,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20087,7 +20090,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20095,70 +20098,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20166,7 +20169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20176,7 +20179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20184,25 +20187,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20210,26 +20213,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20237,45 +20240,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20283,7 +20286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20291,7 +20294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20299,21 +20302,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20321,7 +20324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20330,7 +20333,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20340,19 +20343,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20360,45 +20363,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20406,7 +20409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20414,15 +20417,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20430,55 +20433,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20488,7 +20491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20498,7 +20501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20508,7 +20511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20516,14 +20519,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20531,22 +20534,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20596,19 +20599,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20616,19 +20619,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20636,15 +20639,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20652,7 +20655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20660,21 +20663,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20683,7 +20686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20695,7 +20698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20707,7 +20710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20719,19 +20722,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20739,33 +20742,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20774,11 +20777,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20788,7 +20791,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20798,7 +20801,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20808,19 +20811,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20828,23 +20831,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20855,7 +20858,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20865,23 +20868,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20889,18 +20892,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20909,7 +20912,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20918,33 +20921,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20968,11 +20971,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20980,18 +20983,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20999,7 +21002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21007,7 +21010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21015,21 +21018,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21372,15 +21375,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21388,23 +21391,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21412,27 +21415,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21440,14 +21443,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21455,7 +21458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21484,23 +21487,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21508,11 +21511,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21521,7 +21524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21530,11 +21533,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21559,23 +21562,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21583,14 +21586,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21598,7 +21601,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21608,7 +21611,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21618,7 +21621,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21628,14 +21631,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21644,7 +21647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21653,89 +21656,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21744,92 +21747,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21837,7 +21840,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21845,95 +21848,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21941,7 +21944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21949,14 +21952,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21964,7 +21967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21972,21 +21975,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22054,19 +22057,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22074,43 +22077,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22168,19 +22171,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22188,14 +22191,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22282,19 +22285,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22302,26 +22305,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22329,34 +22332,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22364,11 +22367,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22376,7 +22379,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22384,7 +22387,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22393,7 +22396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22402,23 +22405,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22427,15 +22430,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22444,7 +22447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22452,7 +22455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22460,7 +22463,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22469,7 +22472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22477,7 +22480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22485,7 +22488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22494,7 +22497,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22503,7 +22506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22513,11 +22516,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22526,7 +22529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22535,7 +22538,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22544,7 +22547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22553,7 +22556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22562,259 +22565,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22822,23 +22825,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22846,7 +22849,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22855,40 +22858,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22898,7 +22901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22906,14 +22909,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22923,7 +22926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22931,14 +22934,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22948,7 +22951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22956,14 +22959,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22973,7 +22976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22983,7 +22986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22993,7 +22996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23005,7 +23008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23016,26 +23019,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23045,7 +23048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23054,7 +23057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23063,7 +23066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23071,7 +23074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23079,7 +23082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23087,7 +23090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23248,7 +23251,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23346,7 +23349,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23357,11 +23360,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23370,7 +23373,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23379,7 +23382,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23388,7 +23391,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23397,7 +23400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23406,7 +23409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23415,7 +23418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23424,7 +23427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23433,14 +23436,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23448,32 +23451,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23481,7 +23484,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23489,43 +23492,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23534,7 +23537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23543,31 +23546,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23577,7 +23580,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23589,7 +23592,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23603,15 +23606,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23791,74 +23794,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23883,7 +23886,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23891,7 +23894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23899,79 +23902,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23980,7 +23983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23990,7 +23993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23998,7 +24001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24006,7 +24009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24014,7 +24017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -24022,7 +24025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25466,15 +25469,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25482,26 +25485,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25509,26 +25512,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25536,26 +25539,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25563,26 +25566,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25590,26 +25593,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25617,26 +25620,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25644,26 +25647,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25671,26 +25674,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25698,26 +25701,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25725,26 +25728,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25752,26 +25755,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25779,33 +25782,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25813,26 +25816,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25840,77 +25843,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25920,19 +25923,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25941,14 +25944,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25956,7 +25959,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25966,43 +25969,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26169,15 +26172,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26185,26 +26188,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26212,26 +26215,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26239,26 +26242,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26266,26 +26269,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26293,41 +26296,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26335,7 +26338,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26344,26 +26347,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26371,14 +26374,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26386,7 +26389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26394,15 +26397,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26410,7 +26413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26418,48 +26421,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26470,23 +26473,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26496,7 +26499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26504,7 +26507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26516,7 +26519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26525,7 +26528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26534,7 +26537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26543,7 +26546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26552,7 +26555,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26560,7 +26563,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26570,18 +26573,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26591,14 +26594,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26610,7 +26613,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26621,36 +26624,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26658,7 +26661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26666,7 +26669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26674,21 +26677,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26696,11 +26699,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26715,14 +26718,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26732,7 +26735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26742,7 +26745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26752,7 +26755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26764,7 +26767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26775,7 +26778,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26789,7 +26792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26798,7 +26801,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26807,7 +26810,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26817,7 +26820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26827,7 +26830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26838,7 +26841,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26852,7 +26855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26861,7 +26864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26870,7 +26873,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26879,15 +26882,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26896,7 +26899,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26905,15 +26908,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26922,7 +26925,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26931,23 +26934,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26956,7 +26959,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26965,15 +26968,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26982,7 +26985,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26991,15 +26994,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -27008,7 +27011,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -27017,15 +27020,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27034,7 +27037,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27043,21 +27046,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27066,7 +27069,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27075,7 +27078,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27087,7 +27090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27099,7 +27102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27108,7 +27111,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27117,15 +27120,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27134,7 +27137,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27143,15 +27146,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27160,7 +27163,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27169,7 +27172,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27181,7 +27184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27193,7 +27196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27202,7 +27205,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27211,15 +27214,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27228,7 +27231,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27237,15 +27240,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27254,7 +27257,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27263,7 +27266,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27275,7 +27278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27287,7 +27290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27296,7 +27299,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27305,15 +27308,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27322,7 +27325,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27331,15 +27334,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27348,7 +27351,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27357,7 +27360,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27369,7 +27372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27381,7 +27384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27390,7 +27393,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27399,15 +27402,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27419,7 +27422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27431,7 +27434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27443,7 +27446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27455,7 +27458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27464,7 +27467,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27476,7 +27479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27488,7 +27491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27500,7 +27503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27509,7 +27512,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27521,15 +27524,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27538,14 +27541,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27557,7 +27560,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27570,7 +27573,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27584,7 +27587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27592,7 +27595,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27600,7 +27603,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27609,11 +27612,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27621,27 +27624,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27651,7 +27654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27659,7 +27662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27674,93 +27677,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27861,23 +27864,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27942,11 +27945,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -28033,11 +28036,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28045,50 +28048,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28163,15 +28166,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28184,7 +28187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28199,18 +28202,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28219,14 +28222,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28235,7 +28238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28246,7 +28249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28255,7 +28258,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28267,7 +28270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28279,18 +28282,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28298,14 +28301,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28313,7 +28316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28327,7 +28330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28340,7 +28343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28355,7 +28358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28367,15 +28370,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -4594,7 +4597,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4602,7 +4605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4610,15 +4613,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4630,7 +4633,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4639,7 +4642,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4650,7 +4653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4661,7 +4664,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4673,7 +4676,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4683,7 +4686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4693,7 +4696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4704,7 +4707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4932,27 +4935,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4960,29 +4963,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4990,7 +4993,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4998,11 +5001,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5010,15 +5013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5105,11 +5108,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5117,19 +5120,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5137,19 +5140,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5247,11 +5250,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5259,19 +5262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5279,15 +5282,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5385,11 +5388,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5397,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5417,42 +5420,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5460,62 +5463,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5523,7 +5526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5532,7 +5535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5541,7 +5544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5549,7 +5552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5557,21 +5560,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5579,7 +5582,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5587,7 +5590,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5595,7 +5598,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5604,7 +5607,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5612,11 +5615,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5643,45 +5646,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5694,7 +5697,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5708,7 +5711,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5719,29 +5722,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5797,7 +5800,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5808,7 +5811,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5821,7 +5824,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5833,7 +5836,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5842,7 +5845,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5853,7 +5856,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5863,38 +5866,38 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_armv8_disable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_armv8_disable_dit"]
     pub fn armv8_disable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_armv8_enable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_armv8_enable_dit"]
     pub fn armv8_enable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -5904,105 +5907,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6011,18 +6014,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6031,18 +6034,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6051,7 +6054,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6059,11 +6062,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6074,57 +6077,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6134,15 +6137,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6192,27 +6195,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6220,11 +6223,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6232,7 +6235,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6240,18 +6243,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6260,7 +6263,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6269,45 +6272,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6318,7 +6321,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6378,7 +6381,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6449,23 +6452,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6473,7 +6476,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6482,7 +6485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6490,7 +6493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6498,7 +6501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6507,7 +6510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6515,15 +6518,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6532,7 +6535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6540,7 +6543,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6549,71 +6552,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6636,7 +6639,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6644,68 +6647,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6713,7 +6716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6721,7 +6724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6730,11 +6733,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6743,15 +6746,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6759,11 +6762,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6771,22 +6774,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6794,30 +6797,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6825,89 +6828,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6916,34 +6919,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6952,13 +6955,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6967,13 +6970,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6986,7 +6989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6999,7 +7002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7012,7 +7015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7024,7 +7027,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7038,7 +7041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7051,7 +7054,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7064,7 +7067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7076,23 +7079,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7102,7 +7105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7110,30 +7113,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7145,7 +7148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7156,11 +7159,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7526,197 +7529,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7725,15 +7728,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7743,11 +7746,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7755,47 +7758,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7803,11 +7806,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7815,43 +7818,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7860,7 +7863,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7870,7 +7873,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7879,7 +7882,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7889,7 +7892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7898,7 +7901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7908,7 +7911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7917,7 +7920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7927,7 +7930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7936,7 +7939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7945,7 +7948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7953,7 +7956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7962,7 +7965,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7971,7 +7974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7980,11 +7983,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7992,7 +7995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8120,15 +8123,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8142,7 +8145,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8150,11 +8153,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8169,7 +8172,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8179,7 +8182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8190,7 +8193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8200,7 +8203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8209,7 +8212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8218,7 +8221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8227,7 +8230,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8237,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8247,23 +8250,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8272,7 +8275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8281,7 +8284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8291,7 +8294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8300,7 +8303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8310,7 +8313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8321,7 +8324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8332,7 +8335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8346,15 +8349,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8365,7 +8368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8378,11 +8381,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8390,7 +8393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8398,15 +8401,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8566,15 +8569,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8598,15 +8601,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8615,7 +8618,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8623,7 +8626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8631,14 +8634,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8646,7 +8649,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8654,7 +8657,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8662,7 +8665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8670,7 +8673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8678,14 +8681,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8693,7 +8696,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8701,22 +8704,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8792,54 +8795,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8847,7 +8850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8855,79 +8858,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8935,7 +8938,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8943,7 +8946,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8951,7 +8954,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8959,7 +8962,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8967,7 +8970,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8975,7 +8978,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8983,7 +8986,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8991,7 +8994,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8999,117 +9002,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9117,14 +9120,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9134,7 +9137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9146,7 +9149,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9156,7 +9159,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9166,15 +9169,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9182,26 +9185,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9209,23 +9212,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9233,14 +9236,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9248,25 +9251,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9274,7 +9277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9282,14 +9285,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9318,19 +9321,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9338,11 +9341,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9350,54 +9353,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9405,59 +9408,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9465,23 +9468,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9490,26 +9493,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9517,29 +9520,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9548,22 +9551,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9571,15 +9574,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9588,15 +9591,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9605,52 +9608,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9658,11 +9661,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9687,7 +9690,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9697,11 +9700,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9709,11 +9712,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9721,7 +9724,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10055,15 +10058,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10071,19 +10074,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10091,7 +10094,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10099,12 +10102,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10112,14 +10115,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10127,33 +10130,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10161,7 +10164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10169,19 +10172,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10189,7 +10192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10197,7 +10200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10207,7 +10210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10217,11 +10220,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10229,15 +10232,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10245,52 +10248,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10889,7 +10892,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10914,19 +10917,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10936,19 +10939,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10958,7 +10961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10966,11 +10969,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10980,7 +10983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10988,7 +10991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11147,11 +11150,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11159,11 +11162,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11218,19 +11221,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11239,7 +11242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11300,23 +11303,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11324,86 +11327,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11411,7 +11414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11419,11 +11422,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11431,7 +11434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11440,7 +11443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11451,22 +11454,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11475,7 +11478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11484,7 +11487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11493,7 +11496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11502,37 +11505,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11540,7 +11543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11548,7 +11551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11855,23 +11858,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11879,40 +11882,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11920,15 +11923,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11936,55 +11939,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11992,11 +11995,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12004,7 +12007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12012,11 +12015,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12024,11 +12027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12039,122 +12042,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12165,7 +12168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12175,7 +12178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12185,7 +12188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12195,7 +12198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12203,7 +12206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12213,7 +12216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12221,7 +12224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12231,7 +12234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12239,47 +12242,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12288,49 +12291,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12343,23 +12346,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12369,7 +12372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12378,7 +12381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12387,7 +12390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12395,7 +12398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12403,7 +12406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12411,7 +12414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12420,127 +12423,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12780,7 +12783,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12790,19 +12793,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12812,15 +12815,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12828,7 +12831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -12919,15 +12922,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12935,7 +12938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12943,14 +12946,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12958,7 +12961,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12966,31 +12969,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -12998,11 +13001,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13011,7 +13014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13021,15 +13024,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13037,15 +13040,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13054,7 +13057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13063,7 +13066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13074,7 +13077,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13084,11 +13087,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13099,7 +13102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13172,33 +13175,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13207,7 +13210,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13218,7 +13221,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13229,7 +13232,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13242,7 +13245,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13254,47 +13257,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13302,7 +13305,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13310,7 +13313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13319,7 +13322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13328,44 +13331,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13374,11 +13377,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13386,7 +13389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13397,19 +13400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13417,19 +13420,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13444,7 +13447,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13452,14 +13455,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13467,130 +13470,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13598,11 +13601,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13610,7 +13613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13618,7 +13621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13626,7 +13629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13637,63 +13640,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13701,15 +13704,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13818,39 +13821,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -13858,7 +13861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -13866,31 +13869,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13898,7 +13901,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13907,7 +13910,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13915,7 +13918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13924,7 +13927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13936,11 +13939,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13994,28 +13997,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14024,7 +14027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14034,7 +14037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14045,7 +14048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14056,7 +14059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14067,47 +14070,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14117,7 +14120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14125,14 +14128,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14140,11 +14143,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14152,11 +14155,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14164,11 +14167,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14176,7 +14179,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14187,31 +14190,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14219,19 +14222,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14239,7 +14242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14249,53 +14252,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14303,7 +14306,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14312,7 +14315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14322,7 +14325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14332,7 +14335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14342,7 +14345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14352,7 +14355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14363,7 +14366,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14373,7 +14376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14383,7 +14386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14393,7 +14396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14403,7 +14406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14412,7 +14415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14420,7 +14423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14431,7 +14434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14442,7 +14445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14453,15 +14456,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14470,7 +14473,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14479,7 +14482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14489,7 +14492,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14498,7 +14501,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14556,28 +14559,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14585,15 +14588,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14607,122 +14610,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14730,7 +14733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14739,15 +14742,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14755,11 +14758,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14767,22 +14770,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14792,7 +14795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14800,14 +14803,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14815,11 +14818,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14827,19 +14830,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14847,38 +14850,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -14905,7 +14908,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -14915,18 +14918,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14943,7 +14946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14952,7 +14955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14963,7 +14966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14974,7 +14977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15028,23 +15031,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15052,7 +15055,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15060,7 +15063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15068,7 +15071,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15077,19 +15080,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15097,11 +15100,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15111,7 +15114,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15119,83 +15122,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15333,11 +15336,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15346,11 +15349,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15361,11 +15364,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15380,7 +15383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15395,7 +15398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15413,7 +15416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15428,70 +15431,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15502,7 +15505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15510,7 +15513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15519,7 +15522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15527,70 +15530,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15599,7 +15602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15607,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15615,7 +15618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15696,7 +15699,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15706,163 +15709,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15871,7 +15874,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15880,7 +15883,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15888,7 +15891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15896,7 +15899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15906,7 +15909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15914,7 +15917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15922,7 +15925,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15932,7 +15935,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15942,7 +15945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15950,7 +15953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15958,7 +15961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15968,7 +15971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15976,11 +15979,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15988,7 +15991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15997,7 +16000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16005,11 +16008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16017,7 +16020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16026,7 +16029,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16035,7 +16038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16044,7 +16047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16053,7 +16056,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16066,7 +16069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16078,7 +16081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16093,31 +16096,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16127,11 +16130,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16141,11 +16144,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16155,11 +16158,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16169,11 +16172,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16183,18 +16186,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16202,18 +16205,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16223,7 +16226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16233,102 +16236,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16336,28 +16339,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16365,7 +16368,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16373,7 +16376,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16383,33 +16386,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16417,7 +16420,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16428,15 +16431,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16450,7 +16453,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16464,7 +16467,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16478,15 +16481,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16495,7 +16498,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16503,7 +16506,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16512,14 +16515,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16527,40 +16530,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16568,11 +16571,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16580,11 +16583,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16592,11 +16595,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16604,7 +16607,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16612,7 +16615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16621,45 +16624,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16669,26 +16672,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16702,7 +16705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16714,7 +16717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16726,11 +16729,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16738,15 +16741,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16833,7 +16836,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16845,27 +16848,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16875,7 +16878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16883,7 +16886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16891,27 +16894,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16919,7 +16922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -16928,7 +16931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16937,7 +16940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17113,86 +17116,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17201,18 +17204,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17221,7 +17224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17230,23 +17233,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17262,7 +17265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17280,7 +17283,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17293,7 +17296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17309,7 +17312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17327,7 +17330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17342,7 +17345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17355,7 +17358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17368,7 +17371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17378,19 +17381,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17649,7 +17652,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17657,7 +17660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17666,7 +17669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17675,18 +17678,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17702,7 +17705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17714,7 +17717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17728,7 +17731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17740,21 +17743,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -17762,7 +17765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -17770,7 +17773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -17778,11 +17781,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17790,15 +17793,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17900,7 +17903,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17908,47 +17911,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18216,15 +18219,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18232,26 +18235,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18259,26 +18262,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18286,14 +18289,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18341,37 +18344,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18380,46 +18383,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18428,31 +18431,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18478,15 +18481,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18494,18 +18497,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18513,31 +18516,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18550,59 +18553,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18611,11 +18614,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18624,7 +18627,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18633,12 +18636,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18647,44 +18650,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18699,7 +18702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18714,7 +18717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -18729,7 +18732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -18744,14 +18747,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -18767,7 +18770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18776,7 +18779,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18784,7 +18787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18796,7 +18799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18808,7 +18811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18818,7 +18821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18828,7 +18831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18839,7 +18842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18853,7 +18856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18865,7 +18868,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18876,7 +18879,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18889,7 +18892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18901,7 +18904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18911,7 +18914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18921,31 +18924,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18956,7 +18959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18967,7 +18970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18980,7 +18983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -18990,7 +18993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19001,19 +19004,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19021,19 +19024,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19041,7 +19044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19049,15 +19052,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19070,7 +19073,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19080,7 +19083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19088,34 +19091,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19125,7 +19128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19134,7 +19137,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19142,11 +19145,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19154,11 +19157,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19168,7 +19171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19178,7 +19181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19189,7 +19192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19197,7 +19200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19205,11 +19208,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19228,27 +19231,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19256,62 +19259,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19319,27 +19322,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19365,11 +19368,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19378,15 +19381,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19394,7 +19397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19402,7 +19405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19410,11 +19413,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19423,11 +19426,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19437,7 +19440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19445,84 +19448,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19530,7 +19533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19540,7 +19543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19548,25 +19551,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19574,11 +19577,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19586,7 +19589,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19594,7 +19597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19602,33 +19605,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19668,23 +19671,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19692,27 +19695,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19720,7 +19723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19728,19 +19731,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19748,7 +19751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19756,7 +19759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19764,11 +19767,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19777,7 +19780,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19785,70 +19788,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19856,7 +19859,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19866,7 +19869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19874,25 +19877,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19900,26 +19903,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -19927,45 +19930,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -19973,7 +19976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -19981,7 +19984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -19989,21 +19992,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20011,7 +20014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20020,7 +20023,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20030,19 +20033,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20050,45 +20053,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20096,7 +20099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20104,15 +20107,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20120,55 +20123,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20178,7 +20181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20188,7 +20191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20198,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20206,14 +20209,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20221,22 +20224,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20286,19 +20289,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20306,19 +20309,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20326,15 +20329,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20342,7 +20345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20350,21 +20353,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20373,7 +20376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20385,7 +20388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20397,7 +20400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20409,19 +20412,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20429,33 +20432,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20464,11 +20467,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20478,7 +20481,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20488,7 +20491,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20498,19 +20501,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20518,23 +20521,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20545,7 +20548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20555,23 +20558,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20579,18 +20582,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20599,7 +20602,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20608,33 +20611,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20658,11 +20661,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20670,18 +20673,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20689,7 +20692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20697,7 +20700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20705,21 +20708,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21062,15 +21065,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21078,23 +21081,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21102,27 +21105,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21130,14 +21133,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21145,7 +21148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21174,23 +21177,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21198,11 +21201,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21211,7 +21214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21220,11 +21223,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21249,23 +21252,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21273,14 +21276,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21288,7 +21291,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21298,7 +21301,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21308,7 +21311,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21318,14 +21321,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21334,7 +21337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21343,89 +21346,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21434,92 +21437,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21527,7 +21530,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21535,95 +21538,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21631,7 +21634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21639,14 +21642,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21654,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21662,21 +21665,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -21744,19 +21747,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -21764,43 +21767,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21858,19 +21861,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -21878,14 +21881,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21972,19 +21975,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -21992,26 +21995,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22019,34 +22022,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22054,11 +22057,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22066,7 +22069,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22074,7 +22077,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22083,7 +22086,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22092,23 +22095,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22117,15 +22120,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22134,7 +22137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22142,7 +22145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22150,7 +22153,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22159,7 +22162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22167,7 +22170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22175,7 +22178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22184,7 +22187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22193,7 +22196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22203,11 +22206,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22216,7 +22219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22225,7 +22228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22234,7 +22237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22243,7 +22246,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22252,259 +22255,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22512,23 +22515,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22536,7 +22539,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22545,40 +22548,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22588,7 +22591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22596,14 +22599,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22613,7 +22616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22621,14 +22624,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22638,7 +22641,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22646,14 +22649,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22663,7 +22666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22673,7 +22676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22683,7 +22686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22695,7 +22698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22706,26 +22709,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22735,7 +22738,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22744,7 +22747,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -22753,7 +22756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -22761,7 +22764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22769,7 +22772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -22777,7 +22780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22938,7 +22941,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23036,7 +23039,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23047,11 +23050,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23060,7 +23063,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23069,7 +23072,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23078,7 +23081,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23087,7 +23090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23096,7 +23099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23105,7 +23108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23114,7 +23117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23123,14 +23126,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23138,32 +23141,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23171,7 +23174,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23179,43 +23182,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23224,7 +23227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23233,31 +23236,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23267,7 +23270,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23279,7 +23282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23293,15 +23296,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23481,74 +23484,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23573,7 +23576,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23581,7 +23584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23589,79 +23592,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23670,7 +23673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23680,7 +23683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23688,7 +23691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23696,7 +23699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23704,7 +23707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23712,7 +23715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25156,15 +25159,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25172,26 +25175,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25199,26 +25202,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25226,26 +25229,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25253,26 +25256,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25280,26 +25283,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25307,26 +25310,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25334,26 +25337,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25361,26 +25364,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25388,26 +25391,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25415,26 +25418,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25442,26 +25445,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25469,33 +25472,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25503,26 +25506,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25530,77 +25533,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25610,19 +25613,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25631,14 +25634,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25646,7 +25649,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25656,43 +25659,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25859,15 +25862,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25875,26 +25878,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25902,26 +25905,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25929,26 +25932,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25956,26 +25959,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25983,41 +25986,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26025,7 +26028,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26034,26 +26037,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26061,14 +26064,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26076,7 +26079,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26084,15 +26087,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26100,7 +26103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26108,48 +26111,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26160,23 +26163,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26186,7 +26189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26194,7 +26197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26206,7 +26209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26215,7 +26218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26224,7 +26227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26233,7 +26236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26242,7 +26245,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26250,7 +26253,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26260,18 +26263,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26281,14 +26284,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26300,7 +26303,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26311,36 +26314,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26348,7 +26351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26356,7 +26359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26364,21 +26367,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26386,11 +26389,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26405,14 +26408,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26422,7 +26425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26432,7 +26435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26442,7 +26445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26454,7 +26457,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26465,7 +26468,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26479,7 +26482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26488,7 +26491,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26497,7 +26500,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26507,7 +26510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26517,7 +26520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26528,7 +26531,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26542,7 +26545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26551,7 +26554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26560,7 +26563,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26569,15 +26572,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26586,7 +26589,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26595,15 +26598,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26612,7 +26615,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26621,23 +26624,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26646,7 +26649,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26655,15 +26658,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26672,7 +26675,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26681,15 +26684,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26698,7 +26701,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26707,15 +26710,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26724,7 +26727,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26733,21 +26736,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26756,7 +26759,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26765,7 +26768,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -26777,7 +26780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -26789,7 +26792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26798,7 +26801,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26807,15 +26810,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26824,7 +26827,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26833,15 +26836,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26850,7 +26853,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26859,7 +26862,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -26871,7 +26874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -26883,7 +26886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26892,7 +26895,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26901,15 +26904,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26918,7 +26921,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26927,15 +26930,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26944,7 +26947,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26953,7 +26956,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -26965,7 +26968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -26977,7 +26980,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26986,7 +26989,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26995,15 +26998,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27012,7 +27015,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27021,15 +27024,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27038,7 +27041,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27047,7 +27050,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27059,7 +27062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27071,7 +27074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27080,7 +27083,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27089,15 +27092,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27109,7 +27112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27121,7 +27124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27133,7 +27136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27145,7 +27148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27154,7 +27157,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27166,7 +27169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27178,7 +27181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27190,7 +27193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27199,7 +27202,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27211,15 +27214,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27228,14 +27231,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27247,7 +27250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27260,7 +27263,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27274,7 +27277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27282,7 +27285,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27290,7 +27293,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27299,11 +27302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27311,27 +27314,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27341,7 +27344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27349,7 +27352,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27364,93 +27367,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27551,23 +27554,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27632,11 +27635,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27723,11 +27726,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -27735,50 +27738,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -27853,15 +27856,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27874,7 +27877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27889,18 +27892,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27909,14 +27912,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27925,7 +27928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27936,7 +27939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27945,7 +27948,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27957,7 +27960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -27969,18 +27972,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -27988,14 +27991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28003,7 +28006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28017,7 +28020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28030,7 +28033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28045,7 +28048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28057,15 +28060,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -4550,7 +4553,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4558,7 +4561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4566,15 +4569,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4586,7 +4589,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4595,7 +4598,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4606,7 +4609,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4617,7 +4620,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4629,7 +4632,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4639,7 +4642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4649,7 +4652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4660,7 +4663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5207,27 +5210,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5235,29 +5238,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5265,7 +5268,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5273,11 +5276,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5285,15 +5288,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5380,11 +5383,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5392,19 +5395,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5412,19 +5415,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5522,11 +5525,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5534,19 +5537,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5554,15 +5557,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5660,11 +5663,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5672,19 +5675,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5692,42 +5695,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_calloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5735,62 +5738,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isalpha"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isalnum"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_isspace"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5798,7 +5801,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5807,7 +5810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5816,7 +5819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5824,7 +5827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5832,21 +5835,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5854,7 +5857,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5862,7 +5865,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5870,7 +5873,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5879,7 +5882,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5887,11 +5890,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5918,45 +5921,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5969,7 +5972,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5983,7 +5986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5994,29 +5997,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6072,7 +6075,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6083,7 +6086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6096,7 +6099,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6108,7 +6111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6117,7 +6120,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6128,7 +6131,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6138,30 +6141,30 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6171,105 +6174,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6278,18 +6281,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6298,18 +6301,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6318,7 +6321,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6326,11 +6329,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6341,57 +6344,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6401,15 +6404,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6459,27 +6462,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6487,11 +6490,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6499,7 +6502,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6507,18 +6510,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6527,7 +6530,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6536,45 +6539,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6585,7 +6588,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6645,7 +6648,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6716,23 +6719,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6740,7 +6743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6749,7 +6752,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6757,7 +6760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6765,7 +6768,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6774,7 +6777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6782,15 +6785,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6799,7 +6802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6807,7 +6810,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6816,71 +6819,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_method_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6903,7 +6906,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6911,68 +6914,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6980,7 +6983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6988,7 +6991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6997,11 +7000,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7010,15 +7013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7026,11 +7029,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7038,22 +7041,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7061,30 +7064,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7092,89 +7095,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7183,34 +7186,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7219,13 +7222,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7234,13 +7237,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7253,7 +7256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7266,7 +7269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7279,7 +7282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7291,7 +7294,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7305,7 +7308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7318,7 +7321,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7331,7 +7334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7343,23 +7346,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7369,7 +7372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7377,30 +7380,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7412,7 +7415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7423,11 +7426,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_s_secmem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7793,197 +7796,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7992,15 +7995,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8010,11 +8013,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8022,47 +8025,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8070,11 +8073,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8082,43 +8085,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8127,7 +8130,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8137,7 +8140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8146,7 +8149,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8156,7 +8159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8165,7 +8168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8175,7 +8178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8184,7 +8187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8194,7 +8197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8203,7 +8206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8212,7 +8215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8220,7 +8223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8229,7 +8232,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8238,7 +8241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8247,11 +8250,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8259,7 +8262,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8387,15 +8390,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8409,7 +8412,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8417,11 +8420,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8436,7 +8439,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8446,7 +8449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8457,7 +8460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8467,7 +8470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8476,7 +8479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8485,7 +8488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8494,7 +8497,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8504,7 +8507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8514,23 +8517,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8539,7 +8542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8548,7 +8551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8558,7 +8561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8567,7 +8570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8577,7 +8580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8588,7 +8591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8599,7 +8602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_GENCB_set_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8613,15 +8616,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8632,7 +8635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8645,11 +8648,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8657,7 +8660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8665,15 +8668,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_CTX_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8833,15 +8836,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8865,15 +8868,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8882,7 +8885,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8890,7 +8893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8898,14 +8901,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8913,7 +8916,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8921,7 +8924,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8929,7 +8932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8937,7 +8940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8945,14 +8948,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8960,7 +8963,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8968,22 +8971,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9059,54 +9062,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9114,7 +9117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9122,79 +9125,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9202,7 +9205,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9210,7 +9213,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9218,7 +9221,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9226,7 +9229,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9234,7 +9237,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9242,7 +9245,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9250,7 +9253,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9258,7 +9261,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9266,117 +9269,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9384,14 +9387,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9401,7 +9404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9413,7 +9416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9423,7 +9426,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9433,15 +9436,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9449,26 +9452,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9476,23 +9479,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9500,14 +9503,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9515,25 +9518,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9541,7 +9544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9549,14 +9552,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9585,19 +9588,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9605,11 +9608,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9617,54 +9620,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9672,59 +9675,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9732,23 +9735,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9757,26 +9760,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9784,29 +9787,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9815,22 +9818,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9838,15 +9841,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9855,15 +9858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9872,52 +9875,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9925,11 +9928,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9954,7 +9957,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9964,11 +9967,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9976,11 +9979,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9988,7 +9991,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10322,15 +10325,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10338,19 +10341,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10358,7 +10361,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10366,12 +10369,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10379,14 +10382,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10394,33 +10397,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10428,7 +10431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10436,19 +10439,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10456,7 +10459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10464,7 +10467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10474,7 +10477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10484,11 +10487,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10496,15 +10499,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10512,52 +10515,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11156,7 +11159,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11181,19 +11184,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11203,19 +11206,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11225,7 +11228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11233,11 +11236,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11247,7 +11250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11255,7 +11258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11414,11 +11417,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11426,11 +11429,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11485,19 +11488,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11506,7 +11509,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11567,23 +11570,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11591,86 +11594,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11678,7 +11681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11686,11 +11689,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11698,7 +11701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11707,7 +11710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11718,22 +11721,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11742,7 +11745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11751,7 +11754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11760,7 +11763,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11769,37 +11772,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11807,7 +11810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11815,7 +11818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12122,23 +12125,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12146,40 +12149,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12187,15 +12190,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12203,55 +12206,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12259,11 +12262,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12271,7 +12274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12279,11 +12282,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12291,11 +12294,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12306,122 +12309,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12432,7 +12435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12442,7 +12445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12452,7 +12455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12462,7 +12465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12470,7 +12473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12480,7 +12483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12488,7 +12491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12498,7 +12501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12506,47 +12509,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12555,49 +12558,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12610,23 +12613,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12636,7 +12639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12645,7 +12648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12654,7 +12657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12662,7 +12665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12670,7 +12673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12678,7 +12681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12687,127 +12690,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13047,7 +13050,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13057,19 +13060,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13079,15 +13082,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13095,7 +13098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13186,15 +13189,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13202,7 +13205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13210,14 +13213,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13225,7 +13228,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13233,31 +13236,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_unload"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CONF_modules_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13265,11 +13268,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13278,7 +13281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13288,15 +13291,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CTR_DRBG_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13304,15 +13307,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13321,7 +13324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13330,7 +13333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13341,7 +13344,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13351,11 +13354,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13366,7 +13369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13439,33 +13442,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_is_weak_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_set_key_unchecked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_key_sched"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13474,7 +13477,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13485,7 +13488,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13496,7 +13499,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13509,7 +13512,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13521,47 +13524,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_new_by_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13569,7 +13572,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13577,7 +13580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13586,7 +13589,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13595,44 +13598,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13641,11 +13644,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13653,7 +13656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13664,19 +13667,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13684,19 +13687,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13711,7 +13714,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13719,14 +13722,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13734,130 +13737,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DH_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_shake128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_shake256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13865,11 +13868,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13877,7 +13880,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13885,7 +13888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13893,7 +13896,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13904,63 +13907,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13968,15 +13971,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14085,39 +14088,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14125,7 +14128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14133,31 +14136,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14165,7 +14168,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14174,7 +14177,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14182,7 +14185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14191,7 +14194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14203,11 +14206,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14261,28 +14264,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14291,7 +14294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14301,7 +14304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14312,7 +14315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14323,7 +14326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14334,47 +14337,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14384,7 +14387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14392,14 +14395,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14407,11 +14410,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14419,11 +14422,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14431,11 +14434,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14443,7 +14446,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14454,31 +14457,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_p521"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_group_secp256k1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14486,19 +14489,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14506,7 +14509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14516,53 +14519,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14570,7 +14573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14579,7 +14582,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14589,7 +14592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14599,7 +14602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14609,7 +14612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14619,7 +14622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14630,7 +14633,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14640,7 +14643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14650,7 +14653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14660,7 +14663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14670,7 +14673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14679,7 +14682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14687,7 +14690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14698,7 +14701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14709,7 +14712,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14720,15 +14723,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14737,7 +14740,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14746,7 +14749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_point2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14756,7 +14759,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_bn2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14765,7 +14768,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14823,28 +14826,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14852,15 +14855,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECPKParameters_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14874,122 +14877,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_set_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_get_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_set_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_get_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ENGINE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14997,7 +15000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15006,15 +15009,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15022,11 +15025,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15034,22 +15037,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15059,7 +15062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15067,14 +15070,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15082,11 +15085,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15094,19 +15097,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15114,38 +15117,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15172,7 +15175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15182,18 +15185,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15210,7 +15213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15219,7 +15222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15230,7 +15233,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15241,7 +15244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15295,23 +15298,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15319,7 +15322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15327,7 +15330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15335,7 +15338,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15344,19 +15347,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15364,11 +15367,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15378,7 +15381,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15386,83 +15389,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15600,11 +15603,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15613,11 +15616,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15628,11 +15631,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15647,7 +15650,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15662,7 +15665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15680,7 +15683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15695,70 +15698,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15769,7 +15772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15777,7 +15780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15786,7 +15789,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15794,70 +15797,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_get_undef"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15866,7 +15869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15874,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15882,7 +15885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15963,7 +15966,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15973,163 +15976,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16138,7 +16141,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16147,7 +16150,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16155,7 +16158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16163,7 +16166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16173,7 +16176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16181,7 +16184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16189,7 +16192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16199,7 +16202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16209,7 +16212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16217,7 +16220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16225,7 +16228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16235,7 +16238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16243,11 +16246,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16255,7 +16258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16264,7 +16267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16272,11 +16275,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16284,7 +16287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16293,7 +16296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16302,7 +16305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16311,7 +16314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16320,7 +16323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16333,7 +16336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16345,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16360,31 +16363,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16394,11 +16397,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16408,11 +16411,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16422,11 +16425,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16436,11 +16439,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16450,18 +16453,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16469,18 +16472,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16490,7 +16493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16500,102 +16503,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16603,28 +16606,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16632,7 +16635,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16640,7 +16643,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16650,33 +16653,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16684,7 +16687,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16695,15 +16698,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16717,7 +16720,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16731,7 +16734,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_MD_do_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16745,15 +16748,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16762,7 +16765,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16770,7 +16773,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16779,14 +16782,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16794,40 +16797,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16835,11 +16838,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16847,11 +16850,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16859,11 +16862,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16871,7 +16874,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16879,7 +16882,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16888,45 +16891,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16936,26 +16939,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16969,7 +16972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16981,7 +16984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16993,11 +16996,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17005,15 +17008,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17100,7 +17103,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17112,27 +17115,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17142,7 +17145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17150,7 +17153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17158,27 +17161,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17186,7 +17189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17195,7 +17198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17204,7 +17207,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17380,86 +17383,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17468,18 +17471,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17488,7 +17491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17497,23 +17500,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17529,7 +17532,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17547,7 +17550,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17560,7 +17563,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17576,7 +17579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17594,7 +17597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17609,7 +17612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17622,7 +17625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17635,7 +17638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17645,19 +17648,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17916,7 +17919,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17924,7 +17927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17933,7 +17936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17942,18 +17945,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17969,7 +17972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSKDF_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17981,7 +17984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SSKDF_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17995,7 +17998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18007,21 +18010,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18029,7 +18032,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18037,7 +18040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18045,11 +18048,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18057,15 +18060,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18167,7 +18170,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18175,47 +18178,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18483,15 +18486,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18499,26 +18502,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18526,26 +18529,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18553,14 +18556,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18608,37 +18611,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18647,46 +18650,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_add_signer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_content_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_set_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_set_content"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18695,31 +18698,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18745,15 +18748,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18761,18 +18764,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18780,31 +18783,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18817,59 +18820,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18878,11 +18881,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18891,7 +18894,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18900,12 +18903,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18914,44 +18917,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18966,7 +18969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18981,7 +18984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -18996,7 +18999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19011,14 +19014,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_meth_set_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19034,7 +19037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19043,7 +19046,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19051,7 +19054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19063,7 +19066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19075,7 +19078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19085,7 +19088,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19095,7 +19098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19106,7 +19109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19120,7 +19123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19132,7 +19135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19143,7 +19146,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19156,7 +19159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19168,7 +19171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19178,7 +19181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19188,31 +19191,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19223,7 +19226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19234,7 +19237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19247,7 +19250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS1_MGF1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19257,7 +19260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19268,19 +19271,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19288,19 +19291,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19308,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19316,15 +19319,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19337,7 +19340,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19347,7 +19350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19355,34 +19358,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19392,7 +19395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19401,7 +19404,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19409,11 +19412,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19421,11 +19424,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19435,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19445,7 +19448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19456,7 +19459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19464,7 +19467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19472,11 +19475,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_new_method_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19495,27 +19498,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19523,62 +19526,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19586,27 +19589,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19632,11 +19635,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19645,15 +19648,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19661,7 +19664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19669,7 +19672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19677,11 +19680,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19690,11 +19693,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_signature_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19704,7 +19707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19712,84 +19715,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19797,7 +19800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19807,7 +19810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19815,25 +19818,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19841,11 +19844,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19853,7 +19856,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19861,7 +19864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19869,33 +19872,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19935,23 +19938,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19959,27 +19962,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19987,7 +19990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19995,19 +19998,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20015,7 +20018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20023,7 +20026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20031,11 +20034,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20044,7 +20047,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20052,70 +20055,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20123,7 +20126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20133,7 +20136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20141,25 +20144,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20167,26 +20170,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20194,45 +20197,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20240,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20248,7 +20251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20256,21 +20259,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20278,7 +20281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20287,7 +20290,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20297,19 +20300,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20317,45 +20320,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20363,7 +20366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20371,15 +20374,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20387,55 +20390,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20445,7 +20448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20455,7 +20458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20465,7 +20468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20473,14 +20476,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20488,22 +20491,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20553,19 +20556,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20573,19 +20576,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20593,15 +20596,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20609,7 +20612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20617,21 +20620,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20640,7 +20643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20652,7 +20655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20664,7 +20667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20676,19 +20679,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20696,33 +20699,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20731,11 +20734,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20745,7 +20748,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20755,7 +20758,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20765,19 +20768,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20785,23 +20788,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20812,7 +20815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20822,23 +20825,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20846,18 +20849,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20866,7 +20869,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20875,33 +20878,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20925,11 +20928,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20937,18 +20940,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20956,7 +20959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20964,7 +20967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20972,21 +20975,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21329,15 +21332,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21345,23 +21348,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21369,27 +21372,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21397,14 +21400,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21412,7 +21415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21441,23 +21444,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21465,11 +21468,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21478,7 +21481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21487,11 +21490,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21516,23 +21519,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21540,14 +21543,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21555,7 +21558,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21565,7 +21568,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21575,7 +21578,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21585,14 +21588,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21601,7 +21604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21610,89 +21613,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21701,92 +21704,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21794,7 +21797,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21802,95 +21805,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21898,7 +21901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21906,14 +21909,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21921,7 +21924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21929,21 +21932,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22011,19 +22014,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22031,43 +22034,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22125,19 +22128,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22145,14 +22148,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22239,19 +22242,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22259,26 +22262,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22286,34 +22289,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22321,11 +22324,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22333,7 +22336,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22341,7 +22344,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22350,7 +22353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22359,23 +22362,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22384,15 +22387,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22401,7 +22404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22409,7 +22412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22417,7 +22420,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22426,7 +22429,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22434,7 +22437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22442,7 +22445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22451,7 +22454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22460,7 +22463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22470,11 +22473,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22483,7 +22486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22492,7 +22495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22501,7 +22504,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22510,7 +22513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22519,259 +22522,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22779,23 +22782,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22803,7 +22806,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22812,40 +22815,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22855,7 +22858,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22863,14 +22866,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22880,7 +22883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22888,14 +22891,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22905,7 +22908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22913,14 +22916,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22930,7 +22933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22940,7 +22943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22950,7 +22953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22962,7 +22965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22973,26 +22976,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23002,7 +23005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23011,7 +23014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23020,7 +23023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23028,7 +23031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23036,7 +23039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23044,7 +23047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23205,7 +23208,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23303,7 +23306,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23314,11 +23317,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23327,7 +23330,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23336,7 +23339,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23345,7 +23348,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23354,7 +23357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23363,7 +23366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23372,7 +23375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23381,7 +23384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23390,14 +23393,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23405,32 +23408,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23438,7 +23441,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23446,43 +23449,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23491,7 +23494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23500,31 +23503,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23534,7 +23537,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23546,7 +23549,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23560,15 +23563,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23748,74 +23751,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23840,7 +23843,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23848,7 +23851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23856,79 +23859,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_lock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_unlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23937,7 +23940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23947,7 +23950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23955,7 +23958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23963,7 +23966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23971,7 +23974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23979,7 +23982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25423,15 +25426,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25439,26 +25442,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25466,26 +25469,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25493,26 +25496,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25520,26 +25523,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25547,26 +25550,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25574,26 +25577,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25601,26 +25604,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25628,26 +25631,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25655,26 +25658,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25682,26 +25685,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25709,26 +25712,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25736,33 +25739,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25770,26 +25773,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25797,77 +25800,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25877,19 +25880,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25898,14 +25901,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25913,7 +25916,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25923,43 +25926,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26126,15 +26129,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26142,26 +26145,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26169,26 +26172,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26196,26 +26199,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26223,26 +26226,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26250,41 +26253,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26292,7 +26295,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_sendreq_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26301,26 +26304,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26328,14 +26331,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26343,7 +26346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26351,15 +26354,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_add0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26367,7 +26370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26375,48 +26378,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_check_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_copy_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26427,23 +26430,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_single_get0_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26453,7 +26456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26461,7 +26464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_resp_find_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26473,7 +26476,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_check_validity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26482,7 +26485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26491,7 +26494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_request_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26500,7 +26503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_cert_id_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26509,7 +26512,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_cert_to_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26517,7 +26520,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_parse_url"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26527,18 +26530,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_id_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_id_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26548,14 +26551,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26567,7 +26570,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_basic_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26578,36 +26581,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_response_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_cert_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26615,7 +26618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26623,7 +26626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26631,21 +26634,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26653,11 +26656,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26672,14 +26675,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26689,7 +26692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26699,7 +26702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26709,7 +26712,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26721,7 +26724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26732,7 +26735,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26746,7 +26749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26755,7 +26758,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26764,7 +26767,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26774,7 +26777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26784,7 +26787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26795,7 +26798,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26809,7 +26812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26818,7 +26821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26827,7 +26830,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26836,15 +26839,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26853,7 +26856,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26862,15 +26865,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26879,7 +26882,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26888,23 +26891,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26913,7 +26916,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26922,15 +26925,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26939,7 +26942,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26948,15 +26951,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26965,7 +26968,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26974,15 +26977,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26991,7 +26994,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27000,21 +27003,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27023,7 +27026,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27032,7 +27035,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27044,7 +27047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27056,7 +27059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27065,7 +27068,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27074,15 +27077,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27091,7 +27094,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27100,15 +27103,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27117,7 +27120,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27126,7 +27129,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27138,7 +27141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27150,7 +27153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27159,7 +27162,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27168,15 +27171,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27185,7 +27188,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27194,15 +27197,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27211,7 +27214,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27220,7 +27223,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27232,7 +27235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27244,7 +27247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27253,7 +27256,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27262,15 +27265,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27279,7 +27282,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27288,15 +27291,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27305,7 +27308,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27314,7 +27317,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27326,7 +27329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27338,7 +27341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27347,7 +27350,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27356,15 +27359,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27376,7 +27379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27388,7 +27391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27400,7 +27403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27412,7 +27415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27421,7 +27424,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27433,7 +27436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27445,7 +27448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27457,7 +27460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27466,7 +27469,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27478,15 +27481,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27495,14 +27498,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27514,7 +27517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27527,7 +27530,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27541,7 +27544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27549,7 +27552,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27557,7 +27560,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27566,11 +27569,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27578,27 +27581,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27608,7 +27611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27616,7 +27619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27631,93 +27634,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_priv_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_write_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_egd_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27818,23 +27821,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27899,11 +27902,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27990,11 +27993,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28002,50 +28005,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28120,15 +28123,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28141,7 +28144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28156,18 +28159,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28176,14 +28179,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28192,7 +28195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28203,7 +28206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28212,7 +28215,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28224,7 +28227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28236,18 +28239,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28255,14 +28258,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28270,7 +28273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28284,7 +28287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28297,7 +28300,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28312,7 +28315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28324,15 +28327,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_0_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_1_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -4496,7 +4499,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4504,7 +4507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4512,15 +4515,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4532,7 +4535,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4541,7 +4544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4552,7 +4555,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4563,7 +4566,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4575,7 +4578,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4585,7 +4588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4595,7 +4598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4606,7 +4609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5192,27 +5195,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5220,29 +5223,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5250,7 +5253,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5258,11 +5261,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5270,15 +5273,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5365,11 +5368,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5377,19 +5380,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5397,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5507,11 +5510,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5519,19 +5522,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5539,15 +5542,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5645,11 +5648,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5657,19 +5660,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5677,42 +5680,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5720,62 +5723,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5783,7 +5786,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5792,7 +5795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5801,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5809,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5817,21 +5820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5839,7 +5842,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5847,7 +5850,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5855,7 +5858,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5864,7 +5867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5872,11 +5875,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5903,27 +5906,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 #[repr(C)]
@@ -5979,19 +5982,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6004,7 +6007,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6018,7 +6021,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6029,29 +6032,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6107,7 +6110,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6118,7 +6121,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6131,7 +6134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6143,7 +6146,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6152,7 +6155,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6163,7 +6166,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6173,30 +6176,30 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6206,105 +6209,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6313,18 +6316,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6333,18 +6336,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6353,7 +6356,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6361,11 +6364,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6376,57 +6379,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6436,15 +6439,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6494,27 +6497,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6522,11 +6525,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6534,7 +6537,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6542,18 +6545,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6562,7 +6565,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6571,45 +6574,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6620,7 +6623,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6680,7 +6683,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6751,23 +6754,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6775,7 +6778,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6784,7 +6787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6792,7 +6795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6800,7 +6803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6809,7 +6812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6817,15 +6820,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6834,7 +6837,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6842,7 +6845,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6851,71 +6854,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6938,7 +6941,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6946,68 +6949,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7015,7 +7018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7023,7 +7026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7032,11 +7035,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7045,15 +7048,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7061,11 +7064,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7073,22 +7076,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7096,30 +7099,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7127,89 +7130,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7218,34 +7221,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7254,13 +7257,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7269,13 +7272,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7288,7 +7291,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7301,7 +7304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7314,7 +7317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7326,7 +7329,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7340,7 +7343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7353,7 +7356,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7366,7 +7369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7378,23 +7381,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7404,7 +7407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7412,30 +7415,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7447,7 +7450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7458,11 +7461,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7828,197 +7831,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8027,15 +8030,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8045,11 +8048,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8057,47 +8060,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8105,11 +8108,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8117,43 +8120,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8162,7 +8165,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8172,7 +8175,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8181,7 +8184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8191,7 +8194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8200,7 +8203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8210,7 +8213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8219,7 +8222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8229,7 +8232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8238,7 +8241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8247,7 +8250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8255,7 +8258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8264,7 +8267,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8273,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8282,11 +8285,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8294,7 +8297,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8422,15 +8425,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8444,7 +8447,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8452,11 +8455,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8471,7 +8474,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8481,7 +8484,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8492,7 +8495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8502,7 +8505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8511,7 +8514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8520,7 +8523,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8529,7 +8532,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8539,7 +8542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8549,23 +8552,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8574,7 +8577,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8583,7 +8586,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8593,7 +8596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8602,7 +8605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8612,7 +8615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8623,7 +8626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8634,7 +8637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8648,15 +8651,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8667,7 +8670,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8680,11 +8683,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8692,7 +8695,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8700,15 +8703,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8868,15 +8871,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8900,15 +8903,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8917,7 +8920,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8925,7 +8928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8933,14 +8936,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8948,7 +8951,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8956,7 +8959,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8964,7 +8967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8972,7 +8975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8980,14 +8983,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8995,7 +8998,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -9003,22 +9006,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9094,54 +9097,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9149,7 +9152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9157,79 +9160,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9237,7 +9240,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9245,7 +9248,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9253,7 +9256,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9261,7 +9264,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9269,7 +9272,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9277,7 +9280,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9285,7 +9288,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9293,7 +9296,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9301,117 +9304,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9419,14 +9422,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9436,7 +9439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9448,7 +9451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9458,7 +9461,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9468,15 +9471,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9484,26 +9487,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9511,23 +9514,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9535,14 +9538,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9550,25 +9553,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9576,7 +9579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9584,14 +9587,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9620,19 +9623,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9640,11 +9643,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9652,54 +9655,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9707,59 +9710,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9767,23 +9770,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9792,26 +9795,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9819,29 +9822,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9850,22 +9853,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9873,15 +9876,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9890,15 +9893,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9907,52 +9910,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9960,11 +9963,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9989,7 +9992,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9999,11 +10002,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10011,11 +10014,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10023,7 +10026,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10357,15 +10360,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10373,19 +10376,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10393,7 +10396,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10401,12 +10404,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10414,14 +10417,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10429,33 +10432,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10463,7 +10466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10471,19 +10474,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10491,7 +10494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10499,7 +10502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10509,7 +10512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10519,11 +10522,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10531,15 +10534,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10547,52 +10550,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11191,7 +11194,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11216,19 +11219,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11238,19 +11241,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11260,7 +11263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11268,11 +11271,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11282,7 +11285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11290,7 +11293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11449,11 +11452,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11461,11 +11464,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11520,19 +11523,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11541,7 +11544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11602,23 +11605,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11626,86 +11629,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11713,7 +11716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11721,11 +11724,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11733,7 +11736,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11742,7 +11745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11753,22 +11756,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11777,7 +11780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11786,7 +11789,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11795,7 +11798,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11804,37 +11807,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11842,7 +11845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11850,7 +11853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12157,23 +12160,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12181,40 +12184,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12222,15 +12225,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12238,55 +12241,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12294,11 +12297,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12306,7 +12309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12314,11 +12317,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12326,11 +12329,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12341,122 +12344,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12467,7 +12470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12477,7 +12480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12487,7 +12490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12497,7 +12500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12505,7 +12508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12515,7 +12518,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12523,7 +12526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12533,7 +12536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12541,47 +12544,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12590,49 +12593,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12645,23 +12648,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12671,7 +12674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12680,7 +12683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12689,7 +12692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12697,7 +12700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12705,7 +12708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12713,7 +12716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12722,127 +12725,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13082,7 +13085,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13092,19 +13095,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13114,15 +13117,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13130,7 +13133,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13221,15 +13224,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13237,7 +13240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13245,14 +13248,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13260,7 +13263,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13268,31 +13271,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13300,11 +13303,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13313,7 +13316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13323,15 +13326,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13339,15 +13342,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13356,7 +13359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13365,7 +13368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13376,7 +13379,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13386,11 +13389,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13401,7 +13404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13474,33 +13477,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13509,7 +13512,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13520,7 +13523,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13531,7 +13534,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13544,7 +13547,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13556,47 +13559,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13604,7 +13607,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13612,7 +13615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13621,7 +13624,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13630,44 +13633,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13676,11 +13679,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13688,7 +13691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13699,19 +13702,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13719,19 +13722,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13746,7 +13749,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13754,14 +13757,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13769,130 +13772,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13900,11 +13903,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13912,7 +13915,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13920,7 +13923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13928,7 +13931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13939,63 +13942,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14003,15 +14006,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14120,39 +14123,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14160,7 +14163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14168,31 +14171,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14200,7 +14203,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14209,7 +14212,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14217,7 +14220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14226,7 +14229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14238,11 +14241,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14296,28 +14299,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14326,7 +14329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14336,7 +14339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14347,7 +14350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14358,7 +14361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14369,47 +14372,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14419,7 +14422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14427,14 +14430,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14442,11 +14445,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14454,11 +14457,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14466,11 +14469,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14478,7 +14481,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14489,31 +14492,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14521,19 +14524,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14541,7 +14544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14551,53 +14554,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14605,7 +14608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14614,7 +14617,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14624,7 +14627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14634,7 +14637,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14644,7 +14647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14654,7 +14657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14665,7 +14668,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14675,7 +14678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14685,7 +14688,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14695,7 +14698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14705,7 +14708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14714,7 +14717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14722,7 +14725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14733,7 +14736,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14744,7 +14747,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14755,15 +14758,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14772,7 +14775,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14781,7 +14784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14791,7 +14794,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14800,7 +14803,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14858,28 +14861,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14887,15 +14890,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14909,122 +14912,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15032,7 +15035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15041,15 +15044,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15057,11 +15060,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15069,22 +15072,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15094,7 +15097,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15102,14 +15105,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15117,11 +15120,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15129,19 +15132,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15149,38 +15152,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15207,7 +15210,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15217,18 +15220,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15245,7 +15248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15254,7 +15257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15265,7 +15268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15276,7 +15279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15330,23 +15333,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15354,7 +15357,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15362,7 +15365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15370,7 +15373,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15379,19 +15382,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15399,11 +15402,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15413,7 +15416,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15421,83 +15424,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15635,11 +15638,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15648,11 +15651,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15663,11 +15666,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15682,7 +15685,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15697,7 +15700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15715,7 +15718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15730,70 +15733,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15804,7 +15807,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15812,7 +15815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15821,7 +15824,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15829,70 +15832,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15901,7 +15904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15909,7 +15912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15917,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15998,7 +16001,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -16008,163 +16011,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16173,7 +16176,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16182,7 +16185,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16190,7 +16193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16198,7 +16201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16208,7 +16211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16216,7 +16219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16224,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16234,7 +16237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16244,7 +16247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16252,7 +16255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16260,7 +16263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16270,7 +16273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16278,11 +16281,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16290,7 +16293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16299,7 +16302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16307,11 +16310,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16319,7 +16322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16328,7 +16331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16337,7 +16340,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16346,7 +16349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16355,7 +16358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16368,7 +16371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16380,7 +16383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16395,31 +16398,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16429,11 +16432,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16443,11 +16446,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16457,11 +16460,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16471,11 +16474,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16485,18 +16488,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16504,18 +16507,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16525,7 +16528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16535,102 +16538,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16638,28 +16641,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16667,7 +16670,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16675,7 +16678,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16685,33 +16688,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16719,7 +16722,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16730,15 +16733,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16752,7 +16755,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16766,7 +16769,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16780,15 +16783,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16797,7 +16800,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16805,7 +16808,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16814,14 +16817,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16829,40 +16832,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16870,11 +16873,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16882,11 +16885,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16894,11 +16897,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16906,7 +16909,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16914,7 +16917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16923,45 +16926,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16971,26 +16974,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17004,7 +17007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17016,7 +17019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17028,11 +17031,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17040,15 +17043,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17135,7 +17138,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17147,27 +17150,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17177,7 +17180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17185,7 +17188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17193,27 +17196,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17221,7 +17224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17230,7 +17233,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17239,7 +17242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17415,86 +17418,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17503,18 +17506,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17523,7 +17526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17532,23 +17535,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17564,7 +17567,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17582,7 +17585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17595,7 +17598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17611,7 +17614,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17629,7 +17632,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17644,7 +17647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17657,7 +17660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17670,7 +17673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17680,19 +17683,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17951,7 +17954,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17959,7 +17962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17968,7 +17971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17977,18 +17980,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -18004,7 +18007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -18016,7 +18019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18030,7 +18033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18042,21 +18045,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18064,7 +18067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18072,7 +18075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18080,11 +18083,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18092,15 +18095,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18202,7 +18205,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18210,47 +18213,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18518,15 +18521,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18534,26 +18537,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18561,26 +18564,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18588,14 +18591,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18643,37 +18646,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18682,46 +18685,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18730,31 +18733,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18780,15 +18783,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18796,18 +18799,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18815,31 +18818,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18852,59 +18855,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18913,11 +18916,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18926,7 +18929,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18935,12 +18938,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18949,44 +18952,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -19001,7 +19004,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -19016,7 +19019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -19031,7 +19034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19046,14 +19049,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19069,7 +19072,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19078,7 +19081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19086,7 +19089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19098,7 +19101,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19110,7 +19113,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19120,7 +19123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19130,7 +19133,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19141,7 +19144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19155,7 +19158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19167,7 +19170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19178,7 +19181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19191,7 +19194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19203,7 +19206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19213,7 +19216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19223,31 +19226,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19258,7 +19261,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19269,7 +19272,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19282,7 +19285,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19292,7 +19295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19303,19 +19306,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19323,19 +19326,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19343,7 +19346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19351,15 +19354,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19372,7 +19375,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19382,7 +19385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19390,34 +19393,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19427,7 +19430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19436,7 +19439,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19444,11 +19447,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19456,11 +19459,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19470,7 +19473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19480,7 +19483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19491,7 +19494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19499,7 +19502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19507,11 +19510,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19530,27 +19533,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19558,62 +19561,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19621,27 +19624,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19667,11 +19670,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19680,15 +19683,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19696,7 +19699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19704,7 +19707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19712,11 +19715,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19725,11 +19728,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19739,7 +19742,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19747,84 +19750,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19832,7 +19835,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19842,7 +19845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19850,25 +19853,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19876,11 +19879,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19888,7 +19891,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19896,7 +19899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19904,33 +19907,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19970,23 +19973,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19994,27 +19997,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20022,7 +20025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20030,19 +20033,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20050,7 +20053,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20058,7 +20061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20066,11 +20069,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20079,7 +20082,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20087,70 +20090,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20158,7 +20161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20168,7 +20171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20176,25 +20179,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20202,26 +20205,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20229,45 +20232,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20275,7 +20278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20283,7 +20286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20291,21 +20294,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20313,7 +20316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20322,7 +20325,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20332,19 +20335,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20352,45 +20355,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20398,7 +20401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20406,15 +20409,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20422,55 +20425,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20480,7 +20483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20490,7 +20493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20500,7 +20503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20508,14 +20511,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20523,22 +20526,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20588,19 +20591,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20608,19 +20611,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20628,15 +20631,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20644,7 +20647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20652,21 +20655,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20675,7 +20678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20687,7 +20690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20699,7 +20702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20711,19 +20714,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20731,33 +20734,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20766,11 +20769,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20780,7 +20783,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20790,7 +20793,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20800,19 +20803,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20820,23 +20823,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20847,7 +20850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20857,23 +20860,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20881,18 +20884,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20901,7 +20904,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20910,33 +20913,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20960,11 +20963,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20972,18 +20975,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20991,7 +20994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20999,7 +21002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21007,21 +21010,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21364,15 +21367,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21380,23 +21383,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21404,27 +21407,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21432,14 +21435,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21447,7 +21450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21476,23 +21479,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21500,11 +21503,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21513,7 +21516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21522,11 +21525,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21551,23 +21554,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21575,14 +21578,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21590,7 +21593,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21600,7 +21603,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21610,7 +21613,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21620,14 +21623,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21636,7 +21639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21645,89 +21648,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21736,92 +21739,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21829,7 +21832,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21837,95 +21840,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21933,7 +21936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21941,14 +21944,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21956,7 +21959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21964,21 +21967,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22046,19 +22049,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22066,43 +22069,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22160,19 +22163,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22180,14 +22183,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22274,19 +22277,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22294,26 +22297,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22321,34 +22324,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22356,11 +22359,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22368,7 +22371,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22376,7 +22379,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22385,7 +22388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22394,23 +22397,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22419,15 +22422,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22436,7 +22439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22444,7 +22447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22452,7 +22455,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22461,7 +22464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22469,7 +22472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22477,7 +22480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22486,7 +22489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22495,7 +22498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22505,11 +22508,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22518,7 +22521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22527,7 +22530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22536,7 +22539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22545,7 +22548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22554,259 +22557,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22814,23 +22817,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22838,7 +22841,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22847,40 +22850,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22890,7 +22893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22898,14 +22901,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22915,7 +22918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22923,14 +22926,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22940,7 +22943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22948,14 +22951,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22965,7 +22968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22975,7 +22978,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22985,7 +22988,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22997,7 +23000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23008,26 +23011,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23037,7 +23040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23046,7 +23049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23055,7 +23058,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23063,7 +23066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23071,7 +23074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23079,7 +23082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23240,7 +23243,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23338,7 +23341,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23349,11 +23352,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23362,7 +23365,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23371,7 +23374,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23380,7 +23383,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23389,7 +23392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23398,7 +23401,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23407,7 +23410,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23416,7 +23419,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23425,14 +23428,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23440,32 +23443,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23473,7 +23476,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23481,43 +23484,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23526,7 +23529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23535,31 +23538,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23569,7 +23572,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23581,7 +23584,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23595,15 +23598,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23783,74 +23786,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23875,7 +23878,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23883,7 +23886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23891,79 +23894,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23972,7 +23975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23982,7 +23985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23990,7 +23993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23998,7 +24001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24006,7 +24009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -24014,7 +24017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25458,15 +25461,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25474,26 +25477,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25501,26 +25504,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25528,26 +25531,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25555,26 +25558,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25582,26 +25585,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25609,26 +25612,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25636,26 +25639,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25663,26 +25666,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25690,26 +25693,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25717,26 +25720,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25744,26 +25747,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25771,33 +25774,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25805,26 +25808,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25832,77 +25835,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25912,19 +25915,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25933,14 +25936,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25948,7 +25951,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25958,43 +25961,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26161,15 +26164,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26177,26 +26180,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26204,26 +26207,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26231,26 +26234,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26258,26 +26261,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26285,41 +26288,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26327,7 +26330,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26336,26 +26339,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26363,14 +26366,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26378,7 +26381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26386,15 +26389,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26402,7 +26405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26410,48 +26413,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26462,23 +26465,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26488,7 +26491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26496,7 +26499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26508,7 +26511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26517,7 +26520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26526,7 +26529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26535,7 +26538,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26544,7 +26547,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26552,7 +26555,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26562,18 +26565,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26583,14 +26586,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26602,7 +26605,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26613,36 +26616,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26650,7 +26653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26658,7 +26661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26666,21 +26669,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26688,11 +26691,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26707,14 +26710,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26724,7 +26727,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26734,7 +26737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26744,7 +26747,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26756,7 +26759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26767,7 +26770,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26781,7 +26784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26790,7 +26793,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26799,7 +26802,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26809,7 +26812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26819,7 +26822,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26830,7 +26833,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26844,7 +26847,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26853,7 +26856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26862,7 +26865,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26871,15 +26874,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26888,7 +26891,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26897,15 +26900,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26914,7 +26917,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26923,23 +26926,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26948,7 +26951,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26957,15 +26960,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26974,7 +26977,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26983,15 +26986,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -27000,7 +27003,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -27009,15 +27012,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27026,7 +27029,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27035,21 +27038,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27058,7 +27061,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27067,7 +27070,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27079,7 +27082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27091,7 +27094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27100,7 +27103,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27109,15 +27112,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27126,7 +27129,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27135,15 +27138,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27152,7 +27155,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27161,7 +27164,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27173,7 +27176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27185,7 +27188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27194,7 +27197,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27203,15 +27206,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27220,7 +27223,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27229,15 +27232,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27246,7 +27249,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27255,7 +27258,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27267,7 +27270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27279,7 +27282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27288,7 +27291,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27297,15 +27300,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27314,7 +27317,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27323,15 +27326,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27340,7 +27343,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27349,7 +27352,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27361,7 +27364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27373,7 +27376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27382,7 +27385,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27391,15 +27394,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27411,7 +27414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27423,7 +27426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27435,7 +27438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27447,7 +27450,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27456,7 +27459,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27468,7 +27471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27480,7 +27483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27492,7 +27495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27501,7 +27504,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27513,15 +27516,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27530,14 +27533,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27549,7 +27552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27562,7 +27565,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27576,7 +27579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27584,7 +27587,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27592,7 +27595,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27601,11 +27604,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27613,27 +27616,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27643,7 +27646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27651,7 +27654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27666,93 +27669,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27853,23 +27856,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27934,11 +27937,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -28025,11 +28028,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28037,50 +28040,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28155,15 +28158,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28176,7 +28179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28191,18 +28194,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28211,14 +28214,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28227,7 +28230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28238,7 +28241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28247,7 +28250,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28259,7 +28262,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28271,18 +28274,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28290,14 +28293,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28305,7 +28308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28319,7 +28322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28332,7 +28335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28347,7 +28350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28359,15 +28362,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
 #![allow(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
@@ -4594,7 +4597,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4602,7 +4605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4610,15 +4613,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4630,7 +4633,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4639,7 +4642,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4650,7 +4653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4661,7 +4664,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4673,7 +4676,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4683,7 +4686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4693,7 +4696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4704,7 +4707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4932,27 +4935,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4960,29 +4963,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4990,7 +4993,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4998,11 +5001,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5010,15 +5013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5105,11 +5108,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5117,19 +5120,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5137,19 +5140,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5247,11 +5250,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5259,19 +5262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5279,15 +5282,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5385,11 +5388,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5397,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5417,42 +5420,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5460,62 +5463,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5523,7 +5526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5532,7 +5535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5541,7 +5544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5549,7 +5552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5557,21 +5560,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5579,7 +5582,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5587,7 +5590,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5595,7 +5598,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5604,7 +5607,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5612,11 +5615,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5643,45 +5646,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5694,7 +5697,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5708,7 +5711,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5719,29 +5722,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5797,7 +5800,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5808,7 +5811,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5821,7 +5824,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5833,7 +5836,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5842,7 +5845,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5853,7 +5856,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5863,30 +5866,30 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -5896,105 +5899,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6003,18 +6006,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6023,18 +6026,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6043,7 +6046,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6051,11 +6054,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6066,57 +6069,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6126,15 +6129,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6184,27 +6187,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6212,11 +6215,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6224,7 +6227,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6232,18 +6235,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6252,7 +6255,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6261,45 +6264,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6310,7 +6313,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6370,7 +6373,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6441,23 +6444,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6465,7 +6468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6474,7 +6477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6482,7 +6485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6490,7 +6493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6499,7 +6502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6507,15 +6510,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6524,7 +6527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6532,7 +6535,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6541,71 +6544,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6628,7 +6631,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6636,68 +6639,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6705,7 +6708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6713,7 +6716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6722,11 +6725,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6735,15 +6738,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6751,11 +6754,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6763,22 +6766,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6786,30 +6789,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6817,89 +6820,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6908,34 +6911,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6944,13 +6947,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6959,13 +6962,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6978,7 +6981,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6991,7 +6994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7004,7 +7007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7016,7 +7019,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7030,7 +7033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7043,7 +7046,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7056,7 +7059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7068,23 +7071,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7094,7 +7097,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7102,30 +7105,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7137,7 +7140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7148,11 +7151,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7518,197 +7521,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7717,15 +7720,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7735,11 +7738,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7747,47 +7750,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7795,11 +7798,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7807,43 +7810,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7852,7 +7855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7862,7 +7865,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7871,7 +7874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7881,7 +7884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7890,7 +7893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7900,7 +7903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7909,7 +7912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7919,7 +7922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7928,7 +7931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7937,7 +7940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7945,7 +7948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7954,7 +7957,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7963,7 +7966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7972,11 +7975,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7984,7 +7987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8112,15 +8115,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8134,7 +8137,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8142,11 +8145,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8161,7 +8164,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8171,7 +8174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8182,7 +8185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8192,7 +8195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8201,7 +8204,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8210,7 +8213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8219,7 +8222,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8229,7 +8232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8239,23 +8242,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8264,7 +8267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8273,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8283,7 +8286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8292,7 +8295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8302,7 +8305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8313,7 +8316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8324,7 +8327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8338,15 +8341,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8357,7 +8360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8370,11 +8373,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8382,7 +8385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8390,15 +8393,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8558,15 +8561,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8590,15 +8593,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8607,7 +8610,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8615,7 +8618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8623,14 +8626,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8638,7 +8641,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8646,7 +8649,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8654,7 +8657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8662,7 +8665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8670,14 +8673,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8685,7 +8688,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8693,22 +8696,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8784,54 +8787,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8839,7 +8842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8847,79 +8850,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8927,7 +8930,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8935,7 +8938,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8943,7 +8946,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8951,7 +8954,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8959,7 +8962,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8967,7 +8970,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8975,7 +8978,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8983,7 +8986,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8991,117 +8994,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9109,14 +9112,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9126,7 +9129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9138,7 +9141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9148,7 +9151,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9158,15 +9161,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9174,26 +9177,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9201,23 +9204,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9225,14 +9228,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9240,25 +9243,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9266,7 +9269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9274,14 +9277,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9310,19 +9313,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9330,11 +9333,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9342,54 +9345,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9397,59 +9400,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9457,23 +9460,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9482,26 +9485,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9509,29 +9512,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9540,22 +9543,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9563,15 +9566,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9580,15 +9583,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9597,52 +9600,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9650,11 +9653,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9679,7 +9682,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9689,11 +9692,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9701,11 +9704,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9713,7 +9716,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10047,15 +10050,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10063,19 +10066,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10083,7 +10086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10091,12 +10094,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10104,14 +10107,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10119,33 +10122,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10153,7 +10156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10161,19 +10164,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10181,7 +10184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10189,7 +10192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10199,7 +10202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10209,11 +10212,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10221,15 +10224,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10237,52 +10240,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10881,7 +10884,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10906,19 +10909,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10928,19 +10931,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10950,7 +10953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10958,11 +10961,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10972,7 +10975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10980,7 +10983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11139,11 +11142,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11151,11 +11154,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11210,19 +11213,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11231,7 +11234,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11292,23 +11295,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11316,86 +11319,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11403,7 +11406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11411,11 +11414,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11423,7 +11426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11432,7 +11435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11443,22 +11446,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11467,7 +11470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11476,7 +11479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11485,7 +11488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11494,37 +11497,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11532,7 +11535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11540,7 +11543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11847,23 +11850,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11871,40 +11874,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11912,15 +11915,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11928,55 +11931,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11984,11 +11987,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11996,7 +11999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12004,11 +12007,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12016,11 +12019,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12031,122 +12034,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12157,7 +12160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12167,7 +12170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12177,7 +12180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12187,7 +12190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12195,7 +12198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12205,7 +12208,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12213,7 +12216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12223,7 +12226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12231,47 +12234,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12280,49 +12283,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12335,23 +12338,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12361,7 +12364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12370,7 +12373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12379,7 +12382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12387,7 +12390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12395,7 +12398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12403,7 +12406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12412,127 +12415,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12772,7 +12775,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12782,19 +12785,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12804,15 +12807,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12820,7 +12823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -12911,15 +12914,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12927,7 +12930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12935,14 +12938,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12950,7 +12953,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12958,31 +12961,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -12990,11 +12993,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13003,7 +13006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13013,15 +13016,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13029,15 +13032,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13046,7 +13049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13055,7 +13058,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13066,7 +13069,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13076,11 +13079,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13091,7 +13094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13164,33 +13167,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13199,7 +13202,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13210,7 +13213,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13221,7 +13224,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13234,7 +13237,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13246,47 +13249,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13294,7 +13297,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13302,7 +13305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13311,7 +13314,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13320,44 +13323,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13366,11 +13369,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13378,7 +13381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13389,19 +13392,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13409,19 +13412,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13436,7 +13439,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13444,14 +13447,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13459,130 +13462,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13590,11 +13593,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13602,7 +13605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13610,7 +13613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13618,7 +13621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13629,63 +13632,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13693,15 +13696,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13810,39 +13813,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -13850,7 +13853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -13858,31 +13861,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13890,7 +13893,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13899,7 +13902,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13907,7 +13910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13916,7 +13919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13928,11 +13931,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13986,28 +13989,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14016,7 +14019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14026,7 +14029,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14037,7 +14040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14048,7 +14051,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14059,47 +14062,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14109,7 +14112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14117,14 +14120,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14132,11 +14135,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14144,11 +14147,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14156,11 +14159,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14168,7 +14171,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14179,31 +14182,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14211,19 +14214,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14231,7 +14234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14241,53 +14244,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14295,7 +14298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14304,7 +14307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14314,7 +14317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14324,7 +14327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14334,7 +14337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14344,7 +14347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14355,7 +14358,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14365,7 +14368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14375,7 +14378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14385,7 +14388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14395,7 +14398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14404,7 +14407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14412,7 +14415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14423,7 +14426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14434,7 +14437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14445,15 +14448,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14462,7 +14465,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14471,7 +14474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14481,7 +14484,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14490,7 +14493,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14548,28 +14551,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14577,15 +14580,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14599,122 +14602,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14722,7 +14725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14731,15 +14734,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14747,11 +14750,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14759,22 +14762,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14784,7 +14787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14792,14 +14795,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14807,11 +14810,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14819,19 +14822,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14839,38 +14842,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -14897,7 +14900,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -14907,18 +14910,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14935,7 +14938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14944,7 +14947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14955,7 +14958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14966,7 +14969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15020,23 +15023,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15044,7 +15047,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15052,7 +15055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15060,7 +15063,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15069,19 +15072,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15089,11 +15092,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15103,7 +15106,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15111,83 +15114,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15325,11 +15328,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15338,11 +15341,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15353,11 +15356,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15372,7 +15375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15387,7 +15390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15405,7 +15408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15420,70 +15423,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15494,7 +15497,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15502,7 +15505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15511,7 +15514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15519,70 +15522,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15591,7 +15594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15599,7 +15602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15607,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15688,7 +15691,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15698,163 +15701,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15863,7 +15866,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15872,7 +15875,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15880,7 +15883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15888,7 +15891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15898,7 +15901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15906,7 +15909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15914,7 +15917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15924,7 +15927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15934,7 +15937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15942,7 +15945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15950,7 +15953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15960,7 +15963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15968,11 +15971,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15980,7 +15983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15989,7 +15992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15997,11 +16000,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16009,7 +16012,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16018,7 +16021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16027,7 +16030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16036,7 +16039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16045,7 +16048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16058,7 +16061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16070,7 +16073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16085,31 +16088,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16119,11 +16122,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16133,11 +16136,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16147,11 +16150,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16161,11 +16164,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16175,18 +16178,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16194,18 +16197,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16215,7 +16218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16225,102 +16228,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16328,28 +16331,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16357,7 +16360,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16365,7 +16368,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16375,33 +16378,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16409,7 +16412,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16420,15 +16423,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16442,7 +16445,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16456,7 +16459,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16470,15 +16473,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16487,7 +16490,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16495,7 +16498,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16504,14 +16507,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16519,40 +16522,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16560,11 +16563,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16572,11 +16575,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16584,11 +16587,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16596,7 +16599,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16604,7 +16607,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16613,45 +16616,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16661,26 +16664,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16694,7 +16697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16706,7 +16709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16718,11 +16721,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16730,15 +16733,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16825,7 +16828,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16837,27 +16840,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16867,7 +16870,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16875,7 +16878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16883,27 +16886,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16911,7 +16914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -16920,7 +16923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16929,7 +16932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17105,86 +17108,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17193,18 +17196,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17213,7 +17216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17222,23 +17225,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17254,7 +17257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17272,7 +17275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17285,7 +17288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17301,7 +17304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17319,7 +17322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17334,7 +17337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17347,7 +17350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17360,7 +17363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17370,19 +17373,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17641,7 +17644,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17649,7 +17652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17658,7 +17661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17667,18 +17670,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17694,7 +17697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17706,7 +17709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17720,7 +17723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17732,21 +17735,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -17754,7 +17757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -17762,7 +17765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -17770,11 +17773,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17782,15 +17785,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17892,7 +17895,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17900,47 +17903,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18208,15 +18211,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18224,26 +18227,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18251,26 +18254,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18278,14 +18281,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18333,37 +18336,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18372,46 +18375,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18420,31 +18423,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18470,15 +18473,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18486,18 +18489,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18505,31 +18508,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18542,59 +18545,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18603,11 +18606,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18616,7 +18619,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18625,12 +18628,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18639,44 +18642,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18691,7 +18694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18706,7 +18709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -18721,7 +18724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -18736,14 +18739,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -18759,7 +18762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18768,7 +18771,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18776,7 +18779,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18788,7 +18791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18800,7 +18803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18810,7 +18813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18820,7 +18823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18831,7 +18834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18845,7 +18848,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18857,7 +18860,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18868,7 +18871,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18881,7 +18884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18893,7 +18896,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18903,7 +18906,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18913,31 +18916,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18948,7 +18951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18959,7 +18962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18972,7 +18975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -18982,7 +18985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18993,19 +18996,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19013,19 +19016,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19033,7 +19036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19041,15 +19044,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19062,7 +19065,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19072,7 +19075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19080,34 +19083,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19117,7 +19120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19126,7 +19129,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19134,11 +19137,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19146,11 +19149,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19160,7 +19163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19170,7 +19173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19181,7 +19184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19189,7 +19192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19197,11 +19200,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19220,27 +19223,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19248,62 +19251,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19311,27 +19314,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19357,11 +19360,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19370,15 +19373,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19386,7 +19389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19394,7 +19397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19402,11 +19405,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19415,11 +19418,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19429,7 +19432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19437,84 +19440,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19522,7 +19525,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19532,7 +19535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19540,25 +19543,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19566,11 +19569,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19578,7 +19581,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19586,7 +19589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19594,33 +19597,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19660,23 +19663,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19684,27 +19687,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19712,7 +19715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19720,19 +19723,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19740,7 +19743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19748,7 +19751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19756,11 +19759,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19769,7 +19772,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19777,70 +19780,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19848,7 +19851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19858,7 +19861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19866,25 +19869,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19892,26 +19895,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -19919,45 +19922,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -19965,7 +19968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -19973,7 +19976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -19981,21 +19984,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20003,7 +20006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20012,7 +20015,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20022,19 +20025,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20042,45 +20045,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20088,7 +20091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20096,15 +20099,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20112,55 +20115,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20170,7 +20173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20180,7 +20183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20190,7 +20193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20198,14 +20201,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20213,22 +20216,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20278,19 +20281,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20298,19 +20301,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20318,15 +20321,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20334,7 +20337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20342,21 +20345,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20365,7 +20368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20377,7 +20380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20389,7 +20392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20401,19 +20404,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20421,33 +20424,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20456,11 +20459,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20470,7 +20473,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20480,7 +20483,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20490,19 +20493,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20510,23 +20513,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20537,7 +20540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20547,23 +20550,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20571,18 +20574,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20591,7 +20594,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20600,33 +20603,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20650,11 +20653,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20662,18 +20665,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20681,7 +20684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20689,7 +20692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20697,21 +20700,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21054,15 +21057,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21070,23 +21073,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21094,27 +21097,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21122,14 +21125,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21137,7 +21140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21166,23 +21169,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21190,11 +21193,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21203,7 +21206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21212,11 +21215,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21241,23 +21244,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21265,14 +21268,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21280,7 +21283,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21290,7 +21293,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21300,7 +21303,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21310,14 +21313,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21326,7 +21329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21335,89 +21338,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21426,92 +21429,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21519,7 +21522,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21527,95 +21530,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21623,7 +21626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21631,14 +21634,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21646,7 +21649,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21654,21 +21657,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -21736,19 +21739,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -21756,43 +21759,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21850,19 +21853,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -21870,14 +21873,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21964,19 +21967,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -21984,26 +21987,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22011,34 +22014,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22046,11 +22049,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22058,7 +22061,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22066,7 +22069,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22075,7 +22078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22084,23 +22087,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22109,15 +22112,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22126,7 +22129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22134,7 +22137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22142,7 +22145,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22151,7 +22154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22159,7 +22162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22167,7 +22170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22176,7 +22179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22185,7 +22188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22195,11 +22198,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22208,7 +22211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22217,7 +22220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22226,7 +22229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22235,7 +22238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22244,259 +22247,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22504,23 +22507,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22528,7 +22531,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22537,40 +22540,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22580,7 +22583,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22588,14 +22591,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22605,7 +22608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22613,14 +22616,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22630,7 +22633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22638,14 +22641,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22655,7 +22658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22665,7 +22668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22675,7 +22678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22687,7 +22690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22698,26 +22701,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22727,7 +22730,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22736,7 +22739,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -22745,7 +22748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -22753,7 +22756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22761,7 +22764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -22769,7 +22772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22930,7 +22933,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23028,7 +23031,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23039,11 +23042,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23052,7 +23055,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23061,7 +23064,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23070,7 +23073,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23079,7 +23082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23088,7 +23091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23097,7 +23100,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23106,7 +23109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23115,14 +23118,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23130,32 +23133,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23163,7 +23166,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23171,43 +23174,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23216,7 +23219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23225,31 +23228,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23259,7 +23262,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23271,7 +23274,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23285,15 +23288,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23473,74 +23476,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23565,7 +23568,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23573,7 +23576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23581,79 +23584,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23662,7 +23665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23672,7 +23675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23680,7 +23683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23688,7 +23691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23696,7 +23699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23704,7 +23707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25148,15 +25151,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25164,26 +25167,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25191,26 +25194,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25218,26 +25221,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25245,26 +25248,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25272,26 +25275,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25299,26 +25302,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25326,26 +25329,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25353,26 +25356,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25380,26 +25383,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25407,26 +25410,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25434,26 +25437,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25461,33 +25464,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25495,26 +25498,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25522,77 +25525,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25602,19 +25605,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25623,14 +25626,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25638,7 +25641,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25648,43 +25651,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25851,15 +25854,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25867,26 +25870,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25894,26 +25897,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25921,26 +25924,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25948,26 +25951,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25975,41 +25978,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26017,7 +26020,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26026,26 +26029,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26053,14 +26056,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26068,7 +26071,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26076,15 +26079,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26092,7 +26095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26100,48 +26103,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26152,23 +26155,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26178,7 +26181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26186,7 +26189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26198,7 +26201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26207,7 +26210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26216,7 +26219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26225,7 +26228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26234,7 +26237,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26242,7 +26245,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26252,18 +26255,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26273,14 +26276,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26292,7 +26295,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26303,36 +26306,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26340,7 +26343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26348,7 +26351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26356,21 +26359,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26378,11 +26381,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26397,14 +26400,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26414,7 +26417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26424,7 +26427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26434,7 +26437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26446,7 +26449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26457,7 +26460,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26471,7 +26474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26480,7 +26483,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26489,7 +26492,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26499,7 +26502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26509,7 +26512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26520,7 +26523,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26534,7 +26537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26543,7 +26546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26552,7 +26555,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26561,15 +26564,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26578,7 +26581,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26587,15 +26590,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26604,7 +26607,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26613,23 +26616,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26638,7 +26641,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26647,15 +26650,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26664,7 +26667,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26673,15 +26676,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26690,7 +26693,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26699,15 +26702,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26716,7 +26719,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26725,21 +26728,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26748,7 +26751,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26757,7 +26760,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -26769,7 +26772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -26781,7 +26784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26790,7 +26793,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26799,15 +26802,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26816,7 +26819,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26825,15 +26828,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26842,7 +26845,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26851,7 +26854,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -26863,7 +26866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -26875,7 +26878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26884,7 +26887,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26893,15 +26896,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26910,7 +26913,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26919,15 +26922,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26936,7 +26939,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26945,7 +26948,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -26957,7 +26960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -26969,7 +26972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26978,7 +26981,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26987,15 +26990,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27004,7 +27007,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27013,15 +27016,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27030,7 +27033,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27039,7 +27042,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27051,7 +27054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27063,7 +27066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27072,7 +27075,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27081,15 +27084,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27101,7 +27104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27113,7 +27116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27125,7 +27128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27137,7 +27140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27146,7 +27149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27158,7 +27161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27170,7 +27173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27182,7 +27185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27191,7 +27194,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27203,15 +27206,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27220,14 +27223,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27239,7 +27242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27252,7 +27255,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27266,7 +27269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27274,7 +27277,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27282,7 +27285,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27291,11 +27294,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27303,27 +27306,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27333,7 +27336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27341,7 +27344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27356,93 +27359,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27543,23 +27546,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27624,11 +27627,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27715,11 +27718,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -27727,50 +27730,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -27845,15 +27848,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27866,7 +27869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27881,18 +27884,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27901,14 +27904,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27917,7 +27920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27928,7 +27931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27937,7 +27940,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27949,7 +27952,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -27961,18 +27964,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -27980,14 +27983,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -27995,7 +27998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28009,7 +28012,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28022,7 +28025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28037,7 +28040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28049,15 +28052,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_keygen_deterministic"]
+    pub fn EVP_PKEY_keygen_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        out_pkey: *mut *mut EVP_PKEY,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_EVP_PKEY_encapsulate_deterministic"]
+    pub fn EVP_PKEY_encapsulate_deterministic(
+        ctx: *mut EVP_PKEY_CTX,
+        ciphertext: *mut u8,
+        ciphertext_len: *mut usize,
+        shared_secret: *mut u8,
+        shared_secret_len: *mut usize,
+        seed: *const u8,
+        seed_len: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_0_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_1_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];


### PR DESCRIPTION
### Description of changes:
* Made change to "allowlist" for headers so that `openssl/experimental/kem_deterministic_api.h` can be picked up.
* Improve logic around use of external bindgen (i.e., `bindgen-cli`).
* Bump version of aws-lc-fips-sys to v0.13.1.
* Only [first](https://github.com/aws/aws-lc-rs/pull/651/commits/4acaff19b530314f0bc533597516474acc098608) commits has manual changes.
* See automated workflow here: https://github.com/aws/aws-lc-rs/actions/runs/12671943594


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
