### PR TITLE
aws-lc-fips-sys: Default to clang compiler

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -93,6 +93,16 @@ impl CmakeBuilder {
     const GOCACHE_DIR_NAME: &'static str = "go-cache";
     #[allow(clippy::too_many_lines)]
     fn prepare_cmake_build(&self) -> cmake::Config {
+        // Set the compiler to clang if CC/CXX are not set
+        // TODO: this is a workaround until aws-lc fixes build on GGC-14
+        // See https://github.com/aws/aws-lc/issues/201
+        if env::var("CC").is_err() {
+            env::set_var("CC", "clang");
+        }
+        if env::var("CXX").is_err() {
+            env::set_var("CXX", "clang++");
+        }
+
         env::set_var(
             "GOCACHE",
             self.out_dir.join(Self::GOCACHE_DIR_NAME).as_os_str(),


### PR DESCRIPTION

### Issues:
Addresses #569 

### Description of changes: 
The underlying aws-lc library is broken when built with FIPS support on GCC-14, which comes by default with many Linux distributions.

When this crate is used as a sub-dependency, the users' only workaround is to force all C/C++ code on other crates to also be compiled with clang by setting the CC/CXX environment variables.

This change circumvents the issue by setting the CC/CXX environment variables in the crate build script.

This is a temporary workaround until the underlying issue is resolved: https://github.com/aws/aws-lc/issues/2010

### Testing:
 Tested the builds with and without setting CC and CXX.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
