### PR TITLE
[DRAFT] Migrate from paste

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -76,7 +76,7 @@ bindgen = { version = "0.69.5", optional = true }
 bindgen = { version = "0.69.5" }
 
 [dependencies]
-paste = "1.0.11"
+concat-idents = "1.1.5"
 
 [dev-dependencies]
 # Pinned dependency to preserve MSRV: 1.60.0  <= rust-version < 1.65.0

--- a/aws-lc-fips-sys/src/lib.rs
+++ b/aws-lc-fips-sys/src/lib.rs
@@ -4,26 +4,23 @@
 #![cfg_attr(not(clippy), allow(unexpected_cfgs))]
 #![cfg_attr(not(clippy), allow(unknown_lints))]
 
-use paste::paste;
+use concat_idents::concat_idents;
 use std::os::raw::{c_char, c_long, c_void};
-
-#[allow(unused_macros)]
-macro_rules! use_bindings {
-    ($bindings:ident) => {
-        mod $bindings;
-        pub use $bindings::*;
-    };
-}
 
 macro_rules! platform_binding {
     ($platform:ident) => {
-        paste! {
+        concat_idents!(bindings_name = $platform, _, crypto {
             #[cfg(all($platform, not(feature = "ssl"), not(use_bindgen_generated)))]
-            use_bindings!([< $platform _crypto >]);
-
+            mod bindings_name;
+            #[cfg(all($platform, not(feature = "ssl"), not(use_bindgen_generated)))]
+            pub use bindings_name::*;
+        });
+        concat_idents!(bindings_name = $platform, _, crypto, _, ssl {
             #[cfg(all($platform, feature = "ssl", not(use_bindgen_generated)))]
-            use_bindings!([< $platform _crypto_ssl >]);
-        }
+            mod bindings_name;
+            #[cfg(all($platform, feature = "ssl", not(use_bindgen_generated)))]
+            pub use bindings_name::*;
+        });
     };
 }
 

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -50,7 +50,7 @@ untrusted = { version = "0.7.1", optional = true }
 aws-lc-sys = { version = "0.27.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.13.1", path = "../aws-lc-fips-sys", optional = true }
 zeroize = "1.7"
