### PR TITLE
Improve Ed25519 doctest; improve rand test

### DIFF
--- a/aws-lc-rs/src/rand.rs
+++ b/aws-lc-rs/src/rand.rs
@@ -172,7 +172,8 @@ mod tests {
 
     #[test]
     fn test_secure_random_fill() {
-        let mut random_array = [0u8; 173];
+        // Collect enough random values so that the assertions below should never fail again
+        let mut random_array = [0u8; 1009];
         let rng = SystemRandom::new();
         rng.fill(&mut random_array).unwrap();
 
@@ -184,7 +185,8 @@ mod tests {
 
     #[test]
     fn test_rand_fill() {
-        let mut random_array: [u8; 173] = [0u8; 173];
+        // Collect enough random values so that the assertions below should never fail again
+        let mut random_array = [0u8; 1009];
         rand::fill(&mut random_array).unwrap();
 
         let (mean, variance) = mean_variance(&mut random_array.into_iter());
@@ -197,7 +199,8 @@ mod tests {
     fn test_randomly_constructable() {
         let rando = SystemRandom::new();
         let random_array = generate(&rando).unwrap();
-        let random_array: [u8; 173] = random_array.expose();
+        // Collect enough random values so that the assertions below should never fail again
+        let random_array: [u8; 1009] = random_array.expose();
         let (mean, variance) = mean_variance(&mut random_array.into_iter());
         assert!((106f64..150f64).contains(&mean), "Mean: {mean}");
         assert!(variance > 8f64);

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -124,14 +124,8 @@
 //! };
 //!
 //! fn main() -> Result<(), aws_lc_rs::error::Unspecified> {
-//!     // Generate a key pair in PKCS#8 (v1) format.
-//!     let rng = rand::SystemRandom::new();
-//!     let pkcs8_bytes = signature::Ed25519KeyPair::generate_pkcs8v1(&rng)?;
-//!
-//!     // Normally the application would store the PKCS#8 file persistently. Later
-//!     // it would read the PKCS#8 file from persistent storage to use it.
-//!
-//!     let key_pair = signature::Ed25519KeyPair::from_pkcs8_maybe_unchecked(pkcs8_bytes.as_ref())?;
+//!     // Generate a new key pair for Ed25519.
+//!     let key_pair = signature::Ed25519KeyPair::generate()?;
 //!
 //!     // Sign the message "hello, world".
 //!     const MESSAGE: &[u8] = b"hello, world";


### PR DESCRIPTION
### Description of changes: 
* Update Ed25519 doc-test to use the "generate()` function for key generation instead of `generate_pkcs8v1()`.
* Increase the number of "random" values collected so that mean and variance should always remain within the asserted bounds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
