### PR TITLE
EVP_PKEY refactoring for keygen/sign/verify; Start of ML-DSA impl

### DIFF
--- a/aws-lc-rs/src/bn.rs
+++ b/aws-lc-rs/src/bn.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::aws_lc::{BN_bin2bn, BN_bn2bin, BN_new, BN_num_bits, BN_num_bytes, BN_set_u64, BIGNUM};
+use crate::aws_lc::{BN_bin2bn, BN_bn2bin, BN_new, BN_num_bytes, BN_set_u64, BIGNUM};
 use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
 use core::ptr::null_mut;
 
@@ -59,9 +59,5 @@ impl ConstPointer<BIGNUM> {
             byte_vec.set_len(out_bytes);
             byte_vec
         }
-    }
-
-    pub(crate) fn num_bits(&self) -> u32 {
-        unsafe { BN_num_bits(**self) }
     }
 }

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -6,8 +6,6 @@
 use crate::aws_lc::{EVP_DigestSign, EVP_DigestSignInit, EVP_PKEY, EVP_PKEY_EC};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
-use core::mem::MaybeUninit;
-use core::ptr::{null, null_mut};
 
 use crate::digest::digest_ctx::DigestContext;
 use crate::ec::evp_key_generate;
@@ -17,18 +15,18 @@ use crate::ec::validate_evp_key;
 #[cfg(not(feature = "fips"))]
 use crate::ec::verify_evp_key_nid;
 
+use crate::ec;
 use crate::ec::encoding::rfc5915::{marshal_rfc5915_private_key, parse_rfc5915_private_key};
 use crate::ec::encoding::sec1::{
     marshal_sec1_private_key, parse_sec1_private_bn, parse_sec1_public_point,
 };
 use crate::encoding::{AsBigEndian, AsDer, EcPrivateKeyBin, EcPrivateKeyRfc5915Der};
 use crate::error::{KeyRejected, Unspecified};
-use crate::fips::indicator_check;
+use crate::evp_pkey::No_EVP_PKEY_CTX_consumer;
 use crate::pkcs8::{Document, Version};
 use crate::ptr::LcPtr;
 use crate::rand::SecureRandom;
 use crate::signature::{KeyPair, Signature};
-use crate::{digest, ec};
 
 /// An ECDSA key pair, used for signing.
 #[allow(clippy::module_name_repetitions)]
@@ -212,80 +210,20 @@ impl EcdsaKeyPair {
     // * Digest Algorithms: SHA256, SHA384, SHA512
     #[inline]
     pub fn sign(&self, _rng: &dyn SecureRandom, message: &[u8]) -> Result<Signature, Unspecified> {
-        let mut md_ctx = DigestContext::new_uninit();
-
-        let digest = digest::match_digest_type(&self.algorithm.digest.id);
-
-        if 1 != unsafe {
-            // EVP_DigestSignInit does not mutate |pkey| for thread-safety purposes and may be
-            // used concurrently with other non-mutating functions on |pkey|.
-            // https://github.com/aws/aws-lc/blob/9b4b5a15a97618b5b826d742419ccd54c819fa42/include/openssl/evp.h#L297-L313
-            EVP_DigestSignInit(
-                md_ctx.as_mut_ptr(),
-                null_mut(),
-                *digest,
-                null_mut(),
-                *self.evp_pkey.as_mut_unsafe(),
-            )
-        } {
-            return Err(Unspecified);
-        }
-
-        let mut out_sig = vec![0u8; get_signature_length(&mut md_ctx)?];
-
-        let out_sig = compute_ecdsa_signature(&mut md_ctx, message, out_sig.as_mut_slice())?;
+        let out_sig = self.evp_pkey.sign(
+            message,
+            Some(self.algorithm.digest),
+            No_EVP_PKEY_CTX_consumer,
+        )?;
 
         Ok(match self.algorithm.sig_format {
             EcdsaSignatureFormat::ASN1 => Signature::new(|slice| {
-                slice[..out_sig.len()].copy_from_slice(out_sig);
+                slice[..out_sig.len()].copy_from_slice(&out_sig);
                 out_sig.len()
             }),
-            EcdsaSignatureFormat::Fixed => ec::ecdsa_asn1_to_fixed(self.algorithm.id, out_sig)?,
+            EcdsaSignatureFormat::Fixed => ec::ecdsa_asn1_to_fixed(self.algorithm.id, &out_sig)?,
         })
     }
-}
-
-#[inline]
-fn get_signature_length(ctx: &mut DigestContext) -> Result<usize, Unspecified> {
-    let mut out_sig_len = MaybeUninit::<usize>::uninit();
-
-    // determine signature size
-    if 1 != unsafe {
-        EVP_DigestSign(
-            ctx.as_mut_ptr(),
-            null_mut(),
-            out_sig_len.as_mut_ptr(),
-            null(),
-            0,
-        )
-    } {
-        return Err(Unspecified);
-    }
-
-    Ok(unsafe { out_sig_len.assume_init() })
-}
-
-#[inline]
-fn compute_ecdsa_signature<'a>(
-    ctx: &mut DigestContext,
-    message: &[u8],
-    signature: &'a mut [u8],
-) -> Result<&'a mut [u8], Unspecified> {
-    let mut out_sig_len = signature.len();
-
-    if 1 != indicator_check!(unsafe {
-        EVP_DigestSign(
-            ctx.as_mut_ptr(),
-            signature.as_mut_ptr(),
-            &mut out_sig_len,
-            message.as_ptr(),
-            message.len(),
-        )
-    }) {
-        return Err(Unspecified);
-    }
-
-    Ok(&mut signature[0..out_sig_len])
 }
 
 /// Elliptic curve private key.

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -3,11 +3,10 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::aws_lc::{EVP_DigestSign, EVP_DigestSignInit, EVP_PKEY, EVP_PKEY_EC};
+use crate::aws_lc::{EVP_PKEY, EVP_PKEY_EC};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 
-use crate::digest::digest_ctx::DigestContext;
 use crate::ec::evp_key_generate;
 use crate::ec::signature::{EcdsaSignatureFormat, EcdsaSigningAlgorithm, PublicKey};
 #[cfg(feature = "fips")]

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -12,16 +12,15 @@ use std::marker::PhantomData;
 use untrusted::Input;
 
 use crate::aws_lc::{
-    EVP_DigestSign, EVP_DigestSignInit, EVP_DigestVerify, EVP_DigestVerifyInit,
     EVP_PKEY_CTX_new_id, EVP_PKEY_keygen, EVP_PKEY_keygen_init, EVP_PKEY, EVP_PKEY_ED25519,
 };
 
 use crate::buffer::Buffer;