-paste = "1.0.11"
+concat-idents = "1.1.5"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/aws-lc-rs/src/aead/rand_nonce.rs
+++ b/aws-lc-rs/src/aead/rand_nonce.rs
@@ -151,7 +151,7 @@ mod tests {
     use super::{Aad, RandomizedNonceKey};
     use crate::aead::{AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305};
     use crate::test::from_hex;
-    use paste::paste;
+    use concat_idents::concat_idents;
 
     const TEST_128_BIT_KEY: &[u8] = &[
         0xb0, 0x37, 0x9f, 0xf8, 0xfb, 0x8e, 0xa6, 0x31, 0xf4, 0x1c, 0xe6, 0x3e, 0xb5, 0xc5, 0x20,
@@ -166,17 +166,18 @@ mod tests {
 
     macro_rules! test_randnonce {
         ($name:ident, $alg:expr, $key:expr) => {
-            paste! {
+           concat_idents!(test_name_unsupported = test_, $name, _randnonce_unsupported {
                 #[test]
-                fn [<test_ $name _randnonce_unsupported>]() {
+                fn test_name_unsupported() {
                     assert!(RandomizedNonceKey::new($alg, $key).is_err());
                 }
-            }
+            });
         };
+
         ($name:ident, $alg:expr, $key:expr, $expect_tag_len:expr, $expect_nonce_len:expr) => {
-            paste! {
+            concat_idents!(test_name = test_, $name, _randnonce {
                 #[test]
-                fn [<test_ $name _randnonce>]() {
+                fn test_name() {
                     let plaintext = from_hex("00112233445566778899aabbccddeeff").unwrap();
                     let rand_nonce_key =
                         RandomizedNonceKey::new($alg, $key).unwrap();
@@ -215,7 +216,7 @@ mod tests {
 
                     assert_eq!(plaintext, in_out[..plaintext.len()]);
                 }
-            }
+            });
         };
     }
 

--- a/aws-lc-rs/src/aead/tls.rs
+++ b/aws-lc-rs/src/aead/tls.rs
@@ -298,7 +298,7 @@ mod tests {
     use super::{TlsProtocolId, TlsRecordOpeningKey, TlsRecordSealingKey};
     use crate::aead::{Aad, Nonce, AES_128_GCM, AES_256_GCM, CHACHA20_POLY1305};
     use crate::test::from_hex;
-    use paste::paste;
+    use concat_idents::concat_idents;
 
     const TEST_128_BIT_KEY: &[u8] = &[
         0xb0, 0x37, 0x9f, 0xf8, 0xfb, 0x8e, 0xa6, 0x31, 0xf4, 0x1c, 0xe6, 0x3e, 0xb5, 0xc5, 0x20,
@@ -333,18 +333,18 @@ mod tests {
 
     macro_rules! test_tls_aead {
         ($name:ident, $alg:expr, $proto:expr, $key:expr) => {
-            paste! {
+            concat_idents!( test_name = test_, $name, _tls_aead_unsupported {
                 #[test]
-                fn [<test_ $name _tls_aead_unsupported>]() {
+                fn test_name() {
                     assert!(TlsRecordSealingKey::new($alg, $proto, $key).is_err());
                     assert!(TlsRecordOpeningKey::new($alg, $proto, $key).is_err());
                 }
-            }
+            });
         };
         ($name:ident, $alg:expr, $proto:expr, $key:expr, $expect_tag_len:expr, $expect_nonce_len:expr) => {
-            paste! {
+           concat_idents!( test_name = test_, $name {
                 #[test]
-                fn [<test_ $name>]() {
+                fn test_name() {
                     let mut sealing_key =
                         TlsRecordSealingKey::new($alg, $proto, $key).unwrap();
 
@@ -403,7 +403,7 @@ mod tests {
                         assert_eq!(plaintext, offset_cipher_text[..plaintext.len()]);
                     }
                 }
-            }
+            });
         };
     }
 

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -507,7 +507,7 @@ mod tests {
     use crate::iv::{FixedLength, IV_LEN_128_BIT};
     use crate::rand::{SecureRandom, SystemRandom};
     use crate::test::from_hex;
-    use paste::*;
+    use concat_idents::concat_idents;
 
     fn step_encrypt(
         mut encrypting_key: StreamingEncryptingKey,
@@ -608,8 +608,8 @@ mod tests {
 
     macro_rules! helper_stream_step_encrypt_test {
         ($mode:ident) => {
-            paste! {
-                fn [<helper_test_ $mode _stream_encrypt_step_n_bytes>](
+            concat_idents!(test_name = helper_test_, $mode, _stream_encrypt_step_n_bytes {
+                fn test_name(
                     encrypting_key_creator: impl Fn() -> StreamingEncryptingKey,
                     decrypting_key_creator: impl Fn(DecryptionContext) -> StreamingDecryptingKey,
                     n: usize,
@@ -629,7 +629,7 @@ mod tests {
 
                     assert_eq!(input.as_slice(), &*plaintext);
                 }
-            }
+            });
         };
     }
 

--- a/aws-lc-rs/src/encoding.rs
+++ b/aws-lc-rs/src/encoding.rs
@@ -4,25 +4,29 @@
 //! Serialization formats
 
 use crate::buffer::Buffer;
-use paste::paste;
 
 macro_rules! generated_encodings {
-    ($($name:ident),*) => { paste! {
+    ($($name:ident),*) => {
+
         use core::fmt::{Debug, Error, Formatter};
         use core::ops::Deref;
         mod buffer_type {
-            $(
-                pub struct [<$name Type>] {
-                    _priv: (),
-                }
-            )*
-        }
         $(
+            concat_idents::concat_idents!( name_type = $name,  Type {
+                    pub struct name_type {
+                        _priv: (),
+                    }
+            });
+        )*
+        }
+
+        $(
+        concat_idents::concat_idents!( name_type = $name,  Type {
             /// Serialized bytes
-            pub struct $name<'a>(Buffer<'a, buffer_type::[<$name Type>]>);
+            pub struct $name<'a>(Buffer<'a, buffer_type::name_type>);
 
             impl<'a> Deref for $name<'a> {
-                type Target = Buffer<'a, buffer_type::[<$name Type>]>;
+                type Target = Buffer<'a, buffer_type::name_type>;
 
                 fn deref(&self) -> &Self::Target {
                     &self.0
@@ -46,13 +50,15 @@ macro_rules! generated_encodings {
                 }
             }
 
-            impl<'a> From<Buffer<'a, buffer_type::[<$name Type>]>> for $name<'a> {
-                fn from(value: Buffer<'a, buffer_type::[<$name Type>]>) -> Self {
+            impl<'a> From<Buffer<'a, buffer_type::name_type>> for $name<'a> {
+                fn from(value: Buffer<'a, buffer_type::name_type>) -> Self {
                     Self(value)
                 }
             }
+
+        });
         )*
-    }}
+    }
 }
 pub(crate) use generated_encodings;
 generated_encodings!(

--- a/aws-lc-rs/src/kem.rs
+++ b/aws-lc-rs/src/kem.rs
@@ -289,8 +289,6 @@ where
     }
 }
 
-use paste::paste;
-
 generated_encodings!(EncapsulationKeyBytes);
 
 /// A serializable encapsulation key usable with KEM algorithms. Constructed

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -8,7 +8,7 @@ use aws_lc_rs::cipher::{
 };
 use aws_lc_rs::iv::{FixedLength, IV_LEN_128_BIT};
 use aws_lc_rs::test::from_hex;
-use paste::paste;
+use concat_idents::concat_idents;
 
 fn step_encrypt(
     mut encrypting_key: StreamingEncryptingKey,
@@ -111,9 +111,9 @@ fn step_decrypt(
 
 macro_rules! streaming_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal, $from_step:literal, $to_step:literal) => {
-        paste! {
+        concat_idents!( test_name = $name, _streaming {
         #[test]
-        fn [<$name _streaming>]() {
+        fn test_name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
 
@@ -131,15 +131,15 @@ macro_rules! streaming_cipher_rt {
                 assert_eq!(input.as_slice(), plaintext.as_ref());
             }
         }
-        }
+        });
     };
 }
 
 macro_rules! streaming_ecb_pkcs7_rt {
     ($name:ident, $alg:expr, $key:literal, $plaintext:literal, $from_step:literal, $to_step:literal) => {
-        paste! {
+        concat_idents!( test_name = $name, _streaming {
         #[test]
-        fn [<$name _streaming>]() {
+        fn test_name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
 
@@ -157,15 +157,15 @@ macro_rules! streaming_ecb_pkcs7_rt {
                 assert_eq!(input.as_slice(), plaintext.as_ref());
             }
         }
-        }
+        });
     };
 }
 
 macro_rules! streaming_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv: literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
-        paste! {
+        concat_idents!( test_name = $name, _streaming {
         #[test]
-        fn [<$name _streaming>]() {
+        fn test_name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
             let expected_ciphertext = from_hex($ciphertext).unwrap();
@@ -175,10 +175,10 @@ macro_rules! streaming_cipher_kat {
                 let ec = EncryptionContext::Iv128(
                     FixedLength::<IV_LEN_128_BIT>::try_from(iv.as_slice()).unwrap(),
                 );
-
+                concat_idents!( less_safe_constructor = less_safe_, $constructor {
                 let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
-                    let encrypting_key = StreamingEncryptingKey::[<less_safe_ $constructor>](unbound_key, ec).unwrap();
-
+                    let encrypting_key = StreamingEncryptingKey::less_safe_constructor(unbound_key, ec).unwrap();
+                });
                 let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
 
                 assert_eq!(expected_ciphertext.as_slice(), ciphertext.as_ref());
@@ -191,15 +191,15 @@ macro_rules! streaming_cipher_kat {
                 assert_eq!(input.as_slice(), plaintext.as_ref());
             }
         }
-        }
+        });
     };
 }
 
 macro_rules! streaming_ecb_pkcs7_kat {
     ($name:ident, $alg:expr, $key:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
-        paste! {
+        concat_idents!( test_name = $name, _streaming {
         #[test]
-        fn [<$name _streaming>]() {
+        fn test_name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
             let expected_ciphertext = from_hex($ciphertext).unwrap();
@@ -220,7 +220,7 @@ macro_rules! streaming_ecb_pkcs7_kat {
                 assert_eq!(input.as_slice(), plaintext.as_ref());
             }
         }
-        }
+        });
     };
 }
 

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -68,7 +68,7 @@ bindgen = { version = "0.69.5", optional = true }
 bindgen = { version = "0.69.5" }
 
 [dependencies]
-paste = "1.0.11"
+concat-idents = "1.1.5"
 
 [package.metadata.aws-lc-sys]
 commit-hash = "d0356099f6b668697cdb381dfb09f9a694a6c9c2"

--- a/aws-lc-sys/src/lib.rs
+++ b/aws-lc-sys/src/lib.rs
@@ -4,23 +4,23 @@
 #![cfg_attr(not(clippy), allow(unexpected_cfgs))]
 #![cfg_attr(not(clippy), allow(unknown_lints))]
 
-use paste::paste;
+use concat_idents::concat_idents;
 use std::os::raw::{c_char, c_long, c_void};
-
-#[allow(unused_macros)]
-macro_rules! use_bindings {
-    ($bindings:ident) => {
-        mod $bindings;
-        pub use $bindings::*;
-    };
-}
 
 macro_rules! platform_binding {
     ($platform:ident) => {
-        paste! {
+        concat_idents!(bindings_name = $platform, _, crypto {
             #[cfg(all($platform, not(feature = "ssl"), not(use_bindgen_generated)))]
-            use_bindings!([< $platform _crypto >]);
-        }
+            mod bindings_name;
+            #[cfg(all($platform, not(feature = "ssl"), not(use_bindgen_generated)))]
+            pub use bindings_name::*;
+        });
+        concat_idents!(bindings_name = $platform, _, crypto, _, ssl {
+            #[cfg(all($platform, feature = "ssl", not(use_bindgen_generated)))]
+            mod bindings_name;
+            #[cfg(all($platform, feature = "ssl", not(use_bindgen_generated)))]
+            pub use bindings_name::*;
+        });
     };
 }
 


### PR DESCRIPTION
### Issues:
Addresses:
* #722 

### Context
The paste crate is [no longer maintained](https://github.com/dtolnay/paste).

### Description of changes: 
Migrate use of "paste" to [concat-idents](https://crates.io/crates/concat-idents).

### Callouts
* Usage of the macros is nearly identical, except the constructed identity could not be used in another macro call to (e.g) `stringify!` or `use_bindings!`. Adjustments made accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
