### PR TITLE
Run compiler tests on ubuntu-22.04

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -50,8 +50,10 @@ jobs:
           rm powershell_7.2.23-1.deb_amd64.deb
       - name: Checkout
         run: |
+          mkdir -p /tmp/aws-lc-rs
           git config --global --add safe.directory '*'
-          git clone --recursive ${{ github.server_url }}/${{ github.repository }}.git .
+          git clone --recursive ${{ github.server_url }}/${{ github.repository }}.git /tmp/aws-lc-rs
+          cd /tmp/aws-lc-rs
           git fetch origin ${{ github.sha }}
           git checkout --recurse-submodules -b ci-job ${{ github.sha }}
       - uses: dtolnay/rust-toolchain@master
@@ -64,30 +66,34 @@ jobs:
           version: ${{ matrix.gcc_version }}
           platform: x64
       - name: Run cargo test (debug)
+        working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       - name: Run cargo test (release)
+        working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --release --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       # The steps below verify that we're successfully using `-ffile-prefix-map`
       # to remove build environment paths from the resulting library.
       - if: ${{ matrix.gcc_version == '8' }}
+        working-directory: /tmp/aws-lc-rs/
         name: Verify paths found in debug build
         run: |
           DEBUG_LIBCRYPTO=$(find ./target/debug -name "libaws_lc_*_crypto.a")
