### PR TITLE
Ensure ConstPointers don't outlive parent

### DIFF
--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -415,7 +415,9 @@ impl PrivateKey {
             }
             KeyInner::X25519(priv_key) => {
                 let mut buffer = [0u8; MAX_PUBLIC_KEY_LEN];
-                let out_len = priv_key.marshal_raw_public_to_buffer(&mut buffer)?;
+                let out_len = priv_key
+                    .as_const()
+                    .marshal_raw_public_to_buffer(&mut buffer)?;
                 Ok(PublicKey {
                     inner_key: self.inner_key.clone(),
                     key_bytes: buffer,
@@ -477,6 +479,7 @@ impl AsDer<Pkcs8V1Der<'static>> for PrivateKey {
         Ok(Pkcs8V1Der::new(
             self.inner_key
                 .get_evp_pkey()
+                .as_const()
                 .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
@@ -510,7 +513,9 @@ impl AsBigEndian<Curve25519SeedBin<'static>> for PrivateKey {
             return Err(Unspecified);
         }
         let evp_pkey = self.inner_key.get_evp_pkey();
-        Ok(Curve25519SeedBin::new(evp_pkey.marshal_raw_private_key()?))
+        Ok(Curve25519SeedBin::new(
+            evp_pkey.as_const().marshal_raw_private_key()?,
+        ))
     }
 }
 
@@ -577,7 +582,7 @@ impl AsDer<PublicKeyX509Der<'static>> for PublicKey {
             | KeyInner::ECDH_P384(evp_pkey)
             | KeyInner::ECDH_P521(evp_pkey)
             | KeyInner::X25519(evp_pkey) => {
-                let der = evp_pkey.marshal_rfc5280_public_key()?;
+                let der = evp_pkey.as_const().marshal_rfc5280_public_key()?;
                 Ok(PublicKeyX509Der::from(Buffer::new(der)))
             }
         }

--- a/aws-lc-rs/src/bn.rs
+++ b/aws-lc-rs/src/bn.rs
@@ -35,7 +35,7 @@ impl TryFrom<u64> for DetachableLcPtr<BIGNUM> {
     }
 }
 
