### PR TITLE
Fix cmake build type when opt_level is "s"

### DIFF
--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -108,17 +108,6 @@ impl CmakeBuilder {
             cmake_cfg.define("BUILD_SHARED_LIBS", "0");
         }
 
-        let opt_level = cargo_env("OPT_LEVEL");
-        if opt_level.ne("0") {
-            if opt_level.eq("1") || opt_level.eq("2") {
-                cmake_cfg.define("CMAKE_BUILD_TYPE", "relwithdebinfo");
-            } else {
-                cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
-            }
-        } else {
-            cmake_cfg.define("CMAKE_BUILD_TYPE", "debug");
-        }
-
         if let Some(prefix) = &self.build_prefix {
             cmake_cfg.define("BORINGSSL_PREFIX", format!("{prefix}_"));
             let include_path = self.manifest_dir.join("generated-include");


### PR DESCRIPTION
### Issues:
Resolves #691

### Description of changes: 
Solves the link issue by removing the code that selected the build type. 
This is redundant since cmake-rs does it as well, and in opt-level="s" appearently it chooses a different build type (MinRelSize vs RelWithDebInfo). 

This caused a mismatch in CRT and failed the link.

The logic in cmake-rs is seems more comprehensive and correct, so it's best to let it do its job for us:
https://github.com/rust-lang/cmake-rs/blob/fd56c5a6b4ecda8815c863eb5b12d7b3f0391197/src/lib.rs#L146C1-L147C1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
