### PR TITLE
Exclude Rust scripts from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,13 @@ members = [
     "aws-lc-sys",
     "aws-lc-fips-sys",
     "aws-lc-rs-testing",
-    "links-testing"
+    "links-testing",
+]
+exclude = [
+    "scripts/tools/cargo-dig.rs",
+    "scripts/tools/semver.rs",
+    "scripts/tools/target-platform.rs",
+    "scripts/tests/assert_cpu_jitter_entropy.rs",
 ]
 resolver = "2"
 


### PR DESCRIPTION
### Description of changes: 
Exclude Rust scripts from workspace to avoid failure.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