-impl ConstPointer<BIGNUM> {
+impl ConstPointer<'_, BIGNUM> {
     pub(crate) fn to_be_bytes(&self) -> Vec<u8> {
         unsafe {
             let bn_bytes = BN_num_bytes(**self);

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -285,21 +285,23 @@ pub enum OperatingMode {
 
 impl OperatingMode {
     fn evp_cipher(&self, algorithm: &Algorithm) -> ConstPointer<EVP_CIPHER> {
-        ConstPointer::new(match (self, algorithm.id) {
-            (OperatingMode::CBC, AlgorithmId::Aes128) => unsafe { EVP_aes_128_cbc() },
-            (OperatingMode::CTR, AlgorithmId::Aes128) => unsafe { EVP_aes_128_ctr() },
-            (OperatingMode::CFB128, AlgorithmId::Aes128) => unsafe { EVP_aes_128_cfb128() },
-            (OperatingMode::ECB, AlgorithmId::Aes128) => unsafe { EVP_aes_128_ecb() },
-            (OperatingMode::CBC, AlgorithmId::Aes192) => unsafe { EVP_aes_192_cbc() },
-            (OperatingMode::CTR, AlgorithmId::Aes192) => unsafe { EVP_aes_192_ctr() },
-            (OperatingMode::CFB128, AlgorithmId::Aes192) => unsafe { EVP_aes_192_cfb128() },
-            (OperatingMode::ECB, AlgorithmId::Aes192) => unsafe { EVP_aes_192_ecb() },
-            (OperatingMode::CBC, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cbc() },
-            (OperatingMode::CTR, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ctr() },
-            (OperatingMode::CFB128, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cfb128() },
-            (OperatingMode::ECB, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ecb() },
-        })
-        .unwrap()
+        unsafe {
+            ConstPointer::new_static(match (self, algorithm.id) {
+                (OperatingMode::CBC, AlgorithmId::Aes128) => EVP_aes_128_cbc(),
+                (OperatingMode::CTR, AlgorithmId::Aes128) => EVP_aes_128_ctr(),
+                (OperatingMode::CFB128, AlgorithmId::Aes128) => EVP_aes_128_cfb128(),
+                (OperatingMode::ECB, AlgorithmId::Aes128) => EVP_aes_128_ecb(),
+                (OperatingMode::CBC, AlgorithmId::Aes192) => EVP_aes_192_cbc(),
+                (OperatingMode::CTR, AlgorithmId::Aes192) => EVP_aes_192_ctr(),
+                (OperatingMode::CFB128, AlgorithmId::Aes192) => EVP_aes_192_cfb128(),
+                (OperatingMode::ECB, AlgorithmId::Aes192) => EVP_aes_192_ecb(),
+                (OperatingMode::CBC, AlgorithmId::Aes256) => EVP_aes_256_cbc(),
+                (OperatingMode::CTR, AlgorithmId::Aes256) => EVP_aes_256_ctr(),
+                (OperatingMode::CFB128, AlgorithmId::Aes256) => EVP_aes_256_cfb128(),
+                (OperatingMode::ECB, AlgorithmId::Aes256) => EVP_aes_256_ecb(),
+            })
+            .unwrap()
+        }
     }
 }
 

--- a/aws-lc-rs/src/digest.rs
+++ b/aws-lc-rs/src/digest.rs
@@ -342,7 +342,7 @@ pub const MAX_CHAINING_LEN: usize = MAX_OUTPUT_LEN;
 /// Match digest types for `EVP_MD` functions.
 pub(crate) fn match_digest_type(algorithm_id: &AlgorithmID) -> ConstPointer<EVP_MD> {
     unsafe {
-        ConstPointer::new(match algorithm_id {
+        ConstPointer::new_static(match algorithm_id {
             AlgorithmID::SHA1 => EVP_sha1(),
             AlgorithmID::SHA224 => EVP_sha224(),
             AlgorithmID::SHA256 => EVP_sha256(),

--- a/aws-lc-rs/src/ec.rs
+++ b/aws-lc-rs/src/ec.rs
@@ -3,8 +3,6 @@
 // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::ec::signature::AlgorithmID;
-// TODO: Uncomment when MSRV >= 1.64
 #[cfg(feature = "fips")]
 use crate::aws_lc::EC_KEY_check_fips;
 #[cfg(not(feature = "fips"))]
@@ -16,11 +14,14 @@ use crate::aws_lc::{
     NID_X9_62_prime256v1, NID_secp224r1, NID_secp256k1, NID_secp384r1, NID_secp521r1, EC_GROUP,
     EC_KEY, EVP_PKEY, EVP_PKEY_EC,
 };
+use crate::ec::signature::AlgorithmID;
 use crate::error::{KeyRejected, Unspecified};
 #[cfg(feature = "fips")]
 use crate::fips::indicator_check;
 use crate::ptr::{ConstPointer, LcPtr};
 use crate::signature::Signature;
+// TODO: Uncomment when MSRV >= 1.64
+//use core::ffi::c_int;
 use std::os::raw::c_int;
 use std::ptr::null;
 

--- a/aws-lc-rs/src/ec/encoding.rs
+++ b/aws-lc-rs/src/ec/encoding.rs
@@ -135,9 +135,9 @@ pub(crate) mod sec1 {
         compressed: bool,
     ) -> Result<Vec<u8>, Unspecified> {
         let pub_key_size = if compressed {
-            compressed_public_key_size_bytes(evp_pkey.key_size_bits())
+            compressed_public_key_size_bytes(evp_pkey.as_const().key_size_bits())
         } else {
-            uncompressed_public_key_size_bytes(evp_pkey.key_size_bits())
+            uncompressed_public_key_size_bytes(evp_pkey.as_const().key_size_bits())
         };
         let mut cbb = LcCBB::new(pub_key_size);
         marshal_sec1_public_point_into_cbb(&mut cbb, evp_pkey, compressed)?;
@@ -245,7 +245,7 @@ pub(crate) mod rfc5915 {
         let ec_key = evp_pkey.project_const_lifetime(unsafe {
             |evp_pkey| EVP_PKEY_get0_EC_KEY(*evp_pkey.as_const())
         })?;
-        let mut cbb = LcCBB::new(evp_pkey.key_size_bytes());
+        let mut cbb = LcCBB::new(evp_pkey.as_const().key_size_bytes());
         let enc_flags = unsafe { EC_KEY_get_enc_flags(*ec_key) };
         if 1 != unsafe { EC_KEY_marshal_private_key(cbb.as_mut_ptr(), *ec_key, enc_flags) } {
             return Err(Unspecified);

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -128,7 +128,9 @@ impl EcdsaKeyPair {
     ///
     pub fn to_pkcs8v1(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 

--- a/aws-lc-rs/src/ec/signature.rs
+++ b/aws-lc-rs/src/ec/signature.rs
@@ -121,7 +121,7 @@ impl AsDer<PublicKeyX509Der<'static>> for PublicKey {
     /// # Errors
     /// Returns an error if the public key fails to marshal to X.509.
     fn as_der(&self) -> Result<PublicKeyX509Der<'static>, Unspecified> {
-        let der = self.evp_pkey.marshal_rfc5280_public_key()?;
+        let der = self.evp_pkey.as_const().marshal_rfc5280_public_key()?;
         Ok(PublicKeyX509Der::new(der))
     }
 }

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -182,7 +182,9 @@ impl Ed25519KeyPair {
         let evp_pkey = generate_key()?;
 
         let mut public_key = [0u8; ED25519_PUBLIC_KEY_LEN];
-        let out_len: usize = evp_pkey.as_const().marshal_raw_public_to_buffer(&mut public_key)?;
+        let out_len: usize = evp_pkey
+            .as_const()
+            .marshal_raw_public_to_buffer(&mut public_key)?;
         debug_assert_eq!(public_key.len(), out_len);
 
         Ok(Self {
@@ -219,7 +221,9 @@ impl Ed25519KeyPair {
     pub fn generate_pkcs8(_rng: &dyn SecureRandom) -> Result<Document, Unspecified> {
         let evp_pkey = generate_key()?;
         Ok(Document::new(
-            evp_pkey.as_const().marshal_rfc5208_private_key(Version::V2)?,
+            evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V2)?,
         ))
     }
 
@@ -230,7 +234,9 @@ impl Ed25519KeyPair {
     ///
     pub fn to_pkcs8(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V2)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V2)?,
         ))
     }
 
@@ -251,7 +257,9 @@ impl Ed25519KeyPair {
     pub fn generate_pkcs8v1(_rng: &dyn SecureRandom) -> Result<Document, Unspecified> {
         let evp_pkey = generate_key()?;
         Ok(Document::new(
-            evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
+            evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 
@@ -262,7 +270,9 @@ impl Ed25519KeyPair {
     ///
     pub fn to_pkcs8v1(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 
@@ -307,7 +317,9 @@ impl Ed25519KeyPair {
         let evp_pkey = LcPtr::<EVP_PKEY>::parse_raw_private_key(seed, EVP_PKEY_ED25519)?;
 
         let mut derived_public_key = [0u8; ED25519_PUBLIC_KEY_LEN];
-        let out_len: usize = evp_pkey.as_const().marshal_raw_public_to_buffer(&mut derived_public_key)?;
+        let out_len: usize = evp_pkey
+            .as_const()
+            .marshal_raw_public_to_buffer(&mut derived_public_key)?;
         debug_assert_eq!(derived_public_key.len(), out_len);
 
         Ok(Self {
@@ -363,7 +375,9 @@ impl Ed25519KeyPair {
         evp_pkey.as_const().validate_as_ed25519()?;
 
         let mut public_key = [0u8; ED25519_PUBLIC_KEY_LEN];
-        let out_len: usize = evp_pkey.as_const().marshal_raw_public_to_buffer(&mut public_key)?;
+        let out_len: usize = evp_pkey
+            .as_const()
+            .marshal_raw_public_to_buffer(&mut public_key)?;
         debug_assert_eq!(public_key.len(), out_len);
 
         Ok(Self {
@@ -406,7 +420,11 @@ impl Ed25519KeyPair {
     /// Currently the function cannot fail, but it might in future implementations.
     pub fn seed(&self) -> Result<Seed<'static>, Unspecified> {
         Ok(Seed {
-            bytes: self.evp_pkey.as_const().marshal_raw_private_key()?.into_boxed_slice(),
+            bytes: self
+                .evp_pkey
+                .as_const()
+                .marshal_raw_private_key()?
+                .into_boxed_slice(),
             phantom: PhantomData,
         })
     }
@@ -419,7 +437,9 @@ impl AsDer<Pkcs8V1Der<'static>> for Ed25519KeyPair {
     /// `error::Unspecified` on internal error.
     fn as_der(&self) -> Result<Pkcs8V1Der<'static>, crate::error::Unspecified> {
         Ok(Pkcs8V1Der::new(
-            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 }
@@ -431,7 +451,9 @@ impl AsDer<Pkcs8V2Der<'static>> for Ed25519KeyPair {
     /// `error::Unspecified` on internal error.
     fn as_der(&self) -> Result<Pkcs8V2Der<'static>, crate::error::Unspecified> {
         Ok(Pkcs8V2Der::new(
-            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V2)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V2)?,
         ))
     }
 }

--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -153,7 +153,7 @@ impl AsDer<PublicKeyX509Der<'static>> for PublicKey {
         // 2:d=1  hl=2 l=   5 cons:  SEQUENCE
         // 4:d=2  hl=2 l=   3 prim:   OBJECT            :ED25519
         // 9:d=1  hl=2 l=  33 prim:  BIT STRING
-        let der = self.evp_pkey.marshal_rfc5280_public_key()?;
+        let der = self.evp_pkey.as_const().marshal_rfc5280_public_key()?;
         Ok(PublicKeyX509Der::from(Buffer::new(der)))
     }
 }
@@ -182,7 +182,7 @@ impl Ed25519KeyPair {
         let evp_pkey = generate_key()?;
 
         let mut public_key = [0u8; ED25519_PUBLIC_KEY_LEN];
-        let out_len: usize = evp_pkey.marshal_raw_public_to_buffer(&mut public_key)?;
+        let out_len: usize = evp_pkey.as_const().marshal_raw_public_to_buffer(&mut public_key)?;
         debug_assert_eq!(public_key.len(), out_len);
 
         Ok(Self {
@@ -219,7 +219,7 @@ impl Ed25519KeyPair {
     pub fn generate_pkcs8(_rng: &dyn SecureRandom) -> Result<Document, Unspecified> {
         let evp_pkey = generate_key()?;
         Ok(Document::new(
-            evp_pkey.marshal_rfc5208_private_key(Version::V2)?,
+            evp_pkey.as_const().marshal_rfc5208_private_key(Version::V2)?,
         ))
     }
 
@@ -230,7 +230,7 @@ impl Ed25519KeyPair {
     ///
     pub fn to_pkcs8(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V2)?,
+            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V2)?,
         ))
     }
 
@@ -251,7 +251,7 @@ impl Ed25519KeyPair {
     pub fn generate_pkcs8v1(_rng: &dyn SecureRandom) -> Result<Document, Unspecified> {
         let evp_pkey = generate_key()?;
         Ok(Document::new(
-            evp_pkey.marshal_rfc5208_private_key(Version::V1)?,
+            evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 
@@ -262,7 +262,7 @@ impl Ed25519KeyPair {
     ///
     pub fn to_pkcs8v1(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 
@@ -307,7 +307,7 @@ impl Ed25519KeyPair {
         let evp_pkey = LcPtr::<EVP_PKEY>::parse_raw_private_key(seed, EVP_PKEY_ED25519)?;
 
         let mut derived_public_key = [0u8; ED25519_PUBLIC_KEY_LEN];
-        let out_len: usize = evp_pkey.marshal_raw_public_to_buffer(&mut derived_public_key)?;
+        let out_len: usize = evp_pkey.as_const().marshal_raw_public_to_buffer(&mut derived_public_key)?;
         debug_assert_eq!(derived_public_key.len(), out_len);
 
         Ok(Self {
@@ -360,10 +360,10 @@ impl Ed25519KeyPair {
     fn parse_pkcs8(pkcs8: &[u8]) -> Result<Self, KeyRejected> {
         let evp_pkey = LcPtr::<EVP_PKEY>::parse_rfc5208_private_key(pkcs8, EVP_PKEY_ED25519)?;
 
-        evp_pkey.validate_as_ed25519()?;
+        evp_pkey.as_const().validate_as_ed25519()?;
 
         let mut public_key = [0u8; ED25519_PUBLIC_KEY_LEN];
-        let out_len: usize = evp_pkey.marshal_raw_public_to_buffer(&mut public_key)?;
+        let out_len: usize = evp_pkey.as_const().marshal_raw_public_to_buffer(&mut public_key)?;
         debug_assert_eq!(public_key.len(), out_len);
 
         Ok(Self {
@@ -406,7 +406,7 @@ impl Ed25519KeyPair {
     /// Currently the function cannot fail, but it might in future implementations.
     pub fn seed(&self) -> Result<Seed<'static>, Unspecified> {
         Ok(Seed {
-            bytes: self.evp_pkey.marshal_raw_private_key()?.into_boxed_slice(),
+            bytes: self.evp_pkey.as_const().marshal_raw_private_key()?.into_boxed_slice(),
             phantom: PhantomData,
         })
     }
@@ -419,7 +419,7 @@ impl AsDer<Pkcs8V1Der<'static>> for Ed25519KeyPair {
     /// `error::Unspecified` on internal error.
     fn as_der(&self) -> Result<Pkcs8V1Der<'static>, crate::error::Unspecified> {
         Ok(Pkcs8V1Der::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 }
@@ -431,7 +431,7 @@ impl AsDer<Pkcs8V2Der<'static>> for Ed25519KeyPair {
     /// `error::Unspecified` on internal error.
     fn as_der(&self) -> Result<Pkcs8V2Der<'static>, crate::error::Unspecified> {
         Ok(Pkcs8V2Der::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V2)?,
+            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V2)?,
         ))
     }
 }

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -189,7 +189,6 @@ impl ConstPointer<'_, EVP_PKEY> {
             Err(Unspecified)
         }
     }
-
 }
 
 impl LcPtr<EVP_PKEY> {

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -100,17 +100,15 @@ impl LcPtr<EVP_PKEY> {
 
     #[allow(dead_code)]
     pub(crate) fn get_ec_key(&self) -> Result<ConstPointer<EC_KEY>, KeyRejected> {
-        unsafe {
-            ConstPointer::new(EVP_PKEY_get0_EC_KEY(*self.as_const()))
-                .map_err(|()| KeyRejected::wrong_algorithm())
-        }
+        self.project_const_lifetime(unsafe {
+            |evp_pkey| EVP_PKEY_get0_EC_KEY(*evp_pkey.as_const())
+        })
+        .map_err(|()| KeyRejected::wrong_algorithm())
     }
 
     pub(crate) fn get_rsa(&self) -> Result<ConstPointer<RSA>, KeyRejected> {
-        unsafe {
-            ConstPointer::new(EVP_PKEY_get0_RSA(*self.as_const()))
-                .map_err(|()| KeyRejected::wrong_algorithm())
-        }
+        self.project_const_lifetime(unsafe { |evp_pkey| EVP_PKEY_get0_RSA(*evp_pkey.as_const()) })
+            .map_err(|()| KeyRejected::wrong_algorithm())
     }
 
     pub(crate) fn marshal_rfc5280_public_key(&self) -> Result<Vec<u8>, Unspecified> {

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -43,7 +43,7 @@ impl<T> EVP_PKEY_CTX_consumer for T where T: Fn(*mut EVP_PKEY_CTX) -> Result<(),
 #[allow(non_upper_case_globals, clippy::type_complexity)]
 pub(crate) const No_EVP_PKEY_CTX_consumer: Option<fn(*mut EVP_PKEY_CTX) -> Result<(), ()>> = None;
 
-impl LcPtr<EVP_PKEY> {
+impl ConstPointer<'_, EVP_PKEY> {
     pub(crate) fn validate_as_ed25519(&self) -> Result<(), KeyRejected> {
         const ED25519_KEY_TYPE: c_int = EVP_PKEY_ED25519;
         const ED25519_MIN_BITS: c_int = 253;
@@ -79,7 +79,7 @@ impl LcPtr<EVP_PKEY> {
     // EVP_PKEY_X448 = 961;
     // EVP_PKEY_ED448 = 960;
     pub(crate) fn id(&self) -> i32 {
-        unsafe { EVP_PKEY_id(*self.as_const()) }
+        unsafe { EVP_PKEY_id(**self) }
     }
 
     pub(crate) fn key_size_bytes(&self) -> usize {
@@ -87,27 +87,21 @@ impl LcPtr<EVP_PKEY> {
     }
 
     pub(crate) fn key_size_bits(&self) -> usize {
-        unsafe { EVP_PKEY_bits(*self.as_const()) }
-            .try_into()
-            .unwrap()
+        unsafe { EVP_PKEY_bits(**self) }.try_into().unwrap()
     }
 
     pub(crate) fn signature_size_bytes(&self) -> usize {
-        unsafe { EVP_PKEY_size(*self.as_const()) }
-            .try_into()
-            .unwrap()
+        unsafe { EVP_PKEY_size(**self) }.try_into().unwrap()
     }
 
     #[allow(dead_code)]
     pub(crate) fn get_ec_key(&self) -> Result<ConstPointer<EC_KEY>, KeyRejected> {
-        self.project_const_lifetime(unsafe {
-            |evp_pkey| EVP_PKEY_get0_EC_KEY(*evp_pkey.as_const())
-        })
-        .map_err(|()| KeyRejected::wrong_algorithm())
+        self.project_const_lifetime(unsafe { |evp_pkey| EVP_PKEY_get0_EC_KEY(**evp_pkey) })
+            .map_err(|()| KeyRejected::wrong_algorithm())
     }
 
     pub(crate) fn get_rsa(&self) -> Result<ConstPointer<RSA>, KeyRejected> {
-        self.project_const_lifetime(unsafe { |evp_pkey| EVP_PKEY_get0_RSA(*evp_pkey.as_const()) })
+        self.project_const_lifetime(unsafe { |evp_pkey| EVP_PKEY_get0_RSA(**evp_pkey) })
             .map_err(|()| KeyRejected::wrong_algorithm())
     }
 
@@ -116,43 +110,27 @@ impl LcPtr<EVP_PKEY> {
         // size in bytes for keys ranging from 2048-bit to 4096-bit. So size the initial capacity to be roughly
         // 500% as a conservative estimate to avoid needing to reallocate for any key in that range.
         let mut cbb = LcCBB::new(self.key_size_bytes() * 5);
-        if 1 != unsafe { EVP_marshal_public_key(cbb.as_mut_ptr(), *self.as_const()) } {
+        if 1 != unsafe { EVP_marshal_public_key(cbb.as_mut_ptr(), **self) } {
             return Err(Unspecified);
         }
         cbb.into_vec()
-    }
-
-    pub(crate) fn parse_rfc5280_public_key(
-        bytes: &[u8],
-        evp_pkey_type: c_int,
-    ) -> Result<Self, KeyRejected> {
-        let mut cbs = cbs::build_CBS(bytes);
-        // Also checks the validity of the key
-        let evp_pkey = LcPtr::new(unsafe { EVP_parse_public_key(&mut cbs) })
-            .map_err(|()| KeyRejected::invalid_encoding())?;
-        evp_pkey
-            .id()
-            .eq(&evp_pkey_type)
-            .then_some(evp_pkey)
-            .ok_or(KeyRejected::wrong_algorithm())
     }
 
     pub(crate) fn marshal_rfc5208_private_key(
         &self,
         version: Version,
     ) -> Result<Vec<u8>, Unspecified> {
-        let key_size_bytes = TryInto::<usize>::try_into(unsafe { EVP_PKEY_bits(*self.as_const()) })
-            .expect("fit in usize")
-            / 8;
+        let key_size_bytes =
+            TryInto::<usize>::try_into(unsafe { EVP_PKEY_bits(**self) }).expect("fit in usize") / 8;
         let mut cbb = LcCBB::new(key_size_bytes * 5);
         match version {
             Version::V1 => {
-                if 1 != unsafe { EVP_marshal_private_key(cbb.as_mut_ptr(), *self.as_const()) } {
+                if 1 != unsafe { EVP_marshal_private_key(cbb.as_mut_ptr(), **self) } {
                     return Err(Unspecified);
                 }
             }
             Version::V2 => {
-                if 1 != unsafe { EVP_marshal_private_key_v2(cbb.as_mut_ptr(), *self.as_const()) } {
+                if 1 != unsafe { EVP_marshal_private_key_v2(cbb.as_mut_ptr(), **self) } {
                     return Err(Unspecified);
                 }
             }
@@ -160,32 +138,9 @@ impl LcPtr<EVP_PKEY> {
         cbb.into_vec()
     }
 
-    pub(crate) fn parse_rfc5208_private_key(
-        bytes: &[u8],
-        evp_pkey_type: c_int,
-    ) -> Result<Self, KeyRejected> {
-        let mut cbs = cbs::build_CBS(bytes);
-        // Also checks the validity of the key
-        let evp_pkey = LcPtr::new(unsafe { EVP_parse_private_key(&mut cbs) })
-            .map_err(|()| KeyRejected::invalid_encoding())?;
-        evp_pkey
-            .id()
-            .eq(&evp_pkey_type)
-            .then_some(evp_pkey)
-            .ok_or(KeyRejected::wrong_algorithm())
-    }
-
-    #[allow(non_snake_case)]
-    pub(crate) fn create_EVP_PKEY_CTX(&self) -> Result<LcPtr<EVP_PKEY_CTX>, ()> {
-        // The only modification made by EVP_PKEY_CTX_new to `priv_key` is to increment its
-        // refcount. The modification is made while holding a global lock:
-        // https://github.com/aws/aws-lc/blob/61503f7fe72457e12d3446853a5452d175560c49/crypto/refcount_lock.c#L29
-        LcPtr::new(unsafe { EVP_PKEY_CTX_new(*self.as_mut_unsafe(), null_mut()) })
-    }
-
     pub(crate) fn marshal_raw_private_key(&self) -> Result<Vec<u8>, Unspecified> {
         let mut size = 0;
-        if 1 != unsafe { EVP_PKEY_get_raw_private_key(*self.as_const(), null_mut(), &mut size) } {
+        if 1 != unsafe { EVP_PKEY_get_raw_private_key(**self, null_mut(), &mut size) } {
             return Err(Unspecified);
         }
         let mut buffer = vec![0u8; size];
@@ -199,9 +154,7 @@ impl LcPtr<EVP_PKEY> {
         buffer: &mut [u8],
     ) -> Result<usize, Unspecified> {
         let mut key_len = buffer.len();
-        if 1 == unsafe {
-            EVP_PKEY_get_raw_private_key(*self.as_const(), buffer.as_mut_ptr(), &mut key_len)
-        } {
+        if 1 == unsafe { EVP_PKEY_get_raw_private_key(**self, buffer.as_mut_ptr(), &mut key_len) } {
             Ok(key_len)
         } else {
             Err(Unspecified)
@@ -211,7 +164,7 @@ impl LcPtr<EVP_PKEY> {
     #[allow(dead_code)]
     pub(crate) fn marshal_raw_public_key(&self) -> Result<Vec<u8>, Unspecified> {
         let mut size = 0;
-        if 1 != unsafe { EVP_PKEY_get_raw_public_key(*self.as_const(), null_mut(), &mut size) } {
+        if 1 != unsafe { EVP_PKEY_get_raw_public_key(**self, null_mut(), &mut size) } {
             return Err(Unspecified);
         }
         let mut buffer = vec![0u8; size];
@@ -229,12 +182,55 @@ impl LcPtr<EVP_PKEY> {
             // `EVP_PKEY_get_raw_public_key` writes the total length
             // to `encapsulate_key_size` in the event that the buffer we provide is larger then
             // required.
-            EVP_PKEY_get_raw_public_key(*self.as_const(), buffer.as_mut_ptr(), &mut key_len)
+            EVP_PKEY_get_raw_public_key(**self, buffer.as_mut_ptr(), &mut key_len)
         } {
             Ok(key_len)
         } else {
             Err(Unspecified)
         }
+    }
+
+}
+
+impl LcPtr<EVP_PKEY> {
+    pub(crate) fn parse_rfc5280_public_key(
+        bytes: &[u8],
+        evp_pkey_type: c_int,
+    ) -> Result<Self, KeyRejected> {
+        let mut cbs = cbs::build_CBS(bytes);
+        // Also checks the validity of the key
+        let evp_pkey = LcPtr::new(unsafe { EVP_parse_public_key(&mut cbs) })
+            .map_err(|()| KeyRejected::invalid_encoding())?;
+        evp_pkey
+            .as_const()
+            .id()
+            .eq(&evp_pkey_type)
+            .then_some(evp_pkey)
+            .ok_or(KeyRejected::wrong_algorithm())
+    }
+
+    pub(crate) fn parse_rfc5208_private_key(
+        bytes: &[u8],
+        evp_pkey_type: c_int,
+    ) -> Result<Self, KeyRejected> {
+        let mut cbs = cbs::build_CBS(bytes);
+        // Also checks the validity of the key
+        let evp_pkey = LcPtr::new(unsafe { EVP_parse_private_key(&mut cbs) })
+            .map_err(|()| KeyRejected::invalid_encoding())?;
+        evp_pkey
+            .as_const()
+            .id()
+            .eq(&evp_pkey_type)
+            .then_some(evp_pkey)
+            .ok_or(KeyRejected::wrong_algorithm())
+    }
+
+    #[allow(non_snake_case)]
+    pub(crate) fn create_EVP_PKEY_CTX(&self) -> Result<LcPtr<EVP_PKEY_CTX>, ()> {
+        // The only modification made by EVP_PKEY_CTX_new to `priv_key` is to increment its
+        // refcount. The modification is made while holding a global lock:
+        // https://github.com/aws/aws-lc/blob/61503f7fe72457e12d3446853a5452d175560c49/crypto/refcount_lock.c#L29
+        LcPtr::new(unsafe { EVP_PKEY_CTX_new(*self.as_mut_unsafe(), null_mut()) })
     }
 
     pub(crate) fn parse_raw_private_key(

--- a/aws-lc-rs/src/kem.rs
+++ b/aws-lc-rs/src/kem.rs
@@ -360,7 +360,8 @@ where
         let mut encapsulate_bytes = vec![0u8; self.algorithm.encapsulate_key_size()];
         let encapsulate_key_size = self
             .evp_pkey
-            .as_const().marshal_raw_public_to_buffer(&mut encapsulate_bytes)?;
+            .as_const()
+            .marshal_raw_public_to_buffer(&mut encapsulate_bytes)?;
 
         debug_assert_eq!(encapsulate_key_size, encapsulate_bytes.len());
         encapsulate_bytes.truncate(encapsulate_key_size);

--- a/aws-lc-rs/src/kem.rs
+++ b/aws-lc-rs/src/kem.rs
@@ -360,7 +360,7 @@ where
         let mut encapsulate_bytes = vec![0u8; self.algorithm.encapsulate_key_size()];
         let encapsulate_key_size = self
             .evp_pkey
-            .marshal_raw_public_to_buffer(&mut encapsulate_bytes)?;
+            .as_const().marshal_raw_public_to_buffer(&mut encapsulate_bytes)?;
 
         debug_assert_eq!(encapsulate_key_size, encapsulate_bytes.len());
         encapsulate_bytes.truncate(encapsulate_key_size);

--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -51,7 +51,8 @@ impl AsDer<Pkcs8V1Der<'static>> for PqdsaPrivateKey<'_> {
         Ok(Pkcs8V1Der::new(
             self.0
                 .evp_pkey
-                .as_const().marshal_rfc5208_private_key(pkcs8::Version::V1)?,
+                .as_const()
+                .marshal_rfc5208_private_key(pkcs8::Version::V1)?,
         ))
     }
 }
@@ -121,7 +122,9 @@ impl PqdsaKeyPair {
     /// Returns `Unspecified` if serialization fails.
     pub fn to_pkcs8(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 

--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -51,7 +51,7 @@ impl AsDer<Pkcs8V1Der<'static>> for PqdsaPrivateKey<'_> {
         Ok(Pkcs8V1Der::new(
             self.0
                 .evp_pkey
-                .marshal_rfc5208_private_key(pkcs8::Version::V1)?,
+                .as_const().marshal_rfc5208_private_key(pkcs8::Version::V1)?,
         ))
     }
 }
@@ -59,7 +59,7 @@ impl AsDer<Pkcs8V1Der<'static>> for PqdsaPrivateKey<'_> {
 impl AsRawBytes<PqdsaPrivateKeyRaw<'static>> for PqdsaPrivateKey<'_> {
     fn as_raw_bytes(&self) -> Result<PqdsaPrivateKeyRaw<'static>, Unspecified> {
         Ok(PqdsaPrivateKeyRaw::new(
-            self.0.evp_pkey.marshal_raw_private_key()?,
+            self.0.evp_pkey.as_const().marshal_raw_private_key()?,
         ))
     }
 }
@@ -121,7 +121,7 @@ impl PqdsaKeyPair {
     /// Returns `Unspecified` if serialization fails.
     pub fn to_pkcs8(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey.as_const().marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 

--- a/aws-lc-rs/src/pqdsa/signature.rs
+++ b/aws-lc-rs/src/pqdsa/signature.rs
@@ -47,7 +47,7 @@ unsafe impl Sync for PublicKey {}
 
 impl PublicKey {
     pub(crate) fn from_private_evp_pkey(evp_pkey: &LcPtr<EVP_PKEY>) -> Result<Self, Unspecified> {
-        let octets = evp_pkey.marshal_raw_public_key()?;
+        let octets = evp_pkey.as_const().marshal_raw_public_key()?;
         Ok(Self {
             evp_pkey: evp_pkey.clone(),
             octets: octets.into_boxed_slice(),
@@ -102,7 +102,7 @@ impl AsDer<PublicKeyX509Der<'static>> for PublicKey {
     /// # Errors
     /// Returns an error if the public key fails to marshal to X.509.
     fn as_der(&self) -> Result<PublicKeyX509Der<'static>, crate::error::Unspecified> {
-        let der = self.evp_pkey.marshal_rfc5280_public_key()?;
+        let der = self.evp_pkey.as_const().marshal_rfc5280_public_key()?;
         Ok(PublicKeyX509Der::from(Buffer::new(der)))
     }
 }

--- a/aws-lc-rs/src/rsa/encoding.rs
+++ b/aws-lc-rs/src/rsa/encoding.rs
@@ -21,7 +21,11 @@ pub(in crate::rsa) mod rfc8017 {
         let mut pubkey_bytes = null_mut::<u8>();
         let mut outlen: usize = 0;
         if 1 != unsafe {
-            RSA_public_key_to_bytes(&mut pubkey_bytes, &mut outlen, *pubkey.as_const().get_rsa()?)
+            RSA_public_key_to_bytes(
+                &mut pubkey_bytes,
+                &mut outlen,
+                *pubkey.as_const().get_rsa()?,
+            )
         } {
             return Err(Unspecified);
         }

--- a/aws-lc-rs/src/rsa/encoding.rs
+++ b/aws-lc-rs/src/rsa/encoding.rs
@@ -21,7 +21,7 @@ pub(in crate::rsa) mod rfc8017 {
         let mut pubkey_bytes = null_mut::<u8>();
         let mut outlen: usize = 0;
         if 1 != unsafe {
-            RSA_public_key_to_bytes(&mut pubkey_bytes, &mut outlen, *pubkey.get_rsa()?)
+            RSA_public_key_to_bytes(&mut pubkey_bytes, &mut outlen, *pubkey.as_const().get_rsa()?)
         } {
             return Err(Unspecified);
         }
@@ -85,7 +85,7 @@ pub(in crate::rsa) mod rfc5280 {
     pub(in crate::rsa) fn encode_public_key_der(
         key: &LcPtr<EVP_PKEY>,
     ) -> Result<PublicKeyX509Der<'static>, Unspecified> {
-        let der = key.marshal_rfc5280_public_key()?;
+        let der = key.as_const().marshal_rfc5280_public_key()?;
         Ok(PublicKeyX509Der::from(Buffer::new(der)))
     }
 

--- a/aws-lc-rs/src/rsa/encryption.rs
+++ b/aws-lc-rs/src/rsa/encryption.rs
@@ -44,7 +44,7 @@ impl PrivateDecryptingKey {
         if !is_rsa_key(key) {
             return Err(Unspecified);
         }
-        match key.key_size_bits() {
+        match key.as_const().key_size_bits() {
             2048..=8192 => Ok(()),
             _ => Err(Unspecified),
         }
@@ -105,13 +105,13 @@ impl PrivateDecryptingKey {
     /// Returns the RSA signature size in bytes.
     #[must_use]
     pub fn key_size_bytes(&self) -> usize {
-        self.0.signature_size_bytes()
+        self.0.as_const().signature_size_bytes()
     }
 
     /// Returns the RSA key size in bits.
     #[must_use]
     pub fn key_size_bits(&self) -> usize {
-        self.0.key_size_bits()
+        self.0.as_const().key_size_bits()
     }
 
     /// Retrieves the `PublicEncryptingKey` corresponding with this `PrivateDecryptingKey`.
@@ -133,7 +133,7 @@ impl Debug for PrivateDecryptingKey {
 impl AsDer<Pkcs8V1Der<'static>> for PrivateDecryptingKey {
     fn as_der(&self) -> Result<Pkcs8V1Der<'static>, Unspecified> {
         Ok(Pkcs8V1Der::new(
-            self.0.marshal_rfc5208_private_key(Version::V1)?,
+            self.0.as_const().marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 }
@@ -157,7 +157,7 @@ impl PublicEncryptingKey {
         if !is_rsa_key(key) {
             return Err(Unspecified);
         }
-        match key.key_size_bits() {
+        match key.as_const().key_size_bits() {
             2048..=8192 => Ok(()),
             _ => Err(Unspecified),
         }
@@ -174,13 +174,13 @@ impl PublicEncryptingKey {
     /// Returns the RSA signature size in bytes.
     #[must_use]
     pub fn key_size_bytes(&self) -> usize {
-        self.0.signature_size_bytes()
+        self.0.as_const().signature_size_bytes()
     }
 
     /// Returns the RSA key size in bits.
     #[must_use]
     pub fn key_size_bits(&self) -> usize {
-        self.0.key_size_bits()
+        self.0.as_const().key_size_bits()
     }
 }
 

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -175,7 +175,7 @@ impl KeyPair {
         if !is_rsa_key(key) {
             return Err(KeyRejected::unspecified());
         }
-        match key.key_size_bits() {
+        match key.as_const().key_size_bits() {
             2048..=8192 => Ok(()),
             _ => Err(KeyRejected::unspecified()),
         }
@@ -230,7 +230,7 @@ impl KeyPair {
     #[must_use]
     pub fn public_modulus_len(&self) -> usize {
         // This was already validated to be an RSA key so this can't fail
-        match self.evp_pkey.get_rsa() {
+        match self.evp_pkey.as_const().get_rsa() {
             Ok(rsa) => {
                 // https://github.com/awslabs/aws-lc/blob/main/include/openssl/rsa.h#L99
                 unsafe { RSA_size(*rsa) as usize }
@@ -260,7 +260,9 @@ impl crate::signature::KeyPair for KeyPair {
 impl AsDer<Pkcs8V1Der<'static>> for KeyPair {
     fn as_der(&self) -> Result<Pkcs8V1Der<'static>, Unspecified> {
         Ok(Pkcs8V1Der::new(
-            self.evp_pkey.marshal_rfc5208_private_key(Version::V1)?,
+            self.evp_pkey
+                .as_const()
+                .marshal_rfc5208_private_key(Version::V1)?,
         ))
     }
 }
@@ -291,6 +293,7 @@ impl PublicKey {
         let key = encoding::rfc8017::encode_public_key_der(evp_pkey)?;
         #[cfg(feature = "ring-io")]
         {
+            let evp_pkey = evp_pkey.as_const();
             let pubkey = evp_pkey.get_rsa()?;
             let modulus =
                 pubkey.project_const_lifetime(unsafe { |pubkey| RSA_get0_n(**pubkey) })?;
@@ -498,12 +501,13 @@ pub(super) fn generate_rsa_key(size: c_int) -> Result<LcPtr<EVP_PKEY>, Unspecifi
 #[must_use]
 pub(super) fn is_valid_fips_key(key: &LcPtr<EVP_PKEY>) -> bool {
     // This should always be an RSA key and must-never panic.
-    let rsa_key = key.get_rsa().expect("RSA EVP_PKEY");
+    let evp_pkey = key.as_const();
+    let rsa_key = evp_pkey.get_rsa().expect("RSA EVP_PKEY");
 
     1 == unsafe { RSA_check_fips(*rsa_key as *mut RSA) }
 }
 
 pub(super) fn is_rsa_key(key: &LcPtr<EVP_PKEY>) -> bool {
-    let id = key.id();
+    let id = key.as_const().id();
     id == EVP_PKEY_RSA || id == EVP_PKEY_RSA_PSS
 }

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -109,7 +109,7 @@ impl RsaParameters {
     /// `error::Unspecified` on parse error.
     pub fn public_modulus_len(public_key: &[u8]) -> Result<u32, Unspecified> {
         let rsa = encoding::rfc8017::decode_public_key_der(public_key)?;
-        Ok(unsafe { RSA_bits(*rsa.get_rsa()?) })
+        Ok(unsafe { RSA_bits(*rsa.as_const().get_rsa()?) })
     }
 
     #[must_use]
@@ -222,7 +222,7 @@ pub(crate) fn verify_rsa_signature(
     signature: &[u8],
     allowed_bit_size: &RangeInclusive<u32>,
 ) -> Result<(), Unspecified> {
-    if !allowed_bit_size.contains(&public_key.key_size_bits().try_into()?) {
+    if !allowed_bit_size.contains(&public_key.as_const().key_size_bits().try_into()?) {
         return Err(Unspecified);
     }
 


### PR DESCRIPTION
### Description of changes: 
* Use lifetimes to prevent a "child" object being used after its "parent" is out of scope.
* Move most non-mutating functionality from `LcPtr<EVP_PKEY>` to `ConstPointer<'_, EVP_PKEY>`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