-use crate::digest::digest_ctx::DigestContext;
 use crate::encoding::{
     AsBigEndian, AsDer, Curve25519SeedBin, Pkcs8V1Der, Pkcs8V2Der, PublicKeyX509Der,
 };
 use crate::error::{KeyRejected, Unspecified};
+use crate::evp_pkey::No_EVP_PKEY_CTX_consumer;
 use crate::fips::indicator_check;
 use crate::pkcs8::{Document, Version};
 use crate::ptr::LcPtr;
@@ -30,8 +29,8 @@ use crate::signature::{KeyPair, Signature, VerificationAlgorithm};
 use crate::{constant_time, hex, sealed};
 
 /// The length of an Ed25519 public key.
-pub const ED25519_PUBLIC_KEY_LEN: usize = aws_lc::ED25519_PUBLIC_KEY_LEN as usize;
-const ED25519_SIGNATURE_LEN: usize = aws_lc::ED25519_SIGNATURE_LEN as usize;
+pub const ED25519_PUBLIC_KEY_LEN: usize = crate::aws_lc::ED25519_PUBLIC_KEY_LEN as usize;
+const ED25519_SIGNATURE_LEN: usize = crate::aws_lc::ED25519_SIGNATURE_LEN as usize;
 const ED25519_SEED_LEN: usize = 32;
 
 /// Parameters for `EdDSA` signing and verification.
