### PR TITLE
Fix CMake submodule warning

### DIFF
--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -29,7 +29,7 @@ if (BUILD_SHARED_LIBS AND FIPS)
 endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
-if(NOT EXISTS aws-lc/CMakeLists.txt)
+if(NOT EXISTS "${AWS_LC_RUST_SOURCE_DIR}/aws-lc/CMakeLists.txt")
 message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.\n -- run 'git submodule update --init --recursive' to initialize.")
 endif()
 

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -25,7 +25,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 add_subdirectory(aws-lc aws-lc EXCLUDE_FROM_ALL)
-if(NOT EXISTS aws-lc/CMakeLists.txt)
+if(NOT EXISTS "${AWS_LC_RUST_SOURCE_DIR}/aws-lc/CMakeLists.txt")
 message(WARNING "###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's git submodules? CMakeLists.txt not found.\n -- run 'git submodule update --init --recursive' to initialize.")
 endif()
 


### PR DESCRIPTION
### Description of changes: 
Fix submodule warning that displays on failed CMake build

### Testing
```
aws-lc-rs on  main via 🦀 v1.85.0
at 15:33:13 ❯ cargo clean && AWS_LC_SYS_CMAKE_BUILDER=1 cargo -vv build -p aws-lc-sys 2>&1 | grep 'MISSING GIT SUBMODULE'
     Removed 0 files
[aws-lc-sys 0.27.0]   ###### WARNING: MISSING GIT SUBMODULE ###### Did you initialize the repo's

aws-lc-rs on  main via 🦀 v1.85.0 took 11s
at 15:33:30 ❯ git checkout fix-cmake-submod-warning
Switched to branch 'fix-cmake-submod-warning'

aws-lc-rs on  fix-cmake-submod-warning via 🦀 v1.85.0
at 15:33:41 ❯ cargo clean && AWS_LC_SYS_CMAKE_BUILDER=1 cargo -vv build -p aws-lc-sys 2>&1 | grep 'MISSING GIT SUBMODULE'
     Removed 1032 files, 107.1MiB total
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
