### PR TITLE
Fix regression in EcdsaKeyPair::from_private_key_der

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -113,11 +113,11 @@ impl CmakeBuilder {
 
         if let Some(cc) = option_env!("AWS_LC_FIPS_SYS_CC") {
             env::set_var("CC", cc);
-            emit_warning(&format!("Setting CC: {}", cc));
+            emit_warning(&format!("Setting CC: {cc}"));
         }
         if let Some(cxx) = option_env!("AWS_LC_FIPS_SYS_CXX") {
             env::set_var("CXX", cxx);
-            emit_warning(&format!("Setting CXX: {}", cxx));
+            emit_warning(&format!("Setting CXX: {cxx}"));
         }
 
         let cc_build = cc::Build::new();

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -22,11 +22,7 @@ impl PartialEq<Self> for LcPtr<EVP_PKEY> {
     /// Only compares params and public key
     fn eq(&self, other: &Self) -> bool {
         // EVP_PKEY_cmp only compares params and public key
-        if 1 == unsafe { EVP_PKEY_cmp(*self.as_const(), *other.as_const()) } {
-            true
-        } else {
-            false
-        }
+        1 == unsafe { EVP_PKEY_cmp(*self.as_const(), *other.as_const()) }
     }
 }
 
@@ -107,7 +103,7 @@ impl LcPtr<EVP_PKEY> {
         let mut cbb = LcCBB::new(self.key_size_bytes() * 5);
         if 1 != unsafe { EVP_marshal_public_key(cbb.as_mut_ptr(), *self.as_const()) } {
             return Err(Unspecified);
-        };
+        }
         cbb.into_vec()
     }
 

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{
-    EVP_PKEY_CTX_new, EVP_PKEY_bits, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA,
+    EVP_PKEY_CTX_new, EVP_PKEY_bits, EVP_PKEY_cmp, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA,
     EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_id,
     EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key, EVP_PKEY_size, EVP_PKEY_up_ref,
     EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_marshal_public_key,
@@ -17,6 +17,18 @@ use crate::ptr::{ConstPointer, LcPtr};
 // use core::ffi::c_int;
 use std::os::raw::c_int;
 use std::ptr::null_mut;
+
+impl PartialEq<Self> for LcPtr<EVP_PKEY> {
+    /// Only compares params and public key
+    fn eq(&self, other: &Self) -> bool {
+        // EVP_PKEY_cmp only compares params and public key
+        if 1 == unsafe { EVP_PKEY_cmp(*self.as_const(), *other.as_const()) } {
+            true
+        } else {
+            false
+        }
+    }
+}
 
 impl LcPtr<EVP_PKEY> {
     pub(crate) fn validate_as_ed25519(&self) -> Result<(), KeyRejected> {


### PR DESCRIPTION
### Description of changes: 
* [`EcdsaKeyPair::from_private_key_der`](https://docs.rs/aws-lc-rs/latest/aws_lc_rs/signature/struct.EcdsaKeyPair.html#method.from_private_key_der) should accept either RFC 5208 or RFC 5915 encodings.

### Call-outs:
* I found this problem while investigating the [failure of our rustls integ tests](https://github.com/aws/aws-lc-rs/actions/runs/13116980204/job/36595945901?pr=678#step:6:827).

### Testing
* Added a test to prevent future regression.
* I verified that this fixes the test failure in rcgen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