@@ -49,9 +48,11 @@ impl VerificationAlgorithm for EdDSAParameters {
         msg: Input<'_>,
         signature: Input<'_>,
     ) -> Result<(), Unspecified> {
-        self.verify_sig(
-            public_key.as_slice_less_safe(),
+        let evp_pkey = try_ed25519_public_key_from_bytes(public_key.as_slice_less_safe())?;
+        evp_pkey.verify(
             msg.as_slice_less_safe(),
+            None,
+            No_EVP_PKEY_CTX_consumer,
             signature.as_slice_less_safe(),
         )
     }
@@ -62,35 +63,8 @@ impl VerificationAlgorithm for EdDSAParameters {
         msg: &[u8],
         signature: &[u8],
     ) -> Result<(), Unspecified> {
-        let public_key = try_ed25519_public_key_from_bytes(public_key)?;
-
-        let mut evp_md_ctx = DigestContext::new_uninit();
-
-        if 1 != unsafe {
-            EVP_DigestVerifyInit(
-                evp_md_ctx.as_mut_ptr(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                *public_key.as_mut_unsafe(),
-            )
-        } {
-            return Err(Unspecified);
-        }
-
-        if 1 != indicator_check!(unsafe {
-            EVP_DigestVerify(
-                evp_md_ctx.as_mut_ptr(),
-                signature.as_ptr(),
-                signature.len(),
-                msg.as_ptr(),
-                msg.len(),
-            )
-        }) {
-            return Err(Unspecified);
-        }
-
-        Ok(())
+        let evp_pkey = try_ed25519_public_key_from_bytes(public_key)?;
+        evp_pkey.verify(msg, None, No_EVP_PKEY_CTX_consumer, signature)
     }
 }
 
@@ -433,36 +407,7 @@ impl Ed25519KeyPair {
 
     #[inline]
     fn try_sign(&self, msg: &[u8]) -> Result<Signature, Unspecified> {
-        let mut sig_bytes = [0u8; ED25519_SIGNATURE_LEN];
-
-        let mut evp_md_ctx = DigestContext::new_uninit();
-
-        if 1 != unsafe {
-            EVP_DigestSignInit(
-                evp_md_ctx.as_mut_ptr(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                *self.evp_pkey.as_mut_unsafe(),
-            )
-        } {
-            return Err(Unspecified);
-        }
-
-        let mut out_sig_len = sig_bytes.len();
-        if 1 != indicator_check!(unsafe {
-            EVP_DigestSign(
-                evp_md_ctx.as_mut_ptr(),
-                sig_bytes.as_mut_ptr().cast(),
-                &mut out_sig_len,
-                msg.as_ptr(),
-                msg.len(),
-            )
-        }) {
-            return Err(Unspecified);
-        }
-
-        debug_assert_eq!(out_sig_len, sig_bytes.len());
+        let sig_bytes = self.evp_pkey.sign(msg, None, No_EVP_PKEY_CTX_consumer)?;
 
         Ok(Signature::new(|slice| {
             slice[0..ED25519_SIGNATURE_LEN].copy_from_slice(&sig_bytes);

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -8,6 +8,11 @@ use crate::aws_lc::{
     EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_marshal_public_key,
     EVP_parse_private_key, EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, RSA,
 };
+#[cfg(not(feature = "fips"))]
+use crate::aws_lc::{
+    EVP_PKEY_pqdsa_new_raw_private_key, EVP_PKEY_pqdsa_new_raw_public_key, EVP_PKEY_PQDSA,
+    NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
+};
 use crate::cbb::LcCBB;
 use crate::cbs;
 use crate::error::{KeyRejected, Unspecified};
@@ -193,6 +198,18 @@ impl LcPtr<EVP_PKEY> {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn marshal_raw_public_key(&self) -> Result<Vec<u8>, Unspecified> {
+        let mut size = 0;
+        if 1 != unsafe { EVP_PKEY_get_raw_public_key(*self.as_const(), null_mut(), &mut size) } {
+            return Err(Unspecified);
+        }
+        let mut buffer = vec![0u8; size];
+        let buffer_size = self.marshal_raw_public_to_buffer(&mut buffer)?;
+        debug_assert_eq!(buffer_size, size);
+        Ok(buffer)
+    }
+
     pub(crate) fn marshal_raw_public_to_buffer(
         &self,
         buffer: &mut [u8],
@@ -214,16 +231,50 @@ impl LcPtr<EVP_PKEY> {
         bytes: &[u8],
         evp_pkey_type: c_int,
     ) -> Result<Self, KeyRejected> {
+        #[cfg(not(feature = "fips"))]
+        if evp_pkey_type == EVP_PKEY_PQDSA {
+            return match bytes.len() {
+                2560 => Self::new(unsafe {
+                    EVP_PKEY_pqdsa_new_raw_private_key(NID_MLDSA44, bytes.as_ptr(), bytes.len())
+                }),
+                4032 => Self::new(unsafe {
+                    EVP_PKEY_pqdsa_new_raw_private_key(NID_MLDSA65, bytes.as_ptr(), bytes.len())
+                }),
+                4896 => Self::new(unsafe {
+                    EVP_PKEY_pqdsa_new_raw_private_key(NID_MLDSA87, bytes.as_ptr(), bytes.len())
+                }),
+                _ => Err(()),
+            }
+            .map_err(|()| KeyRejected::unspecified());
+        }
+
         Self::new(unsafe {
             EVP_PKEY_new_raw_private_key(evp_pkey_type, null_mut(), bytes.as_ptr(), bytes.len())
         })
-        .map_err(|()| KeyRejected::invalid_encoding())
+        .map_err(|()| KeyRejected::unspecified())
     }
 
     pub(crate) fn parse_raw_public_key(
         bytes: &[u8],
         evp_pkey_type: c_int,
     ) -> Result<Self, KeyRejected> {
+        #[cfg(not(feature = "fips"))]
+        if evp_pkey_type == EVP_PKEY_PQDSA {
+            return match bytes.len() {
+                1312 => Self::new(unsafe {
+                    EVP_PKEY_pqdsa_new_raw_public_key(NID_MLDSA44, bytes.as_ptr(), bytes.len())
+                }),
+                1952 => Self::new(unsafe {
+                    EVP_PKEY_pqdsa_new_raw_public_key(NID_MLDSA65, bytes.as_ptr(), bytes.len())
+                }),
+                2592 => Self::new(unsafe {
+                    EVP_PKEY_pqdsa_new_raw_public_key(NID_MLDSA87, bytes.as_ptr(), bytes.len())
+                }),
+                _ => Err(()),
+            }
+            .map_err(|()| KeyRejected::unspecified());
+        }
+
         Self::new(unsafe {
             EVP_PKEY_new_raw_public_key(evp_pkey_type, null_mut(), bytes.as_ptr(), bytes.len())
         })

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -3,11 +3,12 @@
 
 use crate::aws_lc::{
     EVP_DigestSign, EVP_DigestSignInit, EVP_DigestVerify, EVP_DigestVerifyInit, EVP_PKEY_CTX_new,
-    EVP_PKEY_bits, EVP_PKEY_cmp, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA, EVP_PKEY_get_raw_private_key,
-    EVP_PKEY_get_raw_public_key, EVP_PKEY_id, EVP_PKEY_new_raw_private_key,
-    EVP_PKEY_new_raw_public_key, EVP_PKEY_size, EVP_PKEY_up_ref, EVP_marshal_private_key,
-    EVP_marshal_private_key_v2, EVP_marshal_public_key, EVP_parse_private_key,
-    EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, EVP_PKEY_ED25519, RSA,
+    EVP_PKEY_CTX_new_id, EVP_PKEY_bits, EVP_PKEY_cmp, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA,
+    EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_id, EVP_PKEY_keygen,
+    EVP_PKEY_keygen_init, EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key, EVP_PKEY_size,
+    EVP_PKEY_up_ref, EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_marshal_public_key,
+    EVP_parse_private_key, EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, EVP_PKEY_ED25519,
+    RSA,
 };
 #[cfg(not(feature = "fips"))]
 use crate::aws_lc::{
@@ -39,7 +40,7 @@ pub(crate) trait EVP_PKEY_CTX_consumer: Fn(*mut EVP_PKEY_CTX) -> Result<(), ()> 
 
 impl<T> EVP_PKEY_CTX_consumer for T where T: Fn(*mut EVP_PKEY_CTX) -> Result<(), ()> {}
 
-#[allow(non_upper_case_globals)]
+#[allow(non_upper_case_globals, clippy::type_complexity)]
 pub(crate) const No_EVP_PKEY_CTX_consumer: Option<fn(*mut EVP_PKEY_CTX) -> Result<(), ()>> = None;
 
 impl LcPtr<EVP_PKEY> {
@@ -408,6 +409,29 @@ impl LcPtr<EVP_PKEY> {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn generate<F>(pkey_type: c_int, params_fn: Option<F>) -> Result<Self, Unspecified>
+    where
+        F: EVP_PKEY_CTX_consumer,
+    {
+        let mut pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new_id(pkey_type, null_mut()) })?;
+
+        if 1 != unsafe { EVP_PKEY_keygen_init(*pkey_ctx.as_mut()) } {
+            return Err(Unspecified);
+        }
+
+        if let Some(pad_fn) = params_fn {
+            pad_fn(*pkey_ctx.as_mut())?;
+        }
+
+        let mut pkey = null_mut::<EVP_PKEY>();
+
+        if 1 != indicator_check!(unsafe { EVP_PKEY_keygen(*pkey_ctx.as_mut(), &mut pkey) }) {
+            return Err(Unspecified);
+        }
+
+        Ok(LcPtr::new(pkey)?)
     }
 }
 

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{
-    EVP_PKEY_CTX_new, EVP_PKEY_bits, EVP_PKEY_cmp, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA,
-    EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_id,
-    EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key, EVP_PKEY_size, EVP_PKEY_up_ref,
-    EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_marshal_public_key,
-    EVP_parse_private_key, EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, RSA,
+    EVP_DigestSign, EVP_DigestSignInit, EVP_DigestVerify, EVP_DigestVerifyInit, EVP_PKEY_CTX_new,
+    EVP_PKEY_bits, EVP_PKEY_cmp, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA, EVP_PKEY_get_raw_private_key,
+    EVP_PKEY_get_raw_public_key, EVP_PKEY_id, EVP_PKEY_new_raw_private_key,
+    EVP_PKEY_new_raw_public_key, EVP_PKEY_size, EVP_PKEY_up_ref, EVP_marshal_private_key,
+    EVP_marshal_private_key_v2, EVP_marshal_public_key, EVP_parse_private_key,
+    EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, RSA,
 };
 #[cfg(not(feature = "fips"))]
 use crate::aws_lc::{
@@ -14,14 +15,16 @@ use crate::aws_lc::{
     NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
 };
 use crate::cbb::LcCBB;
-use crate::cbs;
 use crate::error::{KeyRejected, Unspecified};
 use crate::pkcs8::Version;
 use crate::ptr::{ConstPointer, LcPtr};
+use crate::{cbs, digest};
 // TODO: Uncomment when MSRV >= 1.64
 // use core::ffi::c_int;
+use crate::digest::digest_ctx::DigestContext;
+use crate::fips::indicator_check;
 use std::os::raw::c_int;
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 impl PartialEq<Self> for LcPtr<EVP_PKEY> {
     /// Only compares params and public key
@@ -279,6 +282,105 @@ impl LcPtr<EVP_PKEY> {
             EVP_PKEY_new_raw_public_key(evp_pkey_type, null_mut(), bytes.as_ptr(), bytes.len())
         })
         .map_err(|()| KeyRejected::invalid_encoding())
+    }
+
+    pub(crate) fn sign(
+        &self,
+        message: &[u8],
+        digest: Option<&'static digest::Algorithm>,
+    ) -> Result<Box<[u8]>, Unspecified> {
+        let mut md_ctx = DigestContext::new_uninit();
+        let evp_md = if let Some(alg) = digest {
+            *digest::match_digest_type(&alg.id)
+        } else {
+            null()
+        };
+
+        if 1 != unsafe {
+            // EVP_DigestSignInit does not mutate |pkey| for thread-safety purposes and may be
+            // used concurrently with other non-mutating functions on |pkey|.
+            // https://github.com/aws/aws-lc/blob/9b4b5a15a97618b5b826d742419ccd54c819fa42/include/openssl/evp.h#L297-L313
+            EVP_DigestSignInit(
+                md_ctx.as_mut_ptr(),
+                null_mut(),
+                evp_md,
+                null_mut(),
+                *self.as_mut_unsafe(),
+            )
+        } {
+            return Err(Unspecified);
+        }
+        // Determine the maximum length of the signature.
+        let mut sig_len = 0;
+        if 1 != unsafe {
+            EVP_DigestSign(
+                md_ctx.as_mut_ptr(),
+                null_mut(),
+                &mut sig_len,
+                message.as_ptr(),
+                message.len(),
+            )
+        } {
+            return Err(Unspecified);
+        }
+        if sig_len == 0 {
+            return Err(Unspecified);
+        }
+        let mut signature = vec![0u8; sig_len];
+
+        if 1 != indicator_check!(unsafe {
+            EVP_DigestSign(
+                md_ctx.as_mut_ptr(),
+                signature.as_mut_ptr(),
+                &mut sig_len,
+                message.as_ptr(),
+                message.len(),
+            )
+        }) {
+            return Err(Unspecified);
+        }
+        signature.truncate(sig_len);
+        Ok(signature.into_boxed_slice())
+    }
+
+    pub(crate) fn verify(
+        &self,
+        msg: &[u8],
+        digest: Option<&'static digest::Algorithm>,
+        signature: &[u8],
+    ) -> Result<(), Unspecified> {
+        let mut md_ctx = DigestContext::new_uninit();
+
+        let evp_md = if let Some(alg) = digest {
+            *digest::match_digest_type(&alg.id)
+        } else {
+            null()
+        };
+        if 1 != unsafe {
+            EVP_DigestVerifyInit(
+                md_ctx.as_mut_ptr(),
+                null_mut(),
+                evp_md,
+                null_mut(),
+                *self.as_mut_unsafe(),
+            )
+        } {
+            return Err(Unspecified);
+        }
+
+        if 1 != indicator_check!(unsafe {
+            EVP_DigestVerify(
+                md_ctx.as_mut_ptr(),
+                signature.as_ptr(),
+                signature.len(),
+                msg.as_ptr(),
+                msg.len(),
+            )
+        }) {
+            return Err(Unspecified);
+        }
+
+        Ok(())
     }
 }
 

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -160,7 +160,6 @@ extern crate alloc;
 extern crate aws_lc_fips_sys as aws_lc;
 #[cfg(not(feature = "fips"))]
 extern crate aws_lc_sys as aws_lc;
-extern crate core;
 
 pub mod aead;
 pub mod agreement;
@@ -195,6 +194,8 @@ pub mod iv;
 pub mod kdf;
 #[allow(clippy::module_name_repetitions)]
 pub mod kem;
+#[cfg(not(feature = "fips"))]
+mod pq;
 mod ptr;
 pub mod rsa;
 pub mod tls_prf;

--- a/aws-lc-rs/src/pq.rs
+++ b/aws-lc-rs/src/pq.rs
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+#![allow(unused)]
+
+use std::{ffi::c_int, ptr::null_mut};
+
+use crate::aws_lc::{
+    d2i_PrivateKey, CBB_init, EVP_PKEY_CTX_new_id, EVP_PKEY_CTX_pqdsa_set_params,
+    EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_keygen,
+    EVP_PKEY_keygen_init, EVP_PKEY_new, EVP_PKEY_pqdsa_new_raw_private_key,
+    EVP_PKEY_pqdsa_new_raw_public_key, EVP_marshal_private_key, EVP_marshal_public_key,
+    EVP_parse_public_key, CBB, EVP_PKEY, EVP_PKEY_PQDSA,
+};
+use crate::cbb::LcCBB;
+use crate::cbs::build_CBS;
+use crate::error::KeyRejected;
+use crate::evp_pkey::*;
+use crate::{error::Unspecified, fips::indicator_check, ptr::LcPtr};
+
+pub(crate) fn evp_key_pqdsa_generate(nid: c_int) -> Result<LcPtr<EVP_PKEY>, Unspecified> {
+    let mut pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new_id(EVP_PKEY_PQDSA, null_mut()) })?;
+
+    if 1 != unsafe { EVP_PKEY_keygen_init(*pkey_ctx.as_mut()) } {
+        return Err(Unspecified);
+    }
+
+    if 1 != unsafe { EVP_PKEY_CTX_pqdsa_set_params(*pkey_ctx.as_mut(), nid) } {
+        return Err(Unspecified);
+    }
+
+    let mut pkey = null_mut::<EVP_PKEY>();
+
+    if 1 != indicator_check!(unsafe { EVP_PKEY_keygen(*pkey_ctx.as_mut(), &mut pkey) }) {
+        return Err(Unspecified);
+    }
+
+    let pkey = LcPtr::new(pkey)?;
+
+    Ok(pkey)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::aws_lc::{
+        EVP_PKEY_cmp, EVP_PKEY, EVP_PKEY_PQDSA, NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
+    };
+    use crate::evp_pkey::*;
+    use crate::pkcs8::Version;
+    use crate::pq::evp_key_pqdsa_generate;
+    use crate::ptr::LcPtr;
+    use std::ffi::c_int;
+
+    #[test]
+    fn test_keygen() {
+        for nid in [NID_MLDSA44, NID_MLDSA65, NID_MLDSA87] {
+            test_keygen_for(nid);
+        }
+    }
+
+    fn test_keygen_for(nid: c_int) {
+        let mut buffer = [0u8; 4096];
+        let key = evp_key_pqdsa_generate(nid).unwrap();
+
+        println!("key size: {:?}", key.key_size_bytes());
+
+        let public_buffer = key.marshal_rfc5280_public_key().unwrap();
+        println!("public marshall: {:?}", public_buffer);
+        let key_public =
+            LcPtr::<EVP_PKEY>::parse_rfc5280_public_key(&public_buffer, EVP_PKEY_PQDSA).unwrap();
+
+        let private_buffer = key.marshal_rfc5208_private_key(Version::V1).unwrap();
+        println!("private marshall: {:?}", private_buffer);
+        let key_private =
+            LcPtr::<EVP_PKEY>::parse_rfc5208_private_key(&private_buffer, EVP_PKEY_PQDSA).unwrap();
+
+        let raw_public_buffer = key_public.marshal_raw_public_key().unwrap();
+        println!("raw public size: {}", raw_public_buffer.len());
+        let key_public2 =
+            LcPtr::<EVP_PKEY>::parse_raw_public_key(&raw_public_buffer, EVP_PKEY_PQDSA).unwrap();
+
+        assert_eq!(1, unsafe {
+            EVP_PKEY_cmp(*key_public.as_const(), *key_public2.as_const())
+        });
+
+        let raw_private_buffer = key_private.marshal_raw_private_key().unwrap();
+        println!("raw private size: {}", raw_private_buffer.len());
+        let key_private2 =
+            LcPtr::<EVP_PKEY>::parse_raw_private_key(&raw_private_buffer, EVP_PKEY_PQDSA).unwrap();
+
+        // TODO: Currently the public key is not populated
+        // assert_eq!(1, unsafe {
+        //     EVP_PKEY_cmp(*key_private.as_const(), *key_private2.as_const())
+        // });
+    }
+}

--- a/aws-lc-rs/src/pq.rs
+++ b/aws-lc-rs/src/pq.rs
@@ -2,20 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 #![allow(unused)]
 
-use std::{ffi::c_int, ptr::null_mut};
-
 use crate::aws_lc::{
-    d2i_PrivateKey, CBB_init, EVP_PKEY_CTX_new_id, EVP_PKEY_CTX_pqdsa_set_params,
-    EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_keygen,
-    EVP_PKEY_keygen_init, EVP_PKEY_new, EVP_PKEY_pqdsa_new_raw_private_key,
+    d2i_PrivateKey, CBB_init, EVP_DigestSign, EVP_DigestVerify, EVP_PKEY_CTX_new_id,
+    EVP_PKEY_CTX_pqdsa_set_params, EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key,
+    EVP_PKEY_keygen, EVP_PKEY_keygen_init, EVP_PKEY_new, EVP_PKEY_pqdsa_new_raw_private_key,
     EVP_PKEY_pqdsa_new_raw_public_key, EVP_marshal_private_key, EVP_marshal_public_key,
     EVP_parse_public_key, CBB, EVP_PKEY, EVP_PKEY_PQDSA,
 };
 use crate::cbb::LcCBB;
 use crate::cbs::build_CBS;
+use crate::digest::digest_ctx::DigestContext;
 use crate::error::KeyRejected;
 use crate::evp_pkey::*;
-use crate::{error::Unspecified, fips::indicator_check, ptr::LcPtr};
+use crate::signature::MAX_LEN;
+use crate::{digest, error::Unspecified, fips::indicator_check, ptr::LcPtr};
+use aws_lc_sys::{EVP_DigestSignInit, EVP_DigestVerifyInit};
+use std::{ffi::c_int, ptr::null_mut};
 
 pub(crate) fn evp_key_pqdsa_generate(nid: c_int) -> Result<LcPtr<EVP_PKEY>, Unspecified> {
     let mut pkey_ctx = LcPtr::new(unsafe { EVP_PKEY_CTX_new_id(EVP_PKEY_PQDSA, null_mut()) })?;
@@ -44,7 +46,9 @@ mod tests {
     use crate::aws_lc::{
         EVP_PKEY_cmp, EVP_PKEY, EVP_PKEY_PQDSA, NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
     };
+    use crate::digest;
     use crate::evp_pkey::*;
+    use crate::hmac::sign;
     use crate::pkcs8::Version;
     use crate::pq::evp_key_pqdsa_generate;
     use crate::ptr::LcPtr;
@@ -53,22 +57,20 @@ mod tests {
     #[test]
     fn test_keygen() {
         for nid in [NID_MLDSA44, NID_MLDSA65, NID_MLDSA87] {
-            test_keygen_for(nid);
+            let key = evp_key_pqdsa_generate(nid).unwrap();
+            println!("key size: {:?}", key.key_size_bytes());
+            test_serialization_for(&key);
+            test_signing_for(&key);
         }
     }
 
-    fn test_keygen_for(nid: c_int) {
-        let mut buffer = [0u8; 4096];
-        let key = evp_key_pqdsa_generate(nid).unwrap();
-
-        println!("key size: {:?}", key.key_size_bytes());
-
-        let public_buffer = key.marshal_rfc5280_public_key().unwrap();
+    fn test_serialization_for(evp_pkey: &LcPtr<EVP_PKEY>) {
+        let public_buffer = evp_pkey.marshal_rfc5280_public_key().unwrap();
         println!("public marshall: {:?}", public_buffer);
         let key_public =
             LcPtr::<EVP_PKEY>::parse_rfc5280_public_key(&public_buffer, EVP_PKEY_PQDSA).unwrap();
 
-        let private_buffer = key.marshal_rfc5208_private_key(Version::V1).unwrap();
+        let private_buffer = evp_pkey.marshal_rfc5208_private_key(Version::V1).unwrap();
         println!("private marshall: {:?}", private_buffer);
         let key_private =
             LcPtr::<EVP_PKEY>::parse_rfc5208_private_key(&private_buffer, EVP_PKEY_PQDSA).unwrap();
@@ -91,5 +93,14 @@ mod tests {
         // assert_eq!(1, unsafe {
         //     EVP_PKEY_cmp(*key_private.as_const(), *key_private2.as_const())
         // });
+    }
+
+    fn test_signing_for(evp_pkey: &LcPtr<EVP_PKEY>) {
+        let message = b"hello world";
+        let signature = evp_pkey.sign(message, None).unwrap();
+        println!("signature size: {}", signature.len());
+        assert_eq!(signature.len(), evp_pkey.signature_size_bytes());
+        evp_pkey.verify(message, None, &signature).unwrap();
+        println!("verified: {:?}", signature);
     }
 }

--- a/aws-lc-rs/src/pq.rs
+++ b/aws-lc-rs/src/pq.rs
@@ -23,9 +23,9 @@ use std::ptr::null_mut;
 pub(crate) fn evp_key_pqdsa_generate(nid: c_int) -> Result<LcPtr<EVP_PKEY>, Unspecified> {
     let params_fn = |ctx| {
         if 1 == unsafe { EVP_PKEY_CTX_pqdsa_set_params(ctx, nid) } {
-            return Ok(());
+            Ok(())
         } else {
-            return Err(());
+            Err(())
         }
     };
     LcPtr::<EVP_PKEY>::generate(EVP_PKEY_PQDSA, Some(params_fn))
@@ -56,12 +56,12 @@ mod tests {
 
     fn test_serialization_for(evp_pkey: &LcPtr<EVP_PKEY>) {
         let public_buffer = evp_pkey.marshal_rfc5280_public_key().unwrap();
-        println!("public marshall: {:?}", public_buffer);
+        println!("public marshall: {public_buffer:?}");
         let key_public =
             LcPtr::<EVP_PKEY>::parse_rfc5280_public_key(&public_buffer, EVP_PKEY_PQDSA).unwrap();
 
         let private_buffer = evp_pkey.marshal_rfc5208_private_key(Version::V1).unwrap();
-        println!("private marshall: {:?}", private_buffer);
+        println!("private marshall: {private_buffer:?}");
         let key_private =
             LcPtr::<EVP_PKEY>::parse_rfc5208_private_key(&private_buffer, EVP_PKEY_PQDSA).unwrap();
 
@@ -95,6 +95,6 @@ mod tests {
         evp_pkey
             .verify(message, None, No_EVP_PKEY_CTX_consumer, &signature)
             .unwrap();
-        println!("verified: {:?}", signature);
+        println!("verified: {signature:?}");
     }
 }

--- a/aws-lc-rs/src/rsa/encryption.rs
+++ b/aws-lc-rs/src/rsa/encryption.rs
@@ -61,7 +61,7 @@ impl PrivateDecryptingKey {
     /// # Errors
     /// * `Unspecified` for any error that occurs during the generation of the RSA keypair.
     pub fn generate(size: KeySize) -> Result<Self, Unspecified> {
-        let key = generate_rsa_key(size.bits(), false)?;
+        let key = generate_rsa_key(size.bits())?;
         Self::new(key)
     }
 
@@ -71,13 +71,17 @@ impl PrivateDecryptingKey {
     /// * `KeySize::Rsa2048`
     /// * `KeySize::Rsa3072`
     /// * `KeySize::Rsa4096`
+    /// * `KeySize::Rsa8192`
+    ///
+    /// ## Deprecated
+    /// This is equivalent to `KeyPair::generate`.
     ///
     /// # Errors
-    /// * `Unspecified`: Any key generation failure.
+    /// * `Unspecified` for any error that occurs during the generation of the RSA keypair.
     #[cfg(feature = "fips")]
+    #[deprecated]
     pub fn generate_fips(size: KeySize) -> Result<Self, Unspecified> {
-        let key = generate_rsa_key(size.bits(), true)?;
-        Self::new(key)
+        Self::generate(size)
     }
 
     /// Construct a `PrivateDecryptingKey` from the provided PKCS#8 (v1) document.

--- a/aws-lc-rs/src/rsa/tests/fips.rs
+++ b/aws-lc-rs/src/rsa/tests/fips.rs
@@ -11,13 +11,15 @@ macro_rules! generate_key {
         #[test]
         fn $name() {
             // Using the non-fips generator will not set the indicator
+            #[cfg(not(feature = "fips"))]
             let _ =
                 assert_fips_status_indicator!(KeyPair::generate($size), FipsServiceStatus::Unset)
                     .expect("key generated");
 
             // Using the fips generator should set the indicator
+            #[cfg(feature = "fips")]
             let _ = assert_fips_status_indicator!(
-                KeyPair::generate_fips($size),
+                KeyPair::generate($size),
                 FipsServiceStatus::Approved
             )
             .expect("key generated");
@@ -27,6 +29,7 @@ macro_rules! generate_key {
         #[test]
         fn $name() {
             // Using the non-fips generator will not set the indicator
+            #[cfg(not(feature = "fips"))]
             let _ = assert_fips_status_indicator!(
                 PrivateDecryptingKey::generate($size),
                 FipsServiceStatus::Unset
@@ -34,8 +37,9 @@ macro_rules! generate_key {
             .expect("key generated");
 
             // Using the fips generator should set the indicator
+            #[cfg(feature = "fips")]
             let _ = assert_fips_status_indicator!(
-                PrivateDecryptingKey::generate_fips($size),
+                PrivateDecryptingKey::generate($size),
                 FipsServiceStatus::Approved
             )
             .expect("key generated");

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -317,7 +317,7 @@ macro_rules! generate_fips_encode_decode {
         #[cfg(feature = "fips")]
         #[test]
         fn $name() {
-            let private_key = RsaKeyPair::generate_fips($size).expect("generation");
+            let private_key = RsaKeyPair::generate($size).expect("generation");
 
             assert_eq!(true, private_key.is_valid_fips_key());
 
@@ -388,7 +388,7 @@ macro_rules! encryption_generate_fips_encode_decode {
         #[cfg(feature = "fips")]
         #[test]
         fn $name() {
-            let private_key = PrivateDecryptingKey::generate_fips($size).expect("generation");
+            let private_key = PrivateDecryptingKey::generate($size).expect("generation");
 
             assert_eq!(true, private_key.is_valid_fips_key());
 


### PR DESCRIPTION
### Description of changes: 
* Consolidates various places we call `EVP_PKEY_keygen`
* Consolidates various placeswe call `EVP_DigestSign` and `EVP_DigestVerify`.
* Start of implementation for ML-DSA

### Call-outs:
* RSA key generation will now use `EVP_PKEY_keygen`.  When the "fips" feature is enabled, the FIPS-approved key generation mechanism will be used for all RSA keys.

### Testing:
* RSA "fips" tests had slight modification due to change mentioned above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
