### PR TITLE
Fix build for Open Harmony

### DIFF
--- a/.github/docker_images/ohos-5.0.0/Dockerfile
+++ b/.github/docker_images/ohos-5.0.0/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+FROM ubuntu:24.04
+
+SHELL ["/bin/bash", "-c"]
+VOLUME ["/aws_lc_rs"]
+
+WORKDIR /
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates build-essential cmake git wget curl jq unzip clang sudo && \
+    apt-get autoremove --purge -y && \
+    apt-get clean && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+RUN mkdir /ohos && \
+    wget --progress=dot:giga https://repo.huaweicloud.com/openharmony/os/5.0.0-Release/ohos-sdk-windows_linux-public.tar.gz && \
+    wget https://repo.huaweicloud.com/openharmony/os/5.0.0-Release/ohos-sdk-windows_linux-public.tar.gz.sha256 && \
+    diff <(sha256sum ohos-sdk-windows_linux-public.tar.gz | cut -d ' ' -f 1) ohos-sdk-windows_linux-public.tar.gz.sha256 && \
+    tar zxvf ohos-sdk-windows_linux-public.tar.gz -C /ohos && \
+    cd /ohos/linux && \
+    unzip native-linux-x64-5.0.0.*-Release.zip && \
+    rm -rf /ohos/windows /ohos/linux/*.zip
+
+RUN useradd -m docker
+USER docker
+RUN cd "${HOME}" && \
+    git config --global --add safe.directory '*' && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > ./rustup.sh && \
+    chmod +x ./rustup.sh && \
+    ./rustup.sh -y && \
+    . "${HOME}/.cargo/env" && \
+    cargo install --locked bindgen-cli && \
+    rustup component add rustfmt clippy && \
+    rustup target add aarch64-unknown-linux-ohos armv7-unknown-linux-ohos x86_64-unknown-linux-ohos && \
+    rm ./rustup.sh
+
+COPY aws_lc_rs_build.sh /
+COPY entry.sh /
+
+ENV CMAKE_TOOLCHAIN_FILE=/ohos/linux/native/build/cmake/ohos.toolchain.cmake
+ENV OHOS_NDK_HOME=/ohos/linux
+ENV OHOS_SDK_NATIVE=/ohos/linux/native
+
+ENTRYPOINT ["/entry.sh"]

--- a/.github/docker_images/ohos-5.0.0/aws_lc_rs_build.sh
+++ b/.github/docker_images/ohos-5.0.0/aws_lc_rs_build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex -o pipefail
+
+. "${HOME}/.cargo/env"
+SRC_DIR="${SRC_DIR:-/aws_lc_rs}"
+
+pushd "${SRC_DIR}"
+
+declare -A target_map
+target_map[aarch64-unknown-linux-ohos]="aarch64-linux-ohos"
+target_map[armv7-unknown-linux-ohos]="arm-linux-ohos"
+target_map[x86_64-unknown-linux-ohos]="x86_64-linux-ohos"
+
+function build_ohos_targets() {
+  for target in aarch64-unknown-linux-ohos armv7-unknown-linux-ohos x86_64-unknown-linux-ohos
+  do
+    export CPATH=/ohos/linux/native/sysroot/usr/include/:/ohos/linux/native/sysroot/usr/include/${target_map[${target}]}
+    cargo build -p aws-lc-rs --target ${target}
+    cargo clean
+  done
+}
+
+cargo clean
+build_ohos_targets
+unset CMAKE_TOOLCHAIN_FILE
+build_ohos_targets
+unset OHOS_NDK_HOME
+build_ohos_targets
+
+popd # ${SRC_DIR}

--- a/.github/docker_images/ohos-5.0.0/build_image.sh
+++ b/.github/docker_images/ohos-5.0.0/build_image.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex
+
+# Ubuntu:
+# sudo apt-get install jq
+
+# Amazon Linux:
+# sudo yum install jq
+
+# Log Docker hub limit https://docs.docker.com/docker-hub/download-rate-limit/#how-can-i-check-my-current-rate
+TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
+curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
+EXTRA_ARGS=()
+if [[ -n "${GOPROXY:+x}" ]]; then
+    EXTRA_ARGS=("--build-arg" "GOPROXY=${GOPROXY}" "${EXTRA_ARGS[@]}")
+fi
+
+docker build -t ohos:5.0.0 . --load "${EXTRA_ARGS[@]}"

--- a/.github/docker_images/ohos-5.0.0/entry.sh
+++ b/.github/docker_images/ohos-5.0.0/entry.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+set -ex -o pipefail
+
+/aws_lc_rs_build.sh "${argv[@]}"

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -297,3 +297,18 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --assume-yes mingw-w64
       - name: Run cargo test
         run: cargo build -p aws-lc-rs --features prebuilt-nasm --target x86_64-pc-windows-gnu
+  open-harmony:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Build Docker Image
+        working-directory: .github/docker_images/ohos-5.0.0
+        run: |
+          ./build_image.sh
+      - name: Build
+        run: |
+          docker run -v "${{ github.workspace }}:/aws_lc_rs" ohos:5.0.0

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -14,9 +14,9 @@ mod x86_64_unknown_linux_gnu;
 mod x86_64_unknown_linux_musl;
 
 use crate::{
-    cargo_env, emit_warning, env_var_to_bool, execute_command, get_cflags, is_no_asm, option_env,
-    out_dir, requested_c_std, target, target_arch, target_env, target_os, target_vendor,
-    CStdRequested, OutputLibType,
+    cargo_env, emit_warning, env_var_to_bool, execute_command, get_crate_cflags, is_no_asm,
+    option_env, out_dir, requested_c_std, target, target_arch, target_env, target_os,
+    target_vendor, CStdRequested, OutputLibType,
 };
 use std::path::PathBuf;
 
@@ -180,8 +180,8 @@ impl CcBuilder {
             }
         }
 
-        if !get_cflags().is_empty() {
-            let cflags = get_cflags();
+        if !get_crate_cflags().is_empty() {
+            let cflags = get_crate_cflags();
             emit_warning(&format!(
                 "AWS_LC_SYS_CFLAGS found. Setting CFLAGS: '{cflags}'"
             ));

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -486,7 +486,7 @@ fn is_no_asm() -> bool {
 
 #[allow(unknown_lints)]
 #[allow(static_mut_refs)]
-fn get_cflags() -> &'static str {
+fn get_crate_cflags() -> &'static str {
     unsafe { AWS_LC_SYS_CFLAGS.as_str() }
 }
 


### PR DESCRIPTION
### Issues:
Addresses #648 

### Description of changes: 
* Only collect cflags from `cc` when a cmake toolchain is not provided.
* Add a few necessary tweaks when using the Open Harmony CMake toolchain.

### Testing:
* Added Docker Image that installs the OpenHarmony SDK.
* Added CI job that tests building for targets `aarch64-unknown-linux-ohos`, `armv7-unknown-linux-ohos`, and `x86_64-unknown-linux-ohos`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
