### PR TITLE
Build script handling of OPT_LEVEL='s'

### DIFF
--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -126,7 +126,11 @@ impl CmakeBuilder {
             if opt_level.eq("1") || opt_level.eq("2") {
                 cmake_cfg.define("CMAKE_BUILD_TYPE", "relwithdebinfo");
             } else {
-                cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
+                if opt_level.eq("s") || opt_level.eq("z") {
+                    cmake_cfg.define("CMAKE_BUILD_TYPE", "minsizerel");
+                } else {
+                    cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
+                }
                 // TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
                 // assembly files and its custom compilation commands within CMake), not all
                 // source paths are stripped from the resulting binary.

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -112,6 +112,8 @@ impl CmakeBuilder {
         if opt_level.ne("0") {
             if opt_level.eq("1") || opt_level.eq("2") {
                 cmake_cfg.define("CMAKE_BUILD_TYPE", "relwithdebinfo");
+            } else if opt_level.eq("s") || opt_level.eq("z") {
+                cmake_cfg.define("CMAKE_BUILD_TYPE", "minsizerel");
             } else {
                 cmake_cfg.define("CMAKE_BUILD_TYPE", "release");
             }


### PR DESCRIPTION
### Issues:
Addresses #691

### Description of changes: 
Improve handling of size-optimized builds, specifically, [opt-levels "s" and "z"](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