-          if strings ${DEBUG_LIBCRYPTO} | grep '/__w/aws-lc-rs'; then 
+          if strings ${DEBUG_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then 
             exit 0; # SUCCESS
           else
             strings ${DEBUG_LIBCRYPTO}
-            exit 1; # FAIL - we expected to find "/__w/aws-lc-rs"  (i.e., a path)
+            exit 1; # FAIL - we expected to find "/tmp/aws-lc-rs/"  (i.e., a path)
           fi
       # TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
       # assembly files and its custom compilation commands within CMake), not all
       # source paths are stripped from the resulting binary.
       - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
+        working-directory: /tmp/aws-lc-rs/
         name: Verify paths not found in release build
         run: |
           RELEASE_LIBCRYPTO=$(find ./target/release -name "libaws_lc_*_crypto.a")
-          if strings ${RELEASE_LIBCRYPTO} | grep '/__w/aws-lc-rs'; then 
-            exit 1; # FAIL - we did not expect to find "/__w/aws-lc-rs" (i.e., a path)
+          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then 
+            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
           else
             exit 0; # SUCCESS
           fi

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -35,9 +35,25 @@ jobs:
         gcc_version: [ '7', '8' ]
         fips: [ '0', '1' ]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
+      - run: |
+          apt-get update
+          apt-get install -y ca-certificates
+          apt-get install -y cmake curl sudo
+          apt-get install -y --no-install-recommends gpg-agent software-properties-common
+          apt-add-repository --yes ppa:git-core/ppa
+          add-apt-repository --yes ppa:longsleep/golang-backports
+          apt-get update
+          apt-get install -y build-essential git golang-go
+          curl -L -O -J https://github.com/PowerShell/PowerShell/releases/download/v7.2.23/powershell_7.2.23-1.deb_amd64.deb
+          dpkg -i powershell_7.2.23-1.deb_amd64.deb
+          apt-get install -f
+          rm powershell_7.2.23-1.deb_amd64.deb
+      - name: Checkout
+        run: |
+          git config --global --add safe.directory '*'
+          git clone --recursive ${{ github.server_url }}/${{ github.repository }}.git .
+          git fetch origin ${{ github.sha }}
+          git checkout --recurse-submodules -b ci-job ${{ github.sha }}
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
@@ -47,10 +63,6 @@ jobs:
         with:
           version: ${{ matrix.gcc_version }}
           platform: x64
-      - if: matrix.fips == '1'
-        uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
       - name: Run cargo test (debug)
         run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       - name: Run cargo test (release)
@@ -61,10 +73,11 @@ jobs:
         name: Verify paths found in debug build
         run: |
           DEBUG_LIBCRYPTO=$(find ./target/debug -name "libaws_lc_*_crypto.a")
-          if strings ${DEBUG_LIBCRYPTO} | grep runner; then 
+          if strings ${DEBUG_LIBCRYPTO} | grep '/__w/aws-lc-rs'; then 
             exit 0; # SUCCESS
           else
-            exit 1; # FAIL - we expected to find "runner"  (i.e., a path)
+            strings ${DEBUG_LIBCRYPTO}
+            exit 1; # FAIL - we expected to find "/__w/aws-lc-rs"  (i.e., a path)
           fi
       # TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
       # assembly files and its custom compilation commands within CMake), not all
@@ -73,8 +86,8 @@ jobs:
         name: Verify paths not found in release build
         run: |
           RELEASE_LIBCRYPTO=$(find ./target/release -name "libaws_lc_*_crypto.a")
-          if strings ${RELEASE_LIBCRYPTO} | grep runner; then 
-            exit 1; # FAIL - we did not expect to find "runner" (i.e., a path)
+          if strings ${RELEASE_LIBCRYPTO} | grep '/__w/aws-lc-rs'; then 
+            exit 1; # FAIL - we did not expect to find "/__w/aws-lc-rs" (i.e., a path)
           else
             exit 0; # SUCCESS
           fi

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -23,7 +23,9 @@ jobs:
   aws-lc-rs-2004-gcc:
     if: github.repository_owner == 'aws'
     name: GCC ${{ matrix.gcc_version }} - CMake ${{ matrix.cmake }} - FIPS ${{ matrix.fips }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
     env:
       AWS_LC_SYS_CMAKE_BUILDER: ${{ matrix.cmake }}
     strategy:
@@ -80,7 +82,7 @@ jobs:
   aws-lc-rs-1804-gcc:
     if: github.repository_owner == 'aws'
     name: GCC ${{ matrix.gcc_version }} - CMake ${{ matrix.cmake }} - FIPS ${{ matrix.fips }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: ubuntu:18.04
     env:

--- a/aws-lc-rs/src/agreement.rs
+++ b/aws-lc-rs/src/agreement.rs
@@ -55,11 +55,11 @@ use crate::ec::encoding::sec1::{
     marshal_sec1_private_key, marshal_sec1_public_point, marshal_sec1_public_point_into_buffer,
     parse_sec1_private_bn,
 };
-use crate::ec::{encoding, evp_key_generate, };
-#[cfg(not(feature = "fips"))]
-use crate::ec::verify_evp_key_nid;
 #[cfg(feature = "fips")]
 use crate::ec::validate_evp_key;
+#[cfg(not(feature = "fips"))]
+use crate::ec::verify_evp_key_nid;
+use crate::ec::{encoding, evp_key_generate};
 use crate::error::{KeyRejected, Unspecified};
 use crate::hex;
 use crate::ptr::ConstPointer;

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -285,8 +285,8 @@ impl CcBuilder {
             emit_warning("######");
             emit_warning("###### WARNING: MISSING GIT SUBMODULE ######");
             emit_warning(&format!(
-                "  -- Did you initialize the repo's git submodules? Unable to find source file: {:?}.",
-                &source_file
+                "  -- Did you initialize the repo's git submodules? Unable to find source file: {}.",
+                source_file.display()
             ));
             emit_warning("  -- run 'git submodule update --init --recursive' to initialize.");
             emit_warning("######");
@@ -310,7 +310,7 @@ impl CcBuilder {
             ret_val = true;
         }
         if fs::remove_dir_all(&output_dir).is_err() {
-            emit_warning(&format!("Failed to remove {:?}", &output_dir));
+            emit_warning(&format!("Failed to remove {}", output_dir.display()));
         }
         emit_warning(&format!(
             "Compilation of '{basename}.c' {} - {:?}.",
@@ -354,14 +354,14 @@ impl CcBuilder {
             execute_command(memcmp_compiler.path().as_os_str(), memcmp_args.as_slice());
         assert!(
             memcmp_compile_result.status,
-            "COMPILER: {:?}\
+            "COMPILER: {}\
             ARGS: {:?}\
             EXECUTED: {}\
             ERROR: {}\
             OUTPUT: {}\
             Failed to compile {basename}
             ",
-            memcmp_compiler.path(),
+            memcmp_compiler.path().display(),
             memcmp_args.as_slice(),
             memcmp_compile_result.executed,
             memcmp_compile_result.stderr,

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -616,8 +616,8 @@ fn main() {
             emit_warning("######");
             emit_warning("###### WARNING: MISSING GIT SUBMODULE ######");
             emit_warning(&format!(
-                "  -- Did you initialize the repo's git submodules? Unable to find crypto directory: {:?}.",
-                &aws_lc_crypto_dir
+                "  -- Did you initialize the repo's git submodules? Unable to find crypto directory: {}.",
+                &aws_lc_crypto_dir.display()
             ));
             emit_warning("  -- run 'git submodule update --init --recursive' to initialize.");
             emit_warning("######");


### PR DESCRIPTION

### Description of changes: 
* GH has deprecated their ubuntu-20.04 runner images.
* This change migrates the jobs to run on an Ubuntu 20.04 docker image running on Ubuntu 22.04.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
