### PR TITLE
Implement `from_seed_unchecked` for `Ed25519KeyPair`

### DIFF
--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -360,7 +360,13 @@ impl Ed25519KeyPair {
 
     /// Constructs an Ed25519 key pair from the private key seed `seed`.
     ///
-    /// It is recommended to use `Ed25519KeyPair::from_pkcs8()` instead.
+    /// It is recommended to use `Ed25519KeyPair::from_pkcs8()` instead. If the public key is
+    /// available, prefer to use `Ed25519KeyPair::from_seed_and_public_key()` as it will verify
+    /// the validity of the key pair.
+    ///
+    /// CAUTION: Both an Ed25519 seed and its public key are 32-bytes. If the bytes of a public key
+    /// are provided this function will create an (effectively) invalid `Ed25519KeyPair`. This
+    /// problem is undetectable by the API.
     ///
     /// # Errors
     /// `error::KeyRejected` if parse error, or if key is otherwise unacceptable.

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -351,6 +351,20 @@ impl Ed25519KeyPair {
     /// # Errors
     /// `error::KeyRejected` if parse error, or if key is otherwise unacceptable.
     pub fn from_seed_and_public_key(seed: &[u8], public_key: &[u8]) -> Result<Self, KeyRejected> {
+        let this = Self::from_seed_unchecked(seed)?;
+
+        constant_time::verify_slices_are_equal(public_key, &this.public_key.public_key_bytes)
+            .map_err(|_| KeyRejected::inconsistent_components())?;
+        Ok(this)
+    }
+
+    /// Constructs an Ed25519 key pair from the private key seed `seed`.
+    ///
+    /// It is recommended to use `Ed25519KeyPair::from_pkcs8()` instead.
+    ///
+    /// # Errors
+    /// `error::KeyRejected` if parse error, or if key is otherwise unacceptable.
+    pub fn from_seed_unchecked(seed: &[u8]) -> Result<Self, KeyRejected> {
         if seed.len() < ED25519_SEED_LEN {
             return Err(KeyRejected::inconsistent_components());
         }
@@ -371,9 +385,6 @@ impl Ed25519KeyPair {
             return Err(KeyRejected::unspecified());
         }
         debug_assert_eq!(derived_public_key.len(), out_len);
-
-        constant_time::verify_slices_are_equal(public_key, &derived_public_key)
-            .map_err(|_| KeyRejected::inconsistent_components())?;
 
         Ok(Self {
             public_key: PublicKey {

--- a/aws-lc-rs/tests/ed25519_tests.rs
+++ b/aws-lc-rs/tests/ed25519_tests.rs
@@ -34,6 +34,10 @@ fn test_signature_ed25519() {
 
             let expected_sig = test_case.consume_bytes("SIG");
 
+            let key_pair = Ed25519KeyPair::from_seed_unchecked(&seed).unwrap();
+            let actual_sig = key_pair.sign(&msg);
+            assert_eq!(&expected_sig[..], actual_sig.as_ref());
+
             let key_pair = Ed25519KeyPair::from_seed_and_public_key(&seed, &public_key).unwrap();
             let actual_sig = key_pair.sign(&msg);
             assert_eq!(&expected_sig[..], actual_sig.as_ref());

--- a/aws-lc-rs/tests/ed25519_tests.rs
+++ b/aws-lc-rs/tests/ed25519_tests.rs
@@ -103,6 +103,12 @@ fn test_ed25519_from_seed_and_public_key_misuse() {
 
     // Swapped public and private key.
     assert!(Ed25519KeyPair::from_seed_and_public_key(PUBLIC_KEY, PRIVATE_KEY).is_err());
+
+    // From a private seed
+    assert!(Ed25519KeyPair::from_seed_unchecked(PRIVATE_KEY).is_ok());
+
+    // From a truncated private seed
+    assert!(Ed25519KeyPair::from_seed_unchecked(PRIVATE_KEY).is_ok());
 }
 
 #[test]
@@ -236,4 +242,9 @@ fn test_seed() {
     let key_pair_copy_doc = key_pair_copy.to_pkcs8().unwrap();
 
     assert_eq!(key_pair_doc.as_ref(), key_pair_copy_doc.as_ref());
+
+    let key_pair_seed_copy = Ed25519KeyPair::from_seed_unchecked(seed_buffer.as_ref()).unwrap();
+    let key_pair_seed_copy_doc = key_pair_seed_copy.to_pkcs8().unwrap();
+
+    assert_eq!(key_pair_doc.as_ref(), key_pair_seed_copy_doc.as_ref());
 }


### PR DESCRIPTION
### Issues:
Resolves #662

### Description of changes: 

`Ed25519KeyPair` currently cannot be constructed from a raw private key seed. This copies the `ring` `from_seed_unchecked` API which makes it possible to do so.

### Call-outs:

I've moved most of the `from_seed_and_public_key` implementation to `from_seed_unchecked` and had `from_seed_and_public_key` call it. I'm not sure if it's ok for `from_seed_and_public_key` to do more work before rejecting the seed, in case the provided public key doesn't match the one derived from the seed.

### Testing:

I've added a test for the new function together with the pre-existing test for `from_seed_and_public_key`. I've also tested my application and confirmed the `from_seed_unchecked` API works the same as the `from_seed_unchecked` unchecked function from `ring`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
