### PR TITLE
Implement From<&PublicKey> for PublicKeyComponents

### DIFF
--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -430,6 +430,7 @@ where
     }
 }
 
+#[cfg(feature = "ring-io")]
 impl From<&PublicKey> for PublicKeyComponents<&[u8]> {
     fn from(public_key: &PublicKey) -> Self {
         PublicKeyComponents {

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -430,6 +430,15 @@ where
     }
 }
 
+impl From<&PublicKey> for PublicKeyComponents<&[u8]> {
+    fn from(public_key: &PublicKey) -> Self {
+        PublicKeyComponents {
+            n: public_key.modulus.as_ref(),
+            e: public_key.exponent.as_ref(),
+        }
+    }
+}
+
 impl<B> TryInto<PublicEncryptingKey> for PublicKeyComponents<B>
 where
     B: AsRef<[u8]> + Debug,

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -338,6 +338,11 @@ impl PublicKey {
     pub fn exponent(&self) -> io::Positive<'_> {
         io::Positive::new_non_empty_without_leading_zeros(Input::from(self.exponent.as_ref()))
     }
+
+    /// Returns the length in bytes of the public modulus.
+    pub fn modulus_len(&self) -> usize {
+        self.modulus.len()
+    }
 }
 
 /// Low-level API for RSA public keys.
@@ -431,11 +436,11 @@ where
 }
 
 #[cfg(feature = "ring-io")]
-impl From<&PublicKey> for PublicKeyComponents<&[u8]> {
+impl From<&PublicKey> for PublicKeyComponents<Vec<u8>> {
     fn from(public_key: &PublicKey) -> Self {
         PublicKeyComponents {
-            n: public_key.modulus.as_ref(),
-            e: public_key.exponent.as_ref(),
+            n: public_key.modulus.to_vec(),
+            e: public_key.exponent.to_vec(),
         }
     }
 }


### PR DESCRIPTION
### Issues:

Addresses #697

### Description of changes: 

Add conversion from `&PublicKey` to `PublicKeyComponents<&[u8]>`. Seems pretty straightforward?

(I looked at the minor issue as well, but I'm not sure how to compute the correct `public_modulus_len()` from the decomposed `modulus`.)

### Testing:

No tests yet -- let me know if/where I should add some test coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.