### PR TITLE
Support PKCS8 in agreement::PrivateKey::from_private_key_der

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.12.4"
+version = "1.12.5"
 # this crate re-exports whatever sys crate that was selected
-links = "aws_lc_rs_1_12_4_sys"
+links = "aws_lc_rs_1_12_5_sys"
 edition = "2021"
 rust-version = "1.63.0"
 keywords = ["crypto", "cryptography", "security"]

--- a/aws-lc-rs/src/key_wrap.rs
+++ b/aws-lc-rs/src/key_wrap.rs
@@ -74,14 +74,12 @@ pub struct AesBlockCipher {
 impl BlockCipher for AesBlockCipher {
     /// Returns the algorithm identifier.
     #[inline]
-    #[must_use]
     fn id(&self) -> BlockCipherId {
         self.id
     }
 
     /// Returns the algorithm key length.
     #[inline]
-    #[must_use]
     fn key_len(&self) -> usize {
         self.key_len
     }


### PR DESCRIPTION
### Description of changes: 
* Recent refactoring dropped support for parsing PKCS8 from `agreement::PrivateKey::from_private_key_der`.  This PR restores that support.
* Bump version to 1.12.5

### Call-outs:
* We had no function to serialize an ECDH private key to PKCS8. In order to test this, this functionality needed to be added.

### Testing:
* Updated test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
