### PR TITLE
Fix RustRover insight

### DIFF
--- a/aws-lc-rs/src/aead/aead_ctx.rs
+++ b/aws-lc-rs/src/aead/aead_ctx.rs
@@ -6,10 +6,7 @@ use core::ptr::null_mut;
 
 use crate::cipher::chacha;
 
-use crate::cipher::aes::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
-use crate::error::Unspecified;
-use crate::ptr::LcPtr;
-use aws_lc::{
+use crate::aws_lc::{
     evp_aead_direction_t, evp_aead_direction_t_evp_aead_open, evp_aead_direction_t_evp_aead_seal,
     EVP_AEAD_CTX_init, EVP_AEAD_CTX_init_with_direction, EVP_AEAD_CTX_zero, EVP_aead_aes_128_gcm,
     EVP_aead_aes_128_gcm_randnonce, EVP_aead_aes_128_gcm_siv, EVP_aead_aes_128_gcm_tls12,
@@ -17,6 +14,9 @@ use aws_lc::{
     EVP_aead_aes_256_gcm_randnonce, EVP_aead_aes_256_gcm_siv, EVP_aead_aes_256_gcm_tls12,
     EVP_aead_aes_256_gcm_tls13, EVP_aead_chacha20_poly1305, OPENSSL_malloc, EVP_AEAD_CTX,
 };
+use crate::cipher::aes::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
+use crate::error::Unspecified;
+use crate::ptr::LcPtr;
 
 pub(crate) enum AeadDirection {
     Open,

--- a/aws-lc-rs/src/aead/poly1305.rs
+++ b/aws-lc-rs/src/aead/poly1305.rs
@@ -6,8 +6,8 @@
 // TODO: enforce maximum input length.
 
 use super::{Tag, TAG_LEN};
+use crate::aws_lc::{CRYPTO_poly1305_finish, CRYPTO_poly1305_init, CRYPTO_poly1305_update};
 use crate::cipher::block::BLOCK_LEN;
-use aws_lc::{CRYPTO_poly1305_finish, CRYPTO_poly1305_init, CRYPTO_poly1305_update};
 use core::mem::MaybeUninit;
 
 /// A Poly1305 key.

--- a/aws-lc-rs/src/aead/unbound_key.rs
+++ b/aws-lc-rs/src/aead/unbound_key.rs
@@ -5,11 +5,11 @@ use super::{aead_ctx::AeadCtx, Algorithm, Nonce, MAX_KEY_LEN, MAX_TAG_LEN, NONCE
 use super::{
     Tag, AES_128_GCM, AES_128_GCM_SIV, AES_192_GCM, AES_256_GCM, AES_256_GCM_SIV, CHACHA20_POLY1305,
 };
-use crate::iv::FixedLength;
-use crate::{error::Unspecified, fips::indicator_check, hkdf};
-use aws_lc::{
+use crate::aws_lc::{
     EVP_AEAD_CTX_open, EVP_AEAD_CTX_open_gather, EVP_AEAD_CTX_seal, EVP_AEAD_CTX_seal_scatter,
 };
+use crate::iv::FixedLength;
+use crate::{error::Unspecified, fips::indicator_check, hkdf};
 use core::fmt::Debug;
 use core::{mem::MaybeUninit, ops::RangeFrom, ptr::null};
 

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -53,13 +53,7 @@ mod ephemeral;
 
 pub use ephemeral::{agree_ephemeral, EphemeralPrivateKey};
 
-use crate::cbb::LcCBB;
-use crate::ec::{ec_group_from_nid, evp_key_generate};
-use crate::error::{KeyRejected, Unspecified};
-use crate::fips::indicator_check;
-use crate::ptr::{ConstPointer, LcPtr};
-use crate::{ec, hex};
-use aws_lc::{
+use crate::aws_lc::{
     CBS_init, EVP_PKEY_CTX_new_id, EVP_PKEY_bits, EVP_PKEY_derive, EVP_PKEY_derive_init,
     EVP_PKEY_derive_set_peer, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get_raw_private_key,
     EVP_PKEY_get_raw_public_key, EVP_PKEY_id, EVP_PKEY_keygen, EVP_PKEY_keygen_init,
@@ -67,6 +61,12 @@ use aws_lc::{
     EVP_parse_public_key, NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1, BIGNUM, CBS,
     EVP_PKEY, EVP_PKEY_X25519, NID_X25519,
 };
+use crate::cbb::LcCBB;
+use crate::ec::{ec_group_from_nid, evp_key_generate};
+use crate::error::{KeyRejected, Unspecified};
+use crate::fips::indicator_check;
+use crate::ptr::{ConstPointer, LcPtr};
+use crate::{ec, hex};
 
 use crate::encoding::{
     AsBigEndian, AsDer, Curve25519SeedBin, EcPrivateKeyBin, EcPrivateKeyRfc5915Der,

--- a/aws-lc-rs/src/bn.rs
+++ b/aws-lc-rs/src/bn.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::{BN_bin2bn, BN_bn2bin, BN_new, BN_num_bits, BN_num_bytes, BN_set_u64, BIGNUM};
 use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
-use aws_lc::{BN_bin2bn, BN_bn2bin, BN_new, BN_num_bits, BN_num_bytes, BN_set_u64, BIGNUM};
 use core::ptr::null_mut;
 
 impl TryFrom<&[u8]> for LcPtr<BIGNUM> {

--- a/aws-lc-rs/src/cbb.rs
+++ b/aws-lc-rs/src/cbb.rs
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::{CBB_cleanup, CBB_finish, CBB_init, CBB_init_fixed, CBB};
 use crate::buffer::Buffer;
 use crate::error::Unspecified;
 use crate::ptr::LcPtr;
-use aws_lc::{CBB_cleanup, CBB_finish, CBB_init, CBB_init_fixed, CBB};
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
@@ -76,7 +76,7 @@ impl Drop for LcCBB<'_> {
 #[cfg(test)]
 mod tests {
     use super::LcCBB;
-    use aws_lc::CBB_add_asn1_bool;
+    use crate::aws_lc::CBB_add_asn1_bool;
 
     #[test]
     fn dynamic_buffer() {

--- a/aws-lc-rs/src/cbs.rs
+++ b/aws-lc-rs/src/cbs.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use aws_lc::{CBS_init, CBS};
+use crate::aws_lc::{CBS_init, CBS};
 use core::mem::MaybeUninit;
 
 #[inline]

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -228,17 +228,17 @@ mod streaming;
 pub use padded::{PaddedBlockDecryptingKey, PaddedBlockEncryptingKey};
 pub use streaming::{BufferUpdate, StreamingDecryptingKey, StreamingEncryptingKey};
 
+use crate::aws_lc::{
+    EVP_aes_128_cbc, EVP_aes_128_cfb128, EVP_aes_128_ctr, EVP_aes_128_ecb, EVP_aes_192_cbc,
+    EVP_aes_192_cfb128, EVP_aes_192_ctr, EVP_aes_192_ecb, EVP_aes_256_cbc, EVP_aes_256_cfb128,
+    EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
+};
 use crate::buffer::Buffer;
 use crate::error::Unspecified;
 use crate::hkdf;
 use crate::hkdf::KeyType;
 use crate::iv::{FixedLength, IV_LEN_128_BIT};
 use crate::ptr::ConstPointer;
-use aws_lc::{
-    EVP_aes_128_cbc, EVP_aes_128_cfb128, EVP_aes_128_ctr, EVP_aes_128_ecb, EVP_aes_192_cbc,
-    EVP_aes_192_cfb128, EVP_aes_192_ctr, EVP_aes_192_ecb, EVP_aes_256_cbc, EVP_aes_256_cfb128,
-    EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
-};
 use core::fmt::Debug;
 use key::SymmetricCipherKey;
 

--- a/aws-lc-rs/src/cipher/aes.rs
+++ b/aws-lc-rs/src/cipher/aes.rs
@@ -3,11 +3,11 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::{cipher::block::Block, error::Unspecified, fips::indicator_check};
-use aws_lc::{
+use crate::aws_lc::{
     AES_cbc_encrypt, AES_cfb128_encrypt, AES_ctr128_encrypt, AES_ecb_encrypt, AES_DECRYPT,
     AES_ENCRYPT, AES_KEY,
 };
+use crate::{cipher::block::Block, error::Unspecified, fips::indicator_check};
 use zeroize::Zeroize;
 
 use super::{DecryptionContext, EncryptionContext, OperatingMode, SymmetricCipherKey};

--- a/aws-lc-rs/src/cipher/chacha.rs
+++ b/aws-lc-rs/src/cipher/chacha.rs
@@ -4,8 +4,8 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::CRYPTO_chacha_20;
 use crate::cipher::block::{Block, BLOCK_LEN};
-use aws_lc::CRYPTO_chacha_20;
 use zeroize::Zeroize;
 
 use crate::error;

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
 use crate::error::Unspecified;
-use aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
 use core::mem::{size_of, MaybeUninit};
 use core::ptr::copy_nonoverlapping;
 // TODO: Uncomment when MSRV >= 1.64

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -1,17 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::{
+    EVP_CIPHER_CTX_new, EVP_CIPHER_iv_length, EVP_CIPHER_key_length, EVP_DecryptFinal_ex,
+    EVP_DecryptInit_ex, EVP_DecryptUpdate, EVP_EncryptFinal_ex, EVP_EncryptInit_ex,
+    EVP_EncryptUpdate, EVP_CIPHER, EVP_CIPHER_CTX,
+};
 use crate::cipher::{
     Algorithm, DecryptionContext, EncryptionContext, OperatingMode, UnboundCipherKey,
 };
 use crate::error::Unspecified;
 use crate::fips::indicator_check;
 use crate::ptr::LcPtr;
-use aws_lc::{
-    EVP_CIPHER_CTX_new, EVP_CIPHER_iv_length, EVP_CIPHER_key_length, EVP_DecryptFinal_ex,
-    EVP_DecryptInit_ex, EVP_DecryptUpdate, EVP_EncryptFinal_ex, EVP_EncryptInit_ex,
-    EVP_EncryptUpdate, EVP_CIPHER, EVP_CIPHER_CTX,
-};
 use std::ptr::{null, null_mut};
 
 use super::ConstPointer;

--- a/aws-lc-rs/src/constant_time.rs
+++ b/aws-lc-rs/src/constant_time.rs
@@ -5,8 +5,8 @@
 
 //! Constant-time operations.
 
+use crate::aws_lc::CRYPTO_memcmp;
 use crate::error;
-use aws_lc::CRYPTO_memcmp;
 
 /// Returns `Ok(())` if `a == b` and `Err(error::Unspecified)` otherwise.
 ///

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -33,12 +33,12 @@ use crate::{debug, derive_debug_via_id};
 
 pub(crate) mod digest_ctx;
 mod sha;
-use crate::error::Unspecified;
-use crate::ptr::ConstPointer;
-use aws_lc::{
+use crate::aws_lc::{
     EVP_DigestFinal, EVP_DigestUpdate, EVP_sha1, EVP_sha224, EVP_sha256, EVP_sha384, EVP_sha3_256,
     EVP_sha3_384, EVP_sha3_512, EVP_sha512, EVP_sha512_256, EVP_MD,
 };
+use crate::error::Unspecified;
+use crate::ptr::ConstPointer;
 use core::mem::MaybeUninit;
 use digest_ctx::DigestContext;
 pub use sha::{

--- a/aws-lc-rs/src/digest/digest_ctx.rs
+++ b/aws-lc-rs/src/digest/digest_ctx.rs
@@ -1,9 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::{
+    EVP_DigestInit_ex, EVP_MD_CTX_cleanup, EVP_MD_CTX_copy, EVP_MD_CTX_init, EVP_MD_CTX,
+};
 use crate::digest::{match_digest_type, Algorithm};
 use crate::error::Unspecified;
-use aws_lc::{EVP_DigestInit_ex, EVP_MD_CTX_cleanup, EVP_MD_CTX_copy, EVP_MD_CTX_init, EVP_MD_CTX};
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -12,10 +12,10 @@ use core::ptr::null_mut;
 use std::os::raw::c_int;
 
 #[cfg(feature = "fips")]
-use aws_lc::EC_KEY_check_fips;
+use crate::aws_lc::EC_KEY_check_fips;
 #[cfg(not(feature = "fips"))]
-use aws_lc::EC_KEY_check_key;
-use aws_lc::{
+use crate::aws_lc::EC_KEY_check_key;
+use crate::aws_lc::{
     d2i_PrivateKey, point_conversion_form_t, BN_bn2bin_padded, BN_num_bytes, CBS_init,
     ECDSA_SIG_from_bytes, ECDSA_SIG_get0_r, ECDSA_SIG_get0_s, EC_GROUP_get_curve_name,
     EC_GROUP_new_by_curve_name, EC_KEY_get0_group, EC_KEY_get0_private_key, EC_KEY_get0_public_key,

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -8,7 +8,7 @@ use core::fmt::{Debug, Formatter};
 use core::mem::MaybeUninit;
 use core::ptr::{null, null_mut};
 
-use aws_lc::{EVP_DigestSign, EVP_DigestSignInit, EVP_PKEY_get0_EC_KEY, EVP_PKEY};
+use crate::aws_lc::{EVP_DigestSign, EVP_DigestSignInit, EVP_PKEY_get0_EC_KEY, EVP_PKEY};
 
 use crate::digest::digest_ctx::DigestContext;
 use crate::ec::evp_key_generate;

--- a/aws-lc-rs/src/ec/signature.rs
+++ b/aws-lc-rs/src/ec/signature.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use aws_lc::{
+use crate::aws_lc::{
     i2d_EC_PUBKEY, ECDSA_SIG_new, ECDSA_SIG_set0, ECDSA_SIG_to_bytes, EC_GROUP_new_by_curve_name,
     EC_KEY_new, EC_KEY_set_group, EC_KEY_set_public_key, EVP_DigestVerify, EVP_DigestVerifyInit,
     EVP_PKEY_get0_EC_KEY, NID_X9_62_prime256v1, NID_secp256k1, NID_secp384r1, NID_secp521r1,

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -12,7 +12,7 @@ use std::marker::PhantomData;
 #[cfg(feature = "ring-sig-verify")]
 use untrusted::Input;
 
-use aws_lc::{
+use crate::aws_lc::{
     CBS_init, EVP_DigestSign, EVP_DigestSignInit, EVP_DigestVerify, EVP_DigestVerifyInit,
     EVP_PKEY_CTX_new_id, EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_id,
     EVP_PKEY_keygen, EVP_PKEY_keygen_init, EVP_PKEY_new_raw_private_key,

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -1,17 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use crate::aws_lc::{
+    EVP_PKEY_CTX_new, EVP_PKEY_bits, EVP_PKEY_get1_EC_KEY, EVP_PKEY_get1_RSA, EVP_PKEY_id,
+    EVP_PKEY_up_ref, EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_parse_private_key,
+    EC_KEY, EVP_PKEY, EVP_PKEY_CTX, RSA,
+};
 use crate::cbb::LcCBB;
 use crate::cbs;
 use crate::ec::PKCS8_DOCUMENT_MAX_LEN;
 use crate::error::{KeyRejected, Unspecified};
 use crate::pkcs8::Version;
 use crate::ptr::LcPtr;
-use aws_lc::{
-    EVP_PKEY_CTX_new, EVP_PKEY_bits, EVP_PKEY_get1_EC_KEY, EVP_PKEY_get1_RSA, EVP_PKEY_id,
-    EVP_PKEY_up_ref, EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_parse_private_key,
-    EC_KEY, EVP_PKEY, EVP_PKEY_CTX, RSA,
-};
 // TODO: Uncomment when MSRV >= 1.64
 // use core::ffi::c_int;
 use std::os::raw::c_int;

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -37,11 +37,11 @@
 //! let aead_unbound_key = aead::UnboundKey::from(aes_keying_material);
 //! ```
 
+use crate::aws_lc::{HKDF_expand, HKDF};
 use crate::error::Unspecified;
 use crate::fips::indicator_check;
 use crate::{digest, hmac};
 use alloc::sync::Arc;
-use aws_lc::{HKDF_expand, HKDF};
 use core::fmt;
 use zeroize::Zeroize;
 

--- a/aws-lc-rs/src/hmac.rs
+++ b/aws-lc-rs/src/hmac.rs
@@ -95,13 +95,13 @@
 //! ```
 //! [RFC 2104]: https://tools.ietf.org/html/rfc2104
 
-use crate::error::Unspecified;
-use crate::fips::indicator_check;
-use crate::{constant_time, digest, hkdf};
-use aws_lc::{
+use crate::aws_lc::{
     HMAC_CTX_cleanup, HMAC_CTX_copy_ex, HMAC_CTX_init, HMAC_Final, HMAC_Init_ex, HMAC_Update,
     HMAC_CTX,
 };
+use crate::error::Unspecified;
+use crate::fips::indicator_check;
+use crate::{constant_time, digest, hkdf};
 use core::mem::MaybeUninit;
 use core::ptr::null_mut;
 // TODO: Uncomment when MSRV >= 1.64

--- a/aws-lc-rs/src/kdf/kbkdf.rs
+++ b/aws-lc-rs/src/kdf/kbkdf.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use aws_lc::KBKDF_ctr_hmac;
-use aws_lc::EVP_MD;
+use crate::aws_lc::KBKDF_ctr_hmac;
+use crate::aws_lc::EVP_MD;
 
 use crate::{
     digest::{match_digest_type, AlgorithmID},

--- a/aws-lc-rs/src/kdf/sskdf.rs
+++ b/aws-lc-rs/src/kdf/sskdf.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use aws_lc::EVP_MD;
-use aws_lc::{SSKDF_digest, SSKDF_hmac};
+use crate::aws_lc::EVP_MD;
+use crate::aws_lc::{SSKDF_digest, SSKDF_hmac};
 
 use crate::{
     digest::{match_digest_type, AlgorithmID},

--- a/aws-lc-rs/src/kem.rs
+++ b/aws-lc-rs/src/kem.rs
@@ -45,6 +45,11 @@
 //!
 //! # Ok::<(), aws_lc_rs::error::Unspecified>(())
 //! ```
+use crate::aws_lc::{
+    EVP_PKEY_CTX_kem_set_params, EVP_PKEY_CTX_new_id, EVP_PKEY_decapsulate, EVP_PKEY_encapsulate,
+    EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_kem_new_raw_public_key,
+    EVP_PKEY_keygen, EVP_PKEY_keygen_init, EVP_PKEY, EVP_PKEY_KEM,
+};
 use crate::{
     buffer::Buffer,
     encoding::generated_encodings,
@@ -52,11 +57,6 @@ use crate::{
     ptr::LcPtr,
 };
 use alloc::borrow::Cow;
-use aws_lc::{
-    EVP_PKEY_CTX_kem_set_params, EVP_PKEY_CTX_new_id, EVP_PKEY_decapsulate, EVP_PKEY_encapsulate,
-    EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_kem_new_raw_public_key,
-    EVP_PKEY_keygen, EVP_PKEY_keygen_init, EVP_PKEY, EVP_PKEY_KEM,
-};
 use core::{cmp::Ordering, ptr::null_mut};
 use zeroize::Zeroize;
 
@@ -102,7 +102,7 @@ pub const ML_KEM_1024: Algorithm<AlgorithmId> = Algorithm {
     shared_secret_size: ML_KEM_1024_SHARED_SECRET_LENGTH,
 };
 
-use aws_lc::{NID_MLKEM1024, NID_MLKEM512, NID_MLKEM768};
+use crate::aws_lc::{NID_MLKEM1024, NID_MLKEM512, NID_MLKEM768};
 
 /// An identifier for a KEM algorithm.
 pub trait AlgorithmIdentifier:

--- a/aws-lc-rs/src/key_wrap.rs
+++ b/aws-lc-rs/src/key_wrap.rs
@@ -32,11 +32,11 @@
 //! # }
 //! ```
 
-use crate::{error::Unspecified, fips::indicator_check, sealed::Sealed};
-use aws_lc::{
+use crate::aws_lc::{
     AES_set_decrypt_key, AES_set_encrypt_key, AES_unwrap_key, AES_unwrap_key_padded, AES_wrap_key,
     AES_wrap_key_padded, AES_KEY,
 };
+use crate::{error::Unspecified, fips::indicator_check, sealed::Sealed};
 use core::{fmt::Debug, mem::MaybeUninit, ptr::null};
 
 mod tests;

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -205,7 +205,7 @@ pub(crate) use debug::derive_debug_via_id;
 // use core::ffi::CStr;
 use std::ffi::CStr;
 
-use aws_lc::{
+use crate::aws_lc::{
     CRYPTO_library_init, ERR_error_string, ERR_get_error, FIPS_mode, ERR_GET_FUNC, ERR_GET_LIB,
     ERR_GET_REASON,
 };

--- a/aws-lc-rs/src/pbkdf2.rs
+++ b/aws-lc-rs/src/pbkdf2.rs
@@ -103,10 +103,10 @@
 //!     assert!(db.verify_password("alice", "@74d7]404j|W}6u").is_ok());
 //! }
 
+use crate::aws_lc::PKCS5_PBKDF2_HMAC;
 use crate::error::Unspecified;
 use crate::fips::indicator_check;
 use crate::{constant_time, digest, hmac};
-use aws_lc::PKCS5_PBKDF2_HMAC;
 use core::num::NonZeroU32;
 use zeroize::Zeroize;
 

--- a/aws-lc-rs/src/ptr.rs
+++ b/aws-lc-rs/src/ptr.rs
@@ -3,7 +3,7 @@
 
 use core::ops::Deref;
 
-use aws_lc::{
+use crate::aws_lc::{
     BN_free, ECDSA_SIG_free, EC_GROUP_free, EC_KEY_free, EC_POINT_free, EVP_AEAD_CTX_free,
     EVP_CIPHER_CTX_free, EVP_PKEY_CTX_free, EVP_PKEY_free, OPENSSL_free, RSA_free, BIGNUM,
     ECDSA_SIG, EC_GROUP, EC_KEY, EC_POINT, EVP_AEAD_CTX, EVP_CIPHER_CTX, EVP_PKEY, EVP_PKEY_CTX,
@@ -245,8 +245,8 @@ create_pointer!(EVP_CIPHER_CTX, EVP_CIPHER_CTX_free);
 
 #[cfg(test)]
 mod tests {
+    use crate::aws_lc::BIGNUM;
     use crate::ptr::{DetachablePointer, ManagedPointer};
-    use aws_lc::BIGNUM;
 
     #[test]
     fn test_debug() {

--- a/aws-lc-rs/src/rand.rs
+++ b/aws-lc-rs/src/rand.rs
@@ -32,9 +32,9 @@
 //! let random_array = rand::generate(&rng).unwrap();
 //! let more_rand_bytes: [u8; 64] = random_array.expose();
 //! ```
+use crate::aws_lc::RAND_bytes;
 use crate::error::Unspecified;
 use crate::fips::indicator_check;
-use aws_lc::RAND_bytes;
 use core::fmt::Debug;
 
 /// A secure random number generator.

--- a/aws-lc-rs/src/rsa/encoding.rs
+++ b/aws-lc-rs/src/rsa/encoding.rs
@@ -3,6 +3,7 @@
 
 /// PKCS#8 Encoding Functions
 pub(in crate::rsa) mod pkcs8 {
+    use crate::aws_lc::{EVP_marshal_private_key, EVP_parse_private_key, EVP_PKEY};
     use crate::{
         cbb::LcCBB,
         cbs,
@@ -10,7 +11,6 @@ pub(in crate::rsa) mod pkcs8 {
         ptr::LcPtr,
         rsa::key::is_rsa_key,
     };
-    use aws_lc::{EVP_marshal_private_key, EVP_parse_private_key, EVP_PKEY};
 
     // Based on a measurement of a PKCS#8 v1 document containing an RSA-8192 key with an additional 1% capacity buffer
     // rounded to an even 64-bit words (4678 + 1% + padding ≈ 4728).
@@ -49,14 +49,14 @@ pub(in crate::rsa) mod pkcs8 {
 ///
 /// PKCS #1: RSA Cryptography Specifications Version 2.2
 pub(in crate::rsa) mod rfc8017 {
+    use crate::aws_lc::{
+        EVP_PKEY_assign_RSA, EVP_PKEY_new, RSA_parse_private_key, RSA_public_key_from_bytes,
+        RSA_public_key_to_bytes, EVP_PKEY,
+    };
     use crate::{
         cbs,
         error::{KeyRejected, Unspecified},
         ptr::{DetachableLcPtr, LcPtr},
-    };
-    use aws_lc::{
-        EVP_PKEY_assign_RSA, EVP_PKEY_new, RSA_parse_private_key, RSA_public_key_from_bytes,
-        RSA_public_key_to_bytes, EVP_PKEY,
     };
     use std::ptr::null_mut;
 
@@ -126,6 +126,7 @@ pub(in crate::rsa) mod rfc8017 {
 ///
 /// Encodings that use the `SubjectPublicKeyInfo` structure.
 pub(in crate::rsa) mod rfc5280 {
+    use crate::aws_lc::{EVP_marshal_public_key, EVP_parse_public_key, EVP_PKEY};
     use crate::{
         cbb::LcCBB,
         cbs,
@@ -134,7 +135,6 @@ pub(in crate::rsa) mod rfc5280 {
         ptr::LcPtr,
         rsa::key::{is_rsa_key, key_size_bytes},
     };
-    use aws_lc::{EVP_marshal_public_key, EVP_parse_public_key, EVP_PKEY};
 
     pub(in crate::rsa) fn encode_public_key_der(
         key: &LcPtr<EVP_PKEY>,

--- a/aws-lc-rs/src/rsa/encryption.rs
+++ b/aws-lc-rs/src/rsa/encryption.rs
@@ -9,12 +9,12 @@ use super::{
     key::{generate_rsa_key, is_rsa_key, key_size_bits, key_size_bytes},
     KeySize,
 };
+use crate::aws_lc::EVP_PKEY;
 use crate::{
     encoding::{AsDer, Pkcs8V1Der, PublicKeyX509Der},
     error::{KeyRejected, Unspecified},
     ptr::LcPtr,
 };
-use aws_lc::EVP_PKEY;
 use core::fmt::Debug;
 
 /// RSA Encryption Algorithm Identifier

--- a/aws-lc-rs/src/rsa/encryption/oaep.rs
+++ b/aws-lc-rs/src/rsa/encryption/oaep.rs
@@ -4,16 +4,16 @@
 #![allow(clippy::module_name_repetitions)]
 
 use super::{EncryptionAlgorithmId, PrivateDecryptingKey, PublicEncryptingKey};
-use crate::{
-    error::Unspecified,
-    fips::indicator_check,
-    ptr::{DetachableLcPtr, LcPtr},
-};
-use aws_lc::{
+use crate::aws_lc::{
     EVP_PKEY_CTX_set0_rsa_oaep_label, EVP_PKEY_CTX_set_rsa_mgf1_md, EVP_PKEY_CTX_set_rsa_oaep_md,
     EVP_PKEY_CTX_set_rsa_padding, EVP_PKEY_decrypt, EVP_PKEY_decrypt_init, EVP_PKEY_encrypt,
     EVP_PKEY_encrypt_init, EVP_sha1, EVP_sha256, EVP_sha384, EVP_sha512, OPENSSL_malloc, EVP_MD,
     EVP_PKEY_CTX, RSA_PKCS1_OAEP_PADDING,
+};
+use crate::{
+    error::Unspecified,
+    fips::indicator_check,
+    ptr::{DetachableLcPtr, LcPtr},
 };
 use core::{fmt::Debug, mem::size_of_val, ptr::null_mut};
 

--- a/aws-lc-rs/src/rsa/encryption/pkcs1.rs
+++ b/aws-lc-rs/src/rsa/encryption/pkcs1.rs
@@ -4,11 +4,11 @@
 #![allow(clippy::module_name_repetitions)]
 
 use super::{PrivateDecryptingKey, PublicEncryptingKey};
-use crate::{error::Unspecified, fips::indicator_check, ptr::LcPtr};
-use aws_lc::{
+use crate::aws_lc::{
     EVP_PKEY_CTX_set_rsa_padding, EVP_PKEY_decrypt, EVP_PKEY_decrypt_init, EVP_PKEY_encrypt,
     EVP_PKEY_encrypt_init, EVP_PKEY_CTX, RSA_PKCS1_PADDING,
 };
+use crate::{error::Unspecified, fips::indicator_check, ptr::LcPtr};
 use core::fmt::Debug;
 
 /// RSA PKCS1-v1.5 public key for encryption.

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -8,6 +8,15 @@ use super::{
     signature::{compute_rsa_signature, RsaEncoding, RsaPadding},
     RsaParameters,
 };
+#[cfg(feature = "fips")]
+use crate::aws_lc::RSA_check_fips;
+use crate::aws_lc::{
+    EVP_DigestSignInit, EVP_PKEY_assign_RSA, EVP_PKEY_bits, EVP_PKEY_new, EVP_PKEY_size,
+    RSA_generate_key_ex, RSA_generate_key_fips, RSA_new, RSA_set0_key, RSA_size, BIGNUM, EVP_PKEY,
+    EVP_PKEY_CTX,
+};
+#[cfg(feature = "ring-io")]
+use crate::aws_lc::{RSA_get0_e, RSA_get0_n};
 #[cfg(feature = "ring-io")]
 use crate::io;
 #[cfg(feature = "ring-io")]
@@ -23,15 +32,6 @@ use crate::{
     rsa::PublicEncryptingKey,
     sealed::Sealed,
 };
-#[cfg(feature = "fips")]
-use aws_lc::RSA_check_fips;
-use aws_lc::{
-    EVP_DigestSignInit, EVP_PKEY_assign_RSA, EVP_PKEY_bits, EVP_PKEY_new, EVP_PKEY_size,
-    RSA_generate_key_ex, RSA_generate_key_fips, RSA_new, RSA_set0_key, RSA_size, BIGNUM, EVP_PKEY,
-    EVP_PKEY_CTX,
-};
-#[cfg(feature = "ring-io")]
-use aws_lc::{RSA_get0_e, RSA_get0_n};
 use core::{
     fmt::{self, Debug, Formatter},
     ptr::null_mut,

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -8,7 +8,7 @@ use std::{
     ptr::{null, null_mut},
 };
 
-use aws_lc::{
+use crate::aws_lc::{
     EVP_DigestSign, EVP_DigestVerify, EVP_DigestVerifyInit, EVP_PKEY_CTX_set_rsa_padding,
     EVP_PKEY_CTX_set_rsa_pss_saltlen, EVP_PKEY_get0_RSA, RSA_bits, RSA_get0_n, EVP_PKEY,
     EVP_PKEY_CTX, RSA_PKCS1_PSS_PADDING, RSA_PSS_SALTLEN_DIGEST,

--- a/aws-lc-rs/src/tls_prf.rs
+++ b/aws-lc-rs/src/tls_prf.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use core::ptr::null;
 
-use aws_lc::CRYPTO_tls1_prf;
+use crate::aws_lc::CRYPTO_tls1_prf;
 
 /// The TLS PRF `P_hash` Algorithm
 pub struct Algorithm(AlgorithmID);


### PR DESCRIPTION
### Description of changes: 
* RustRover appears unable to understand `use aws_lc::XXX`, but is fine with `use crate::aws_lc::XXX`.
   * To correct this I used the IDE to do a find/replace across everything under `aws-lc-rs/src/`.

### Testing
* Verified the IDE no longer complains about symbols used from `aws_lc`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
