### PR TITLE
Prepare v1.12.2

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.12.1"
+version = "1.12.2"
 # this crate re-exports whatever sys crate that was selected
 links = "aws_lc_rs_1_12_1_sys"
 edition = "2021"
@@ -48,7 +48,7 @@ fips = ["dep:aws-lc-fips-sys"]
 [dependencies]
 untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.25.0", path = "../aws-lc-sys", optional = true }
-aws-lc-fips-sys = { version = "0.13.0", path = "../aws-lc-fips-sys", optional = true }
+aws-lc-fips-sys = { version = "0.13.1", path = "../aws-lc-fips-sys", optional = true }
 zeroize = "1.7"
 paste = "1.0.11"
 


### PR DESCRIPTION
### Description of changes: 
* Prepare `v1.12.2`.
* We need to bump the `aws-lc-fips-sys` dependency to `v0.13.1` b/c we use a newly added function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
