### PR TITLE
Bump aws-lc-fips-sys to v0.13.4

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aws-lc-fips-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. This is the FIPS validated version of AWS-LC."
-version = "0.13.3"
-links = "aws_lc_fips_0_13_3"
+version = "0.13.4"
+links = "aws_lc_fips_0_13_4"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols.h
@@ -17,7 +17,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_H	
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_13_3
+#define BORINGSSL_PREFIX aws_lc_fips_0_13_4
 #endif // BORINGSSL_PREFIX
 
 

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_asm.h
@@ -20,7 +20,7 @@
 #define BORINGSSL_PREFIX_SYMBOLS_ASM_H
 
 #ifndef BORINGSSL_PREFIX
-#define BORINGSSL_PREFIX aws_lc_fips_0_13_3
+#define BORINGSSL_PREFIX aws_lc_fips_0_13_4
 #endif // BORINGSSL_PREFIX
 
 // On iOS and macOS, we need to treat assembly symbols differently from other

--- a/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
+++ b/aws-lc-fips-sys/generated-include/openssl/boringssl_prefix_symbols_nasm.inc
@@ -17,7 +17,7 @@
 %define BORINGSSL_PREFIX_SYMBOLS_NASM_INC
 
 %ifndef BORINGSSL_PREFIX
-%define BORINGSSL_PREFIX aws_lc_fips_0_13_3
+%define BORINGSSL_PREFIX aws_lc_fips_0_13_4
 %endif ; BORINGSSL_PREFIX
 
 ; 32-bit Windows adds underscores to C functions, while 64-bit Windows does not.

--- a/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_apple_darwin_crypto.rs
@@ -4553,7 +4553,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4561,7 +4561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4569,15 +4569,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4589,7 +4589,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4598,7 +4598,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4609,7 +4609,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4620,7 +4620,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4632,7 +4632,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4642,7 +4642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4652,7 +4652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4663,7 +4663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5210,27 +5210,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5238,29 +5238,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5268,7 +5268,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5276,11 +5276,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5288,15 +5288,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5383,11 +5383,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5395,19 +5395,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5415,19 +5415,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5525,11 +5525,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5537,19 +5537,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5557,15 +5557,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5663,11 +5663,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5675,19 +5675,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5695,42 +5695,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_calloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5738,62 +5738,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isalpha"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isalnum"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isspace"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5801,7 +5801,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5810,7 +5810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5819,7 +5819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5827,7 +5827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5835,21 +5835,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5857,7 +5857,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5865,7 +5865,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5873,7 +5873,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5882,7 +5882,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5890,11 +5890,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5921,45 +5921,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5972,7 +5972,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5986,7 +5986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5997,29 +5997,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6075,7 +6075,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6086,7 +6086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6099,7 +6099,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6111,7 +6111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6120,7 +6120,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6131,7 +6131,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6141,38 +6141,38 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_armv8_disable_dit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_armv8_disable_dit"]
     pub fn armv8_disable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_armv8_enable_dit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_armv8_enable_dit"]
     pub fn armv8_enable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6182,105 +6182,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6289,18 +6289,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6309,18 +6309,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6329,7 +6329,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6337,11 +6337,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6352,57 +6352,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6412,15 +6412,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6470,27 +6470,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6498,11 +6498,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6510,7 +6510,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6518,18 +6518,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6538,7 +6538,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6547,45 +6547,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6596,7 +6596,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6656,7 +6656,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6727,23 +6727,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6751,7 +6751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6760,7 +6760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6768,7 +6768,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6776,7 +6776,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6785,7 +6785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6793,15 +6793,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6810,7 +6810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6818,7 +6818,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6827,71 +6827,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_method_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6914,7 +6914,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6922,68 +6922,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6991,7 +6991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6999,7 +6999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7008,11 +7008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7021,15 +7021,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7037,11 +7037,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7049,22 +7049,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7072,30 +7072,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7103,89 +7103,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7194,34 +7194,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7230,13 +7230,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7245,13 +7245,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7264,7 +7264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7277,7 +7277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7290,7 +7290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7302,7 +7302,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7316,7 +7316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7329,7 +7329,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7342,7 +7342,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7354,23 +7354,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7380,7 +7380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7388,30 +7388,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7423,7 +7423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7434,11 +7434,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_secmem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7804,197 +7804,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8003,15 +8003,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8021,11 +8021,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8033,47 +8033,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8081,11 +8081,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8093,43 +8093,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8138,7 +8138,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8148,7 +8148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8157,7 +8157,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8167,7 +8167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8176,7 +8176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8186,7 +8186,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8195,7 +8195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8205,7 +8205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8214,7 +8214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8223,7 +8223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8231,7 +8231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8249,7 +8249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8258,11 +8258,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8270,7 +8270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8398,15 +8398,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8420,7 +8420,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8428,11 +8428,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8447,7 +8447,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8457,7 +8457,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8468,7 +8468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8478,7 +8478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8487,7 +8487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8496,7 +8496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8505,7 +8505,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8515,7 +8515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8525,23 +8525,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8550,7 +8550,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8559,7 +8559,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8569,7 +8569,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8578,7 +8578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8588,7 +8588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8599,7 +8599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8610,7 +8610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_set_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8624,15 +8624,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8643,7 +8643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8656,11 +8656,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8668,7 +8668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8676,15 +8676,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8844,15 +8844,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8876,15 +8876,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8893,7 +8893,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8901,7 +8901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8909,14 +8909,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8924,7 +8924,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8932,7 +8932,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8940,7 +8940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8948,7 +8948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8956,14 +8956,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8971,7 +8971,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8979,22 +8979,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9070,54 +9070,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9125,7 +9125,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9133,79 +9133,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9213,7 +9213,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9221,7 +9221,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9229,7 +9229,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9237,7 +9237,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9245,7 +9245,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9253,7 +9253,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9261,7 +9261,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9269,7 +9269,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9277,117 +9277,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9395,14 +9395,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9412,7 +9412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9424,7 +9424,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9434,7 +9434,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9444,15 +9444,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9460,26 +9460,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9487,23 +9487,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9511,14 +9511,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9526,25 +9526,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9552,7 +9552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9560,14 +9560,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9596,19 +9596,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9616,11 +9616,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9628,54 +9628,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9683,59 +9683,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9743,23 +9743,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9768,26 +9768,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9795,29 +9795,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9826,22 +9826,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9849,15 +9849,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9866,15 +9866,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9883,52 +9883,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9936,11 +9936,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9965,7 +9965,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9975,11 +9975,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9987,11 +9987,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9999,7 +9999,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10333,15 +10333,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10349,19 +10349,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10369,7 +10369,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10377,12 +10377,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10390,14 +10390,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10405,33 +10405,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10439,7 +10439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10447,19 +10447,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10467,7 +10467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10475,7 +10475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10485,7 +10485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10495,11 +10495,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10507,15 +10507,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10523,52 +10523,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11167,7 +11167,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11192,19 +11192,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11214,19 +11214,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11236,7 +11236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11244,11 +11244,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11258,7 +11258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11266,7 +11266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11425,11 +11425,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11437,11 +11437,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11496,19 +11496,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11517,7 +11517,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11578,23 +11578,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11602,86 +11602,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11689,7 +11689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11697,11 +11697,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11709,7 +11709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11718,7 +11718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11729,22 +11729,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11753,7 +11753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11762,7 +11762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11771,7 +11771,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11780,37 +11780,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11818,7 +11818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11826,7 +11826,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12133,23 +12133,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12157,40 +12157,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12198,15 +12198,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12214,55 +12214,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12270,11 +12270,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12282,7 +12282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12290,11 +12290,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12302,11 +12302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12317,122 +12317,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12443,7 +12443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12453,7 +12453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12463,7 +12463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12473,7 +12473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12481,7 +12481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12491,7 +12491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12499,7 +12499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12509,7 +12509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12517,47 +12517,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12566,49 +12566,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12621,23 +12621,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12647,7 +12647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12656,7 +12656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12665,7 +12665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12673,7 +12673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12681,7 +12681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12689,7 +12689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12698,127 +12698,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13058,7 +13058,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13068,19 +13068,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13090,15 +13090,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13106,7 +13106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13197,15 +13197,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13213,7 +13213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13221,14 +13221,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13236,7 +13236,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13244,31 +13244,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_unload"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13276,11 +13276,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13289,7 +13289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13299,15 +13299,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13315,15 +13315,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13332,7 +13332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13341,7 +13341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13352,7 +13352,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13362,11 +13362,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13377,7 +13377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13450,33 +13450,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_is_weak_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_set_key_unchecked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_key_sched"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13485,7 +13485,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13496,7 +13496,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13507,7 +13507,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13520,7 +13520,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13532,47 +13532,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_new_by_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13580,7 +13580,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13588,7 +13588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13597,7 +13597,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13606,44 +13606,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13652,11 +13652,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13664,7 +13664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13675,19 +13675,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13695,19 +13695,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13722,7 +13722,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13730,14 +13730,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13745,130 +13745,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_shake128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_shake256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13876,11 +13876,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13888,7 +13888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13896,7 +13896,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13904,7 +13904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13915,63 +13915,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13979,15 +13979,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14096,39 +14096,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14136,7 +14136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14144,31 +14144,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14176,7 +14176,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14185,7 +14185,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14193,7 +14193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14202,7 +14202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14214,11 +14214,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14272,28 +14272,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14302,7 +14302,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14312,7 +14312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14323,7 +14323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14334,7 +14334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14345,47 +14345,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14395,7 +14395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14403,14 +14403,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14418,11 +14418,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14430,11 +14430,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14442,11 +14442,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14454,7 +14454,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14465,31 +14465,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p521"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_secp256k1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14497,19 +14497,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14517,7 +14517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14527,53 +14527,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14581,7 +14581,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14590,7 +14590,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14600,7 +14600,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14610,7 +14610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14620,7 +14620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14630,7 +14630,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14641,7 +14641,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14651,7 +14651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14661,7 +14661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14671,7 +14671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14681,7 +14681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14690,7 +14690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14698,7 +14698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14709,7 +14709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14720,7 +14720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14731,15 +14731,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14748,7 +14748,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14757,7 +14757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_point2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14767,7 +14767,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_bn2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14776,7 +14776,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14834,28 +14834,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14863,15 +14863,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECPKParameters_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14885,122 +14885,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_set_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_get_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_set_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_get_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15008,7 +15008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15017,15 +15017,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15033,11 +15033,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15045,22 +15045,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15070,7 +15070,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15078,14 +15078,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15093,11 +15093,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15105,19 +15105,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15125,38 +15125,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15183,7 +15183,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15193,18 +15193,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15221,7 +15221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15230,7 +15230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15241,7 +15241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15252,7 +15252,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15306,23 +15306,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15330,7 +15330,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15338,7 +15338,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15346,7 +15346,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15355,19 +15355,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15375,11 +15375,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15389,7 +15389,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15397,83 +15397,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15611,11 +15611,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15624,11 +15624,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15639,11 +15639,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15658,7 +15658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15673,7 +15673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15691,7 +15691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15706,70 +15706,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15780,7 +15780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15788,7 +15788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15797,7 +15797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15805,70 +15805,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_get_undef"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15877,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15885,7 +15885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15893,7 +15893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15974,7 +15974,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15984,163 +15984,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16149,7 +16149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16158,7 +16158,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16166,7 +16166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16174,7 +16174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16184,7 +16184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16192,7 +16192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16200,7 +16200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16210,7 +16210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16220,7 +16220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16228,7 +16228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16236,7 +16236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16246,7 +16246,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16254,11 +16254,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16266,7 +16266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16275,7 +16275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16283,11 +16283,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16295,7 +16295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16304,7 +16304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16313,7 +16313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16322,7 +16322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16331,7 +16331,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16344,7 +16344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16356,7 +16356,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16371,31 +16371,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16405,11 +16405,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16419,11 +16419,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16433,11 +16433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16447,11 +16447,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16461,18 +16461,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16480,18 +16480,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16501,7 +16501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16511,102 +16511,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16614,28 +16614,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16643,7 +16643,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16651,7 +16651,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16661,33 +16661,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16695,7 +16695,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16706,15 +16706,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16728,7 +16728,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16742,7 +16742,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_do_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16756,15 +16756,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16773,7 +16773,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16781,7 +16781,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16790,14 +16790,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16805,40 +16805,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16846,11 +16846,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16858,11 +16858,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16870,11 +16870,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16882,7 +16882,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16890,7 +16890,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16899,45 +16899,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16947,26 +16947,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16980,7 +16980,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16992,7 +16992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17004,11 +17004,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17016,15 +17016,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17111,7 +17111,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17123,27 +17123,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17153,7 +17153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17161,7 +17161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17169,27 +17169,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17197,7 +17197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17206,7 +17206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17215,7 +17215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17391,86 +17391,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17479,18 +17479,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17499,7 +17499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17508,23 +17508,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17540,7 +17540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17558,7 +17558,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17571,7 +17571,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17587,7 +17587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17605,7 +17605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17620,7 +17620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17633,7 +17633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17646,7 +17646,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17656,19 +17656,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17927,7 +17927,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17935,7 +17935,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17944,7 +17944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17953,18 +17953,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17980,7 +17980,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSKDF_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17992,7 +17992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSKDF_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18006,7 +18006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18018,21 +18018,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18040,7 +18040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18048,7 +18048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18056,11 +18056,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18068,15 +18068,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18178,7 +18178,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18186,47 +18186,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18494,15 +18494,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18510,26 +18510,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18537,26 +18537,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18564,14 +18564,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18619,37 +18619,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18658,46 +18658,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_signer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_content_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_set_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_set_content"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18706,31 +18706,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18756,15 +18756,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18772,18 +18772,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18791,31 +18791,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18828,59 +18828,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18889,11 +18889,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18902,7 +18902,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18911,12 +18911,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18925,44 +18925,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18977,7 +18977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18992,7 +18992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -19007,7 +19007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19022,14 +19022,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19045,7 +19045,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19054,7 +19054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19062,7 +19062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19074,7 +19074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19086,7 +19086,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19096,7 +19096,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19106,7 +19106,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19117,7 +19117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19131,7 +19131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19143,7 +19143,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19154,7 +19154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19167,7 +19167,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19179,7 +19179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19189,7 +19189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19199,31 +19199,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19234,7 +19234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19245,7 +19245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19258,7 +19258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS1_MGF1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19268,7 +19268,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19279,19 +19279,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19299,19 +19299,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19319,7 +19319,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19327,15 +19327,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19348,7 +19348,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19358,7 +19358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19366,34 +19366,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19403,7 +19403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19412,7 +19412,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19420,11 +19420,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19432,11 +19432,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19446,7 +19446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19456,7 +19456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19467,7 +19467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19475,7 +19475,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19483,11 +19483,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_method_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19506,27 +19506,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19534,62 +19534,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19597,27 +19597,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19643,11 +19643,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19656,15 +19656,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19672,7 +19672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19680,7 +19680,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19688,11 +19688,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19701,11 +19701,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_signature_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19715,7 +19715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19723,84 +19723,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19808,7 +19808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19818,7 +19818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19826,25 +19826,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19852,11 +19852,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19864,7 +19864,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19872,7 +19872,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19880,33 +19880,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19946,23 +19946,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19970,27 +19970,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19998,7 +19998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20006,19 +20006,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20026,7 +20026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20034,7 +20034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20042,11 +20042,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20055,7 +20055,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20063,70 +20063,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20134,7 +20134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20144,7 +20144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20152,25 +20152,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20178,26 +20178,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20205,45 +20205,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20251,7 +20251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20259,7 +20259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20267,21 +20267,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20289,7 +20289,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20298,7 +20298,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20308,19 +20308,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20328,45 +20328,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20374,7 +20374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20382,15 +20382,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20398,55 +20398,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20456,7 +20456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20466,7 +20466,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20476,7 +20476,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20484,14 +20484,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20499,22 +20499,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20564,19 +20564,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20584,19 +20584,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20604,15 +20604,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20620,7 +20620,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20628,21 +20628,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20651,7 +20651,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20663,7 +20663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20675,7 +20675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20687,19 +20687,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20707,33 +20707,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20742,11 +20742,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20756,7 +20756,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20766,7 +20766,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20776,19 +20776,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20796,23 +20796,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20823,7 +20823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20833,23 +20833,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20857,18 +20857,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20877,7 +20877,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20886,33 +20886,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20936,11 +20936,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20948,18 +20948,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20967,7 +20967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20975,7 +20975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20983,21 +20983,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21340,15 +21340,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21356,23 +21356,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21380,27 +21380,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21408,14 +21408,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21423,7 +21423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21452,23 +21452,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21476,11 +21476,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21489,7 +21489,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21498,11 +21498,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21527,23 +21527,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21551,14 +21551,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21566,7 +21566,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21576,7 +21576,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21586,7 +21586,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21596,14 +21596,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21612,7 +21612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21621,89 +21621,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21712,92 +21712,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21805,7 +21805,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21813,95 +21813,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21909,7 +21909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21917,14 +21917,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21932,7 +21932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21940,21 +21940,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22022,19 +22022,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22042,43 +22042,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22136,19 +22136,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22156,14 +22156,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22250,19 +22250,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22270,26 +22270,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22297,34 +22297,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22332,11 +22332,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22344,7 +22344,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22352,7 +22352,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22361,7 +22361,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22370,23 +22370,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22395,15 +22395,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22412,7 +22412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22420,7 +22420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22428,7 +22428,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22437,7 +22437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22445,7 +22445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22453,7 +22453,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22462,7 +22462,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22471,7 +22471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22481,11 +22481,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22494,7 +22494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22503,7 +22503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22512,7 +22512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22521,7 +22521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22530,259 +22530,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22790,23 +22790,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22814,7 +22814,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22823,40 +22823,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22866,7 +22866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22874,14 +22874,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22891,7 +22891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22899,14 +22899,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22916,7 +22916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22924,14 +22924,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22941,7 +22941,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22951,7 +22951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22961,7 +22961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22973,7 +22973,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22984,26 +22984,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23013,7 +23013,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23022,7 +23022,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23031,7 +23031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23039,7 +23039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23047,7 +23047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23055,7 +23055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23216,7 +23216,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23314,7 +23314,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23325,11 +23325,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23338,7 +23338,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23347,7 +23347,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23356,7 +23356,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23365,7 +23365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23374,7 +23374,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23383,7 +23383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23392,7 +23392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23401,14 +23401,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23416,32 +23416,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23449,7 +23449,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23457,43 +23457,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23502,7 +23502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23511,31 +23511,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23545,7 +23545,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23557,7 +23557,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23571,15 +23571,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23759,74 +23759,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23851,7 +23851,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23859,7 +23859,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23867,79 +23867,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_lock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_unlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23948,7 +23948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23958,7 +23958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23966,7 +23966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23974,7 +23974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23982,7 +23982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23990,7 +23990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25434,15 +25434,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25450,26 +25450,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25477,26 +25477,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25504,26 +25504,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25531,26 +25531,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25558,26 +25558,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25585,26 +25585,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25612,26 +25612,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25639,26 +25639,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25666,26 +25666,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25693,26 +25693,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25720,26 +25720,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25747,33 +25747,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25781,26 +25781,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25808,77 +25808,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25888,19 +25888,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25909,14 +25909,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25924,7 +25924,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25934,43 +25934,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26137,15 +26137,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26153,26 +26153,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26180,26 +26180,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26207,26 +26207,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26234,26 +26234,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26261,41 +26261,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26303,7 +26303,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_sendreq_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26312,26 +26312,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26339,14 +26339,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26354,7 +26354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26362,15 +26362,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_add0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26378,7 +26378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26386,48 +26386,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_check_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_copy_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26438,23 +26438,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_single_get0_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26464,7 +26464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26472,7 +26472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_find_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26484,7 +26484,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_check_validity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26493,7 +26493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26502,7 +26502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26511,7 +26511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_cert_id_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26520,7 +26520,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_cert_to_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26528,7 +26528,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_parse_url"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26538,18 +26538,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_id_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_id_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26559,14 +26559,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26578,7 +26578,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26589,36 +26589,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_cert_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26626,7 +26626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26634,7 +26634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26642,21 +26642,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26664,11 +26664,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26683,14 +26683,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26700,7 +26700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26710,7 +26710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26720,7 +26720,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26732,7 +26732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26743,7 +26743,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26757,7 +26757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26766,7 +26766,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26775,7 +26775,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26785,7 +26785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26795,7 +26795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26806,7 +26806,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26820,7 +26820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26829,7 +26829,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26838,7 +26838,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26847,15 +26847,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26864,7 +26864,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26873,15 +26873,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26890,7 +26890,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26899,23 +26899,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26924,7 +26924,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26933,15 +26933,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26950,7 +26950,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26959,15 +26959,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26976,7 +26976,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26985,15 +26985,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27002,7 +27002,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27011,21 +27011,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27034,7 +27034,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27043,7 +27043,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27055,7 +27055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27067,7 +27067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27076,7 +27076,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27085,15 +27085,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27102,7 +27102,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27111,15 +27111,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27128,7 +27128,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27137,7 +27137,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27149,7 +27149,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27161,7 +27161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27170,7 +27170,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27179,15 +27179,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27196,7 +27196,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27205,15 +27205,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27222,7 +27222,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27231,7 +27231,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27243,7 +27243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27255,7 +27255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27264,7 +27264,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27273,15 +27273,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27290,7 +27290,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27299,15 +27299,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27316,7 +27316,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27325,7 +27325,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27337,7 +27337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27349,7 +27349,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27358,7 +27358,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27367,15 +27367,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27387,7 +27387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27399,7 +27399,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27411,7 +27411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27423,7 +27423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27432,7 +27432,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27444,7 +27444,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27456,7 +27456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27468,7 +27468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27477,7 +27477,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27489,15 +27489,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27506,14 +27506,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27525,7 +27525,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27538,7 +27538,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27552,7 +27552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27560,7 +27560,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27568,7 +27568,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27577,11 +27577,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27589,27 +27589,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27619,7 +27619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27627,7 +27627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27642,93 +27642,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_priv_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_write_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_egd_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27829,23 +27829,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27910,11 +27910,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -28001,11 +28001,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28013,50 +28013,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28131,15 +28131,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28152,7 +28152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28167,18 +28167,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28187,14 +28187,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28203,7 +28203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28214,7 +28214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28223,7 +28223,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28235,7 +28235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28247,18 +28247,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28266,14 +28266,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28281,7 +28281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28295,7 +28295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28308,7 +28308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28323,7 +28323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28335,7 +28335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_keygen_deterministic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_keygen_deterministic"]
     pub fn EVP_PKEY_keygen_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
@@ -28344,7 +28344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encapsulate_deterministic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encapsulate_deterministic"]
     pub fn EVP_PKEY_encapsulate_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -28356,15 +28356,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_gnu_crypto.rs
@@ -4499,7 +4499,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4507,7 +4507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4515,15 +4515,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4535,7 +4535,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4544,7 +4544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4555,7 +4555,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4566,7 +4566,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4578,7 +4578,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4588,7 +4588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4598,7 +4598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4609,7 +4609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5195,27 +5195,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5223,29 +5223,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5253,7 +5253,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5261,11 +5261,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5273,15 +5273,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5368,11 +5368,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5380,19 +5380,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5400,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5510,11 +5510,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5522,19 +5522,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5542,15 +5542,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5648,11 +5648,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5660,19 +5660,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5680,42 +5680,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5723,62 +5723,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5786,7 +5786,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5795,7 +5795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5804,7 +5804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5812,7 +5812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5820,21 +5820,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5842,7 +5842,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5850,7 +5850,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5858,7 +5858,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5867,7 +5867,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5875,11 +5875,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5906,27 +5906,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 #[repr(C)]
@@ -5982,19 +5982,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6007,7 +6007,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6021,7 +6021,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6032,29 +6032,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6110,7 +6110,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6121,7 +6121,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6134,7 +6134,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6146,7 +6146,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6155,7 +6155,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6166,7 +6166,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6176,38 +6176,38 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_armv8_disable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_armv8_disable_dit"]
     pub fn armv8_disable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_armv8_enable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_armv8_enable_dit"]
     pub fn armv8_enable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6217,105 +6217,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6324,18 +6324,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6344,18 +6344,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6364,7 +6364,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6372,11 +6372,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6387,57 +6387,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6447,15 +6447,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6505,27 +6505,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6533,11 +6533,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6545,7 +6545,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6553,18 +6553,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6573,7 +6573,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6582,45 +6582,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6631,7 +6631,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6691,7 +6691,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6762,23 +6762,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6786,7 +6786,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6795,7 +6795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6803,7 +6803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6811,7 +6811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6820,7 +6820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6828,15 +6828,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6845,7 +6845,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6853,7 +6853,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6862,71 +6862,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6949,7 +6949,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6957,68 +6957,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7026,7 +7026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7034,7 +7034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7043,11 +7043,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7056,15 +7056,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7072,11 +7072,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7084,22 +7084,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7107,30 +7107,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7138,89 +7138,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7229,34 +7229,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7265,13 +7265,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7280,13 +7280,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7299,7 +7299,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7312,7 +7312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7325,7 +7325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7337,7 +7337,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7351,7 +7351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7364,7 +7364,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7377,7 +7377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7389,23 +7389,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7415,7 +7415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7423,30 +7423,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7458,7 +7458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7469,11 +7469,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7839,197 +7839,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8038,15 +8038,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8056,11 +8056,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8068,47 +8068,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8116,11 +8116,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8128,43 +8128,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8173,7 +8173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8183,7 +8183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8192,7 +8192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8202,7 +8202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8211,7 +8211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8221,7 +8221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8230,7 +8230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8249,7 +8249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8258,7 +8258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8266,7 +8266,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8275,7 +8275,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8284,7 +8284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8293,11 +8293,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8305,7 +8305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8433,15 +8433,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8455,7 +8455,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8463,11 +8463,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8482,7 +8482,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8492,7 +8492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8503,7 +8503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8513,7 +8513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8522,7 +8522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8531,7 +8531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8540,7 +8540,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8550,7 +8550,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8560,23 +8560,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8585,7 +8585,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8594,7 +8594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8604,7 +8604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8613,7 +8613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8623,7 +8623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8634,7 +8634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8645,7 +8645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8659,15 +8659,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8678,7 +8678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8691,11 +8691,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8703,7 +8703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8711,15 +8711,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8879,15 +8879,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8911,15 +8911,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8928,7 +8928,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8936,7 +8936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8944,14 +8944,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8959,7 +8959,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8967,7 +8967,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8975,7 +8975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8983,7 +8983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8991,14 +8991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -9006,7 +9006,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -9014,22 +9014,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9105,54 +9105,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9160,7 +9160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9168,79 +9168,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9248,7 +9248,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9256,7 +9256,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9264,7 +9264,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9272,7 +9272,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9280,7 +9280,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9288,7 +9288,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9296,7 +9296,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9304,7 +9304,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9312,117 +9312,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9430,14 +9430,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9447,7 +9447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9459,7 +9459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9469,7 +9469,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9479,15 +9479,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9495,26 +9495,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9522,23 +9522,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9546,14 +9546,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9561,25 +9561,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9587,7 +9587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9595,14 +9595,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9631,19 +9631,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9651,11 +9651,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9663,54 +9663,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9718,59 +9718,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9778,23 +9778,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9803,26 +9803,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9830,29 +9830,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9861,22 +9861,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9884,15 +9884,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9901,15 +9901,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9918,52 +9918,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9971,11 +9971,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10000,7 +10000,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -10010,11 +10010,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10022,11 +10022,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10034,7 +10034,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10368,15 +10368,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10384,19 +10384,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10404,7 +10404,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10412,12 +10412,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10425,14 +10425,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10440,33 +10440,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10474,7 +10474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10482,19 +10482,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10502,7 +10502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10510,7 +10510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10520,7 +10520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10530,11 +10530,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10542,15 +10542,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10558,52 +10558,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11202,7 +11202,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11227,19 +11227,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11249,19 +11249,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11271,7 +11271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11279,11 +11279,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11293,7 +11293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11301,7 +11301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11460,11 +11460,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11472,11 +11472,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11531,19 +11531,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11552,7 +11552,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11613,23 +11613,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11637,86 +11637,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11724,7 +11724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11732,11 +11732,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11744,7 +11744,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11753,7 +11753,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11764,22 +11764,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11788,7 +11788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11797,7 +11797,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11806,7 +11806,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11815,37 +11815,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11853,7 +11853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11861,7 +11861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12168,23 +12168,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12192,40 +12192,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12233,15 +12233,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12249,55 +12249,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12305,11 +12305,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12317,7 +12317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12325,11 +12325,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12337,11 +12337,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12352,122 +12352,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12478,7 +12478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12488,7 +12488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12498,7 +12498,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12508,7 +12508,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12516,7 +12516,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12526,7 +12526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12534,7 +12534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12544,7 +12544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12552,47 +12552,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12601,49 +12601,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12656,23 +12656,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12682,7 +12682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12691,7 +12691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12700,7 +12700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12708,7 +12708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12716,7 +12716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12724,7 +12724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12733,127 +12733,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13093,7 +13093,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13103,19 +13103,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13125,15 +13125,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13141,7 +13141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13232,15 +13232,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13248,7 +13248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13256,14 +13256,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13271,7 +13271,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13279,31 +13279,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13311,11 +13311,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13324,7 +13324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13334,15 +13334,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13350,15 +13350,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13367,7 +13367,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13376,7 +13376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13387,7 +13387,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13397,11 +13397,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13412,7 +13412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13485,33 +13485,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13520,7 +13520,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13531,7 +13531,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13542,7 +13542,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13555,7 +13555,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13567,47 +13567,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13615,7 +13615,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13623,7 +13623,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13632,7 +13632,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13641,44 +13641,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13687,11 +13687,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13699,7 +13699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13710,19 +13710,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13730,19 +13730,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13757,7 +13757,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13765,14 +13765,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13780,130 +13780,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13911,11 +13911,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13923,7 +13923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13931,7 +13931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13939,7 +13939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13950,63 +13950,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14014,15 +14014,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14131,39 +14131,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14179,31 +14179,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14211,7 +14211,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14220,7 +14220,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14228,7 +14228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14237,7 +14237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14249,11 +14249,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14307,28 +14307,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14337,7 +14337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14347,7 +14347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14358,7 +14358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14369,7 +14369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14380,47 +14380,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14430,7 +14430,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14438,14 +14438,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14453,11 +14453,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14465,11 +14465,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14477,11 +14477,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14489,7 +14489,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14500,31 +14500,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14532,19 +14532,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14552,7 +14552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14562,53 +14562,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14616,7 +14616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14625,7 +14625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14635,7 +14635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14645,7 +14645,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14655,7 +14655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14665,7 +14665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14676,7 +14676,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14686,7 +14686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14696,7 +14696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14706,7 +14706,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14716,7 +14716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14725,7 +14725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14733,7 +14733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14744,7 +14744,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14755,7 +14755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14766,15 +14766,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14783,7 +14783,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14792,7 +14792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14802,7 +14802,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14811,7 +14811,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14869,28 +14869,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14898,15 +14898,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14920,122 +14920,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15043,7 +15043,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15052,15 +15052,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15068,11 +15068,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15080,22 +15080,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15105,7 +15105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15113,14 +15113,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15128,11 +15128,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15140,19 +15140,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15160,38 +15160,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15218,7 +15218,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15228,18 +15228,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15256,7 +15256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15265,7 +15265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15276,7 +15276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15287,7 +15287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15341,23 +15341,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15365,7 +15365,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15373,7 +15373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15381,7 +15381,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15390,19 +15390,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15410,11 +15410,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15424,7 +15424,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15432,83 +15432,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15646,11 +15646,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15659,11 +15659,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15674,11 +15674,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15693,7 +15693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15708,7 +15708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15726,7 +15726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15741,70 +15741,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15815,7 +15815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15823,7 +15823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15832,7 +15832,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15840,70 +15840,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15912,7 +15912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15920,7 +15920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15928,7 +15928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -16009,7 +16009,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -16019,163 +16019,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16184,7 +16184,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16193,7 +16193,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16201,7 +16201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16209,7 +16209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16219,7 +16219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16227,7 +16227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16235,7 +16235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16245,7 +16245,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16255,7 +16255,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16263,7 +16263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16271,7 +16271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16281,7 +16281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16289,11 +16289,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16301,7 +16301,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16310,7 +16310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16318,11 +16318,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16330,7 +16330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16339,7 +16339,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16348,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16357,7 +16357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16366,7 +16366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16379,7 +16379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16391,7 +16391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16406,31 +16406,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16440,11 +16440,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16454,11 +16454,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16468,11 +16468,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16482,11 +16482,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16496,18 +16496,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16515,18 +16515,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16536,7 +16536,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16546,102 +16546,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16649,28 +16649,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16678,7 +16678,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16686,7 +16686,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16696,33 +16696,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16730,7 +16730,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16741,15 +16741,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16763,7 +16763,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16777,7 +16777,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16791,15 +16791,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16808,7 +16808,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16816,7 +16816,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16825,14 +16825,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16840,40 +16840,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16881,11 +16881,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16893,11 +16893,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16905,11 +16905,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16917,7 +16917,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16925,7 +16925,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16934,45 +16934,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16982,26 +16982,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17015,7 +17015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17027,7 +17027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17039,11 +17039,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17051,15 +17051,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17146,7 +17146,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17158,27 +17158,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17188,7 +17188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17196,7 +17196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17204,27 +17204,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17232,7 +17232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17241,7 +17241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17250,7 +17250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17426,86 +17426,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17514,18 +17514,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17534,7 +17534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17543,23 +17543,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17575,7 +17575,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17593,7 +17593,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17606,7 +17606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17622,7 +17622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17640,7 +17640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17655,7 +17655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17668,7 +17668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17681,7 +17681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17691,19 +17691,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17962,7 +17962,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17970,7 +17970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17979,7 +17979,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17988,18 +17988,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -18015,7 +18015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -18027,7 +18027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18041,7 +18041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18053,21 +18053,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18075,7 +18075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18083,7 +18083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18091,11 +18091,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18103,15 +18103,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18213,7 +18213,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18221,47 +18221,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18529,15 +18529,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18545,26 +18545,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18572,26 +18572,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18599,14 +18599,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18654,37 +18654,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18693,46 +18693,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18741,31 +18741,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18791,15 +18791,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18807,18 +18807,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18826,31 +18826,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18863,59 +18863,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18924,11 +18924,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18937,7 +18937,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18946,12 +18946,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18960,44 +18960,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -19012,7 +19012,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -19027,7 +19027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -19042,7 +19042,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19057,14 +19057,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19080,7 +19080,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19089,7 +19089,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19097,7 +19097,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19109,7 +19109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19121,7 +19121,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19131,7 +19131,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19141,7 +19141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19152,7 +19152,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19166,7 +19166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19178,7 +19178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19189,7 +19189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19202,7 +19202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19214,7 +19214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19224,7 +19224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19234,31 +19234,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19269,7 +19269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19280,7 +19280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19293,7 +19293,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19303,7 +19303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19314,19 +19314,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19334,19 +19334,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19354,7 +19354,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19362,15 +19362,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19383,7 +19383,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19393,7 +19393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19401,34 +19401,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19438,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19447,7 +19447,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19455,11 +19455,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19467,11 +19467,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19481,7 +19481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19491,7 +19491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19502,7 +19502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19510,7 +19510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19518,11 +19518,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19541,27 +19541,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19569,62 +19569,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19632,27 +19632,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19678,11 +19678,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19691,15 +19691,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19707,7 +19707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19715,7 +19715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19723,11 +19723,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19736,11 +19736,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19750,7 +19750,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19758,84 +19758,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19843,7 +19843,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19853,7 +19853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19861,25 +19861,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19887,11 +19887,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19899,7 +19899,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19907,7 +19907,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19915,33 +19915,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19981,23 +19981,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -20005,27 +20005,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20033,7 +20033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20041,19 +20041,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20061,7 +20061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20069,7 +20069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20077,11 +20077,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20090,7 +20090,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20098,70 +20098,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20169,7 +20169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20179,7 +20179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20187,25 +20187,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20213,26 +20213,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20240,45 +20240,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20286,7 +20286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20294,7 +20294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20302,21 +20302,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20324,7 +20324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20333,7 +20333,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20343,19 +20343,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20363,45 +20363,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20409,7 +20409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20417,15 +20417,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20433,55 +20433,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20491,7 +20491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20501,7 +20501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20511,7 +20511,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20519,14 +20519,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20534,22 +20534,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20599,19 +20599,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20619,19 +20619,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20639,15 +20639,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20655,7 +20655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20663,21 +20663,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20686,7 +20686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20698,7 +20698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20710,7 +20710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20722,19 +20722,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20742,33 +20742,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20777,11 +20777,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20791,7 +20791,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20801,7 +20801,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20811,19 +20811,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20831,23 +20831,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20858,7 +20858,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20868,23 +20868,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20892,18 +20892,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20912,7 +20912,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20921,33 +20921,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20971,11 +20971,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20983,18 +20983,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -21002,7 +21002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21010,7 +21010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21018,21 +21018,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21375,15 +21375,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21391,23 +21391,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21415,27 +21415,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21443,14 +21443,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21458,7 +21458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21487,23 +21487,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21511,11 +21511,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21524,7 +21524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21533,11 +21533,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21562,23 +21562,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21586,14 +21586,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21601,7 +21601,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21611,7 +21611,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21621,7 +21621,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21631,14 +21631,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21647,7 +21647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21656,89 +21656,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21747,92 +21747,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21840,7 +21840,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21848,95 +21848,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21944,7 +21944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21952,14 +21952,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21967,7 +21967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21975,21 +21975,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22057,19 +22057,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22077,43 +22077,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22171,19 +22171,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22191,14 +22191,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22285,19 +22285,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22305,26 +22305,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22332,34 +22332,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22367,11 +22367,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22379,7 +22379,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22387,7 +22387,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22396,7 +22396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22405,23 +22405,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22430,15 +22430,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22447,7 +22447,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22455,7 +22455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22463,7 +22463,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22472,7 +22472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22480,7 +22480,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22488,7 +22488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22497,7 +22497,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22506,7 +22506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22516,11 +22516,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22529,7 +22529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22538,7 +22538,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22547,7 +22547,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22556,7 +22556,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22565,259 +22565,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22825,23 +22825,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22849,7 +22849,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22858,40 +22858,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22901,7 +22901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22909,14 +22909,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22926,7 +22926,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22934,14 +22934,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22951,7 +22951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22959,14 +22959,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22976,7 +22976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22986,7 +22986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22996,7 +22996,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23008,7 +23008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23019,26 +23019,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23048,7 +23048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23057,7 +23057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23066,7 +23066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23074,7 +23074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23082,7 +23082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23090,7 +23090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23251,7 +23251,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23349,7 +23349,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23360,11 +23360,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23373,7 +23373,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23382,7 +23382,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23391,7 +23391,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23400,7 +23400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23409,7 +23409,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23418,7 +23418,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23427,7 +23427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23436,14 +23436,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23451,32 +23451,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23484,7 +23484,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23492,43 +23492,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23537,7 +23537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23546,31 +23546,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23580,7 +23580,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23592,7 +23592,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23606,15 +23606,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23794,74 +23794,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23886,7 +23886,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23894,7 +23894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23902,79 +23902,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23983,7 +23983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23993,7 +23993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24001,7 +24001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24009,7 +24009,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24017,7 +24017,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -24025,7 +24025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25469,15 +25469,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25485,26 +25485,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25512,26 +25512,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25539,26 +25539,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25566,26 +25566,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25593,26 +25593,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25620,26 +25620,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25647,26 +25647,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25674,26 +25674,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25701,26 +25701,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25728,26 +25728,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25755,26 +25755,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25782,33 +25782,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25816,26 +25816,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25843,77 +25843,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25923,19 +25923,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25944,14 +25944,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25959,7 +25959,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25969,43 +25969,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26172,15 +26172,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26188,26 +26188,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26215,26 +26215,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26242,26 +26242,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26269,26 +26269,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26296,41 +26296,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26338,7 +26338,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26347,26 +26347,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26374,14 +26374,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26389,7 +26389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26397,15 +26397,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26413,7 +26413,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26421,48 +26421,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26473,23 +26473,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26499,7 +26499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26507,7 +26507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26519,7 +26519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26528,7 +26528,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26537,7 +26537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26546,7 +26546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26555,7 +26555,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26563,7 +26563,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26573,18 +26573,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26594,14 +26594,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26613,7 +26613,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26624,36 +26624,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26661,7 +26661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26669,7 +26669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26677,21 +26677,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26699,11 +26699,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26718,14 +26718,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26735,7 +26735,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26745,7 +26745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26755,7 +26755,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26767,7 +26767,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26778,7 +26778,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26792,7 +26792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26801,7 +26801,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26810,7 +26810,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26820,7 +26820,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26830,7 +26830,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26841,7 +26841,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26855,7 +26855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26864,7 +26864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26873,7 +26873,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26882,15 +26882,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26899,7 +26899,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26908,15 +26908,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26925,7 +26925,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26934,23 +26934,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26959,7 +26959,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26968,15 +26968,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26985,7 +26985,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26994,15 +26994,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -27011,7 +27011,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -27020,15 +27020,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27037,7 +27037,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27046,21 +27046,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27069,7 +27069,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27078,7 +27078,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27090,7 +27090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27102,7 +27102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27111,7 +27111,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27120,15 +27120,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27137,7 +27137,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27146,15 +27146,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27163,7 +27163,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27172,7 +27172,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27184,7 +27184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27196,7 +27196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27205,7 +27205,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27214,15 +27214,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27231,7 +27231,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27240,15 +27240,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27257,7 +27257,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27266,7 +27266,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27278,7 +27278,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27290,7 +27290,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27299,7 +27299,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27308,15 +27308,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27325,7 +27325,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27334,15 +27334,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27351,7 +27351,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27360,7 +27360,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27372,7 +27372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27384,7 +27384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27393,7 +27393,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27402,15 +27402,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27422,7 +27422,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27434,7 +27434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27446,7 +27446,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27458,7 +27458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27467,7 +27467,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27479,7 +27479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27491,7 +27491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27503,7 +27503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27512,7 +27512,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27524,15 +27524,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27541,14 +27541,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27560,7 +27560,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27573,7 +27573,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27587,7 +27587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27595,7 +27595,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27603,7 +27603,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27612,11 +27612,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27624,27 +27624,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27654,7 +27654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27662,7 +27662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27677,93 +27677,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27864,23 +27864,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27945,11 +27945,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -28036,11 +28036,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28048,50 +28048,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28166,15 +28166,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28187,7 +28187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28202,18 +28202,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28222,14 +28222,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28238,7 +28238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28249,7 +28249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28258,7 +28258,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28270,7 +28270,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28282,18 +28282,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28301,14 +28301,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28316,7 +28316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28330,7 +28330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28343,7 +28343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28358,7 +28358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28370,7 +28370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_deterministic"]
     pub fn EVP_PKEY_keygen_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
@@ -28379,7 +28379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate_deterministic"]
     pub fn EVP_PKEY_encapsulate_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -28391,15 +28391,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/aarch64_unknown_linux_musl_crypto.rs
@@ -4597,7 +4597,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4605,7 +4605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4613,15 +4613,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4633,7 +4633,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4642,7 +4642,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4653,7 +4653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4664,7 +4664,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4676,7 +4676,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4686,7 +4686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4696,7 +4696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4707,7 +4707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4935,27 +4935,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4963,29 +4963,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4993,7 +4993,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5001,11 +5001,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5013,15 +5013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5108,11 +5108,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5120,19 +5120,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5140,19 +5140,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5250,11 +5250,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5262,19 +5262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5282,15 +5282,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5388,11 +5388,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5400,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5420,42 +5420,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5463,62 +5463,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5526,7 +5526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5535,7 +5535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5544,7 +5544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5552,7 +5552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5560,21 +5560,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5582,7 +5582,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5590,7 +5590,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5598,7 +5598,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5607,7 +5607,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5615,11 +5615,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5646,45 +5646,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5697,7 +5697,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5711,7 +5711,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5722,29 +5722,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5800,7 +5800,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5811,7 +5811,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5824,7 +5824,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5836,7 +5836,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5845,7 +5845,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5856,7 +5856,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5866,38 +5866,38 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_armv8_disable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_armv8_disable_dit"]
     pub fn armv8_disable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_armv8_enable_dit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_armv8_enable_dit"]
     pub fn armv8_enable_dit();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -5907,105 +5907,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6014,18 +6014,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6034,18 +6034,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6054,7 +6054,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6062,11 +6062,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6077,57 +6077,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6137,15 +6137,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6195,27 +6195,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6223,11 +6223,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6235,7 +6235,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6243,18 +6243,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6263,7 +6263,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6272,45 +6272,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6321,7 +6321,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6381,7 +6381,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6452,23 +6452,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6476,7 +6476,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6485,7 +6485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6493,7 +6493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6501,7 +6501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6510,7 +6510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6518,15 +6518,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6535,7 +6535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6543,7 +6543,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6552,71 +6552,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6639,7 +6639,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6647,68 +6647,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6716,7 +6716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6724,7 +6724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6733,11 +6733,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6746,15 +6746,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6762,11 +6762,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6774,22 +6774,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6797,30 +6797,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6828,89 +6828,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6919,34 +6919,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6955,13 +6955,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6970,13 +6970,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6989,7 +6989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7002,7 +7002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7015,7 +7015,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7027,7 +7027,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7041,7 +7041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7054,7 +7054,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7067,7 +7067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7079,23 +7079,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7105,7 +7105,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7113,30 +7113,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7148,7 +7148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7159,11 +7159,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7529,197 +7529,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7728,15 +7728,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7746,11 +7746,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7758,47 +7758,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7806,11 +7806,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7818,43 +7818,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7863,7 +7863,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7873,7 +7873,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7882,7 +7882,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7892,7 +7892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7901,7 +7901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7911,7 +7911,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7920,7 +7920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7930,7 +7930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7939,7 +7939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7948,7 +7948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7956,7 +7956,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7965,7 +7965,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7974,7 +7974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7983,11 +7983,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7995,7 +7995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8123,15 +8123,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8145,7 +8145,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8153,11 +8153,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8172,7 +8172,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8182,7 +8182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8193,7 +8193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8203,7 +8203,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8212,7 +8212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8221,7 +8221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8230,7 +8230,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8240,7 +8240,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8250,23 +8250,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8275,7 +8275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8284,7 +8284,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8294,7 +8294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8303,7 +8303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8313,7 +8313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8324,7 +8324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8335,7 +8335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8349,15 +8349,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8368,7 +8368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8381,11 +8381,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8393,7 +8393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8401,15 +8401,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8569,15 +8569,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8601,15 +8601,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8618,7 +8618,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8626,7 +8626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8634,14 +8634,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8649,7 +8649,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8657,7 +8657,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8665,7 +8665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8673,7 +8673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8681,14 +8681,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8696,7 +8696,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8704,22 +8704,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8795,54 +8795,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8850,7 +8850,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8858,79 +8858,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8938,7 +8938,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8946,7 +8946,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8954,7 +8954,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8962,7 +8962,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8970,7 +8970,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8978,7 +8978,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8986,7 +8986,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8994,7 +8994,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9002,117 +9002,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9120,14 +9120,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9137,7 +9137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9149,7 +9149,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9159,7 +9159,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9169,15 +9169,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9185,26 +9185,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9212,23 +9212,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9236,14 +9236,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9251,25 +9251,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9277,7 +9277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9285,14 +9285,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9321,19 +9321,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9341,11 +9341,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9353,54 +9353,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9408,59 +9408,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9468,23 +9468,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9493,26 +9493,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9520,29 +9520,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9551,22 +9551,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9574,15 +9574,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9591,15 +9591,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9608,52 +9608,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9661,11 +9661,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9690,7 +9690,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9700,11 +9700,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9712,11 +9712,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9724,7 +9724,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10058,15 +10058,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10074,19 +10074,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10094,7 +10094,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10102,12 +10102,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10115,14 +10115,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10130,33 +10130,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10164,7 +10164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10172,19 +10172,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10192,7 +10192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10200,7 +10200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10210,7 +10210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10220,11 +10220,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10232,15 +10232,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10248,52 +10248,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10892,7 +10892,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10917,19 +10917,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10939,19 +10939,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10961,7 +10961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10969,11 +10969,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10983,7 +10983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10991,7 +10991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11150,11 +11150,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11162,11 +11162,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11221,19 +11221,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11242,7 +11242,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11303,23 +11303,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11327,86 +11327,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11414,7 +11414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11422,11 +11422,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11434,7 +11434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11443,7 +11443,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11454,22 +11454,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11478,7 +11478,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11487,7 +11487,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11496,7 +11496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11505,37 +11505,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11543,7 +11543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11551,7 +11551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11858,23 +11858,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11882,40 +11882,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11923,15 +11923,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11939,55 +11939,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11995,11 +11995,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12007,7 +12007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12015,11 +12015,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12027,11 +12027,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12042,122 +12042,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12168,7 +12168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12178,7 +12178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12188,7 +12188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12198,7 +12198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12206,7 +12206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12216,7 +12216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12224,7 +12224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12234,7 +12234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12242,47 +12242,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12291,49 +12291,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12346,23 +12346,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12372,7 +12372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12381,7 +12381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12390,7 +12390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12398,7 +12398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12406,7 +12406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12414,7 +12414,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12423,127 +12423,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12783,7 +12783,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12793,19 +12793,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12815,15 +12815,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12831,7 +12831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -12922,15 +12922,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12938,7 +12938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12946,14 +12946,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12961,7 +12961,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12969,31 +12969,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13001,11 +13001,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13014,7 +13014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13024,15 +13024,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13040,15 +13040,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13057,7 +13057,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13066,7 +13066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13077,7 +13077,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13087,11 +13087,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13102,7 +13102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13175,33 +13175,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13210,7 +13210,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13221,7 +13221,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13232,7 +13232,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13245,7 +13245,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13257,47 +13257,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13305,7 +13305,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13313,7 +13313,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13322,7 +13322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13331,44 +13331,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13377,11 +13377,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13389,7 +13389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13400,19 +13400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13420,19 +13420,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13447,7 +13447,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13455,14 +13455,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13470,130 +13470,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13601,11 +13601,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13613,7 +13613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13621,7 +13621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13629,7 +13629,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13640,63 +13640,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13704,15 +13704,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13821,39 +13821,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -13861,7 +13861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -13869,31 +13869,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13901,7 +13901,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13910,7 +13910,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13918,7 +13918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13927,7 +13927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13939,11 +13939,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13997,28 +13997,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14027,7 +14027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14037,7 +14037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14048,7 +14048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14059,7 +14059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14070,47 +14070,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14120,7 +14120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14128,14 +14128,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14143,11 +14143,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14155,11 +14155,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14167,11 +14167,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14179,7 +14179,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14190,31 +14190,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14222,19 +14222,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14242,7 +14242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14252,53 +14252,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14306,7 +14306,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14315,7 +14315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14325,7 +14325,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14335,7 +14335,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14345,7 +14345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14355,7 +14355,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14366,7 +14366,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14376,7 +14376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14386,7 +14386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14396,7 +14396,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14406,7 +14406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14415,7 +14415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14423,7 +14423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14434,7 +14434,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14445,7 +14445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14456,15 +14456,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14473,7 +14473,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14482,7 +14482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14492,7 +14492,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14501,7 +14501,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14559,28 +14559,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14588,15 +14588,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14610,122 +14610,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14733,7 +14733,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14742,15 +14742,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14758,11 +14758,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14770,22 +14770,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14795,7 +14795,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14803,14 +14803,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14818,11 +14818,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14830,19 +14830,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14850,38 +14850,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -14908,7 +14908,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -14918,18 +14918,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14946,7 +14946,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14955,7 +14955,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14966,7 +14966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14977,7 +14977,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15031,23 +15031,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15055,7 +15055,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15063,7 +15063,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15071,7 +15071,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15080,19 +15080,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15100,11 +15100,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15114,7 +15114,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15122,83 +15122,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15336,11 +15336,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15349,11 +15349,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15364,11 +15364,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15383,7 +15383,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15398,7 +15398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15416,7 +15416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15431,70 +15431,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15505,7 +15505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15513,7 +15513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15522,7 +15522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15530,70 +15530,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15602,7 +15602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15610,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15618,7 +15618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15699,7 +15699,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15709,163 +15709,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15874,7 +15874,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15883,7 +15883,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15891,7 +15891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15899,7 +15899,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15909,7 +15909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15917,7 +15917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15925,7 +15925,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15935,7 +15935,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15945,7 +15945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15953,7 +15953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15961,7 +15961,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15971,7 +15971,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15979,11 +15979,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15991,7 +15991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16000,7 +16000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16008,11 +16008,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16020,7 +16020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16029,7 +16029,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16038,7 +16038,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16047,7 +16047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16056,7 +16056,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16069,7 +16069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16081,7 +16081,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16096,31 +16096,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16130,11 +16130,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16144,11 +16144,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16158,11 +16158,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16172,11 +16172,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16186,18 +16186,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16205,18 +16205,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16226,7 +16226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16236,102 +16236,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16339,28 +16339,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16368,7 +16368,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16376,7 +16376,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16386,33 +16386,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16420,7 +16420,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16431,15 +16431,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16453,7 +16453,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16467,7 +16467,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16481,15 +16481,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16498,7 +16498,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16506,7 +16506,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16515,14 +16515,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16530,40 +16530,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16571,11 +16571,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16583,11 +16583,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16595,11 +16595,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16607,7 +16607,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16615,7 +16615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16624,45 +16624,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16672,26 +16672,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16705,7 +16705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16717,7 +16717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16729,11 +16729,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16741,15 +16741,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16836,7 +16836,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16848,27 +16848,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16878,7 +16878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16886,7 +16886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16894,27 +16894,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16922,7 +16922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -16931,7 +16931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16940,7 +16940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17116,86 +17116,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17204,18 +17204,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17224,7 +17224,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17233,23 +17233,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17265,7 +17265,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17283,7 +17283,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17296,7 +17296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17312,7 +17312,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17330,7 +17330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17345,7 +17345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17358,7 +17358,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17371,7 +17371,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17381,19 +17381,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17652,7 +17652,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17660,7 +17660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17669,7 +17669,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17678,18 +17678,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17705,7 +17705,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17717,7 +17717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17731,7 +17731,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17743,21 +17743,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -17765,7 +17765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -17773,7 +17773,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -17781,11 +17781,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17793,15 +17793,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17903,7 +17903,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17911,47 +17911,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18219,15 +18219,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18235,26 +18235,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18262,26 +18262,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18289,14 +18289,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18344,37 +18344,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18383,46 +18383,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18431,31 +18431,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18481,15 +18481,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18497,18 +18497,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18516,31 +18516,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18553,59 +18553,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18614,11 +18614,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18627,7 +18627,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18636,12 +18636,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18650,44 +18650,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18702,7 +18702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18717,7 +18717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -18732,7 +18732,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -18747,14 +18747,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -18770,7 +18770,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18779,7 +18779,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18787,7 +18787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18799,7 +18799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18811,7 +18811,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18821,7 +18821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18831,7 +18831,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18842,7 +18842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18856,7 +18856,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18868,7 +18868,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18879,7 +18879,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18892,7 +18892,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18904,7 +18904,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18914,7 +18914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18924,31 +18924,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18959,7 +18959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18970,7 +18970,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18983,7 +18983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -18993,7 +18993,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19004,19 +19004,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19024,19 +19024,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19044,7 +19044,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19052,15 +19052,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19073,7 +19073,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19083,7 +19083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19091,34 +19091,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19128,7 +19128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19137,7 +19137,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19145,11 +19145,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19157,11 +19157,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19171,7 +19171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19181,7 +19181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19192,7 +19192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19200,7 +19200,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19208,11 +19208,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19231,27 +19231,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19259,62 +19259,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19322,27 +19322,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19368,11 +19368,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19381,15 +19381,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19397,7 +19397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19405,7 +19405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19413,11 +19413,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19426,11 +19426,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19440,7 +19440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19448,84 +19448,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19533,7 +19533,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19543,7 +19543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19551,25 +19551,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19577,11 +19577,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19589,7 +19589,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19597,7 +19597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19605,33 +19605,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19671,23 +19671,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19695,27 +19695,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19723,7 +19723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19731,19 +19731,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19751,7 +19751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19759,7 +19759,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19767,11 +19767,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19780,7 +19780,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19788,70 +19788,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19859,7 +19859,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19869,7 +19869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19877,25 +19877,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19903,26 +19903,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -19930,45 +19930,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -19976,7 +19976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -19984,7 +19984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -19992,21 +19992,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20014,7 +20014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20023,7 +20023,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20033,19 +20033,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20053,45 +20053,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20099,7 +20099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20107,15 +20107,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20123,55 +20123,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20181,7 +20181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20191,7 +20191,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20201,7 +20201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20209,14 +20209,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20224,22 +20224,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20289,19 +20289,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20309,19 +20309,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20329,15 +20329,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20345,7 +20345,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20353,21 +20353,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20376,7 +20376,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20388,7 +20388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20400,7 +20400,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20412,19 +20412,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20432,33 +20432,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20467,11 +20467,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20481,7 +20481,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20491,7 +20491,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20501,19 +20501,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20521,23 +20521,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20548,7 +20548,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20558,23 +20558,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20582,18 +20582,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20602,7 +20602,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20611,33 +20611,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20661,11 +20661,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20673,18 +20673,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20692,7 +20692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20700,7 +20700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20708,21 +20708,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21065,15 +21065,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21081,23 +21081,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21105,27 +21105,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21133,14 +21133,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21148,7 +21148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21177,23 +21177,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21201,11 +21201,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21214,7 +21214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21223,11 +21223,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21252,23 +21252,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21276,14 +21276,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21291,7 +21291,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21301,7 +21301,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21311,7 +21311,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21321,14 +21321,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21337,7 +21337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21346,89 +21346,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21437,92 +21437,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21530,7 +21530,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21538,95 +21538,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21634,7 +21634,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21642,14 +21642,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21657,7 +21657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21665,21 +21665,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -21747,19 +21747,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -21767,43 +21767,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21861,19 +21861,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -21881,14 +21881,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21975,19 +21975,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -21995,26 +21995,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22022,34 +22022,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22057,11 +22057,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22069,7 +22069,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22077,7 +22077,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22086,7 +22086,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22095,23 +22095,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22120,15 +22120,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22137,7 +22137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22145,7 +22145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22153,7 +22153,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22162,7 +22162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22170,7 +22170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22178,7 +22178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22187,7 +22187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22196,7 +22196,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22206,11 +22206,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22219,7 +22219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22228,7 +22228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22237,7 +22237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22246,7 +22246,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22255,259 +22255,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22515,23 +22515,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22539,7 +22539,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22548,40 +22548,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22591,7 +22591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22599,14 +22599,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22616,7 +22616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22624,14 +22624,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22641,7 +22641,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22649,14 +22649,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22666,7 +22666,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22676,7 +22676,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22686,7 +22686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22698,7 +22698,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22709,26 +22709,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22738,7 +22738,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22747,7 +22747,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -22756,7 +22756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -22764,7 +22764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22772,7 +22772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -22780,7 +22780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22941,7 +22941,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23039,7 +23039,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23050,11 +23050,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23063,7 +23063,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23072,7 +23072,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23081,7 +23081,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23090,7 +23090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23099,7 +23099,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23108,7 +23108,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23117,7 +23117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23126,14 +23126,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23141,32 +23141,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23174,7 +23174,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23182,43 +23182,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23227,7 +23227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23236,31 +23236,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23270,7 +23270,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23282,7 +23282,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23296,15 +23296,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23484,74 +23484,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23576,7 +23576,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23584,7 +23584,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23592,79 +23592,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23673,7 +23673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23683,7 +23683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23691,7 +23691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23699,7 +23699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23707,7 +23707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23715,7 +23715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25159,15 +25159,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25175,26 +25175,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25202,26 +25202,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25229,26 +25229,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25256,26 +25256,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25283,26 +25283,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25310,26 +25310,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25337,26 +25337,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25364,26 +25364,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25391,26 +25391,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25418,26 +25418,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25445,26 +25445,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25472,33 +25472,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25506,26 +25506,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25533,77 +25533,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25613,19 +25613,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25634,14 +25634,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25649,7 +25649,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25659,43 +25659,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25862,15 +25862,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25878,26 +25878,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25905,26 +25905,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25932,26 +25932,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25959,26 +25959,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25986,41 +25986,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26028,7 +26028,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26037,26 +26037,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26064,14 +26064,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26079,7 +26079,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26087,15 +26087,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26103,7 +26103,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26111,48 +26111,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26163,23 +26163,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26189,7 +26189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26197,7 +26197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26209,7 +26209,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26218,7 +26218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26227,7 +26227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26236,7 +26236,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26245,7 +26245,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26253,7 +26253,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26263,18 +26263,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26284,14 +26284,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26303,7 +26303,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26314,36 +26314,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26351,7 +26351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26359,7 +26359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26367,21 +26367,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26389,11 +26389,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26408,14 +26408,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26425,7 +26425,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26435,7 +26435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26445,7 +26445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26457,7 +26457,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26468,7 +26468,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26482,7 +26482,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26491,7 +26491,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26500,7 +26500,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26510,7 +26510,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26520,7 +26520,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26531,7 +26531,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26545,7 +26545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26554,7 +26554,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26563,7 +26563,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26572,15 +26572,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26589,7 +26589,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26598,15 +26598,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26615,7 +26615,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26624,23 +26624,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26649,7 +26649,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26658,15 +26658,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26675,7 +26675,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26684,15 +26684,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26701,7 +26701,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26710,15 +26710,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26727,7 +26727,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26736,21 +26736,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26759,7 +26759,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26768,7 +26768,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -26780,7 +26780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -26792,7 +26792,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26801,7 +26801,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26810,15 +26810,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26827,7 +26827,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26836,15 +26836,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26853,7 +26853,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26862,7 +26862,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -26874,7 +26874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -26886,7 +26886,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26895,7 +26895,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26904,15 +26904,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26921,7 +26921,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26930,15 +26930,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26947,7 +26947,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26956,7 +26956,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -26968,7 +26968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -26980,7 +26980,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26989,7 +26989,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26998,15 +26998,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27015,7 +27015,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27024,15 +27024,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27041,7 +27041,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27050,7 +27050,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27062,7 +27062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27074,7 +27074,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27083,7 +27083,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27092,15 +27092,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27112,7 +27112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27124,7 +27124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27136,7 +27136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27148,7 +27148,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27157,7 +27157,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27169,7 +27169,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27181,7 +27181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27193,7 +27193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27202,7 +27202,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27214,15 +27214,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27231,14 +27231,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27250,7 +27250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27263,7 +27263,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27277,7 +27277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27285,7 +27285,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27293,7 +27293,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27302,11 +27302,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27314,27 +27314,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27344,7 +27344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27352,7 +27352,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27367,93 +27367,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27554,23 +27554,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27635,11 +27635,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27726,11 +27726,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -27738,50 +27738,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -27856,15 +27856,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27877,7 +27877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27892,18 +27892,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27912,14 +27912,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27928,7 +27928,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27939,7 +27939,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27948,7 +27948,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27960,7 +27960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -27972,18 +27972,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -27991,14 +27991,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28006,7 +28006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28020,7 +28020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28033,7 +28033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28048,7 +28048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28060,7 +28060,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_deterministic"]
     pub fn EVP_PKEY_keygen_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
@@ -28069,7 +28069,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate_deterministic"]
     pub fn EVP_PKEY_encapsulate_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -28081,15 +28081,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 #[repr(C)]

--- a/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_apple_darwin_crypto.rs
@@ -4553,7 +4553,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_set_encrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4561,7 +4561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_set_decrypt_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4569,15 +4569,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4589,7 +4589,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4598,7 +4598,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4609,7 +4609,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4620,7 +4620,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4632,7 +4632,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_wrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4642,7 +4642,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_unwrap_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4652,7 +4652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_wrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4663,7 +4663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5210,27 +5210,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_grow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_MEM_append"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5238,29 +5238,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5268,7 +5268,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BUF_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5276,11 +5276,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5288,15 +5288,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA1_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5383,11 +5383,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5395,19 +5395,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5415,19 +5415,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5525,11 +5525,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5537,19 +5537,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5557,15 +5557,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5663,11 +5663,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5675,19 +5675,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5695,42 +5695,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SHA512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_calloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_memcmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5738,62 +5738,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_hash32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strhash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strnlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isalpha"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isalnum"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_tolower"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_isspace"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5801,7 +5801,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_snprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5810,7 +5810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_vsnprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5819,7 +5819,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5827,7 +5827,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_asprintf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5835,21 +5835,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strndup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_memdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5857,7 +5857,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_strlcat"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5865,7 +5865,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5873,7 +5873,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_realloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5882,7 +5882,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5890,11 +5890,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5921,45 +5921,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_secure_used"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_num_locks"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5972,7 +5972,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5986,7 +5986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5997,29 +5997,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6075,7 +6075,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6086,7 +6086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6099,7 +6099,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6111,7 +6111,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6120,7 +6120,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6131,7 +6131,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6141,30 +6141,30 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_library_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_has_asm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BORINGSSL_self_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6174,105 +6174,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_read_counter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSLeay_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_awslc_api_version_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_mode_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_free_strings"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6281,18 +6281,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6301,18 +6301,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_last_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6321,7 +6321,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_error_string_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6329,11 +6329,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_lib_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_reason_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6344,57 +6344,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_print_errors_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_print_errors_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_clear_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_set_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_pop_to_mark"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_get_next_error_library"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_remove_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_remove_thread_state"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_func_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_clear_system_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_put_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6404,15 +6404,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_add_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_add_error_dataf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_set_error_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6462,27 +6462,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_num"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6490,11 +6490,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6502,7 +6502,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6510,18 +6510,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6530,7 +6530,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6539,45 +6539,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6588,7 +6588,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_sk_pop_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6648,7 +6648,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6719,23 +6719,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_vfree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6743,7 +6743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6752,7 +6752,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6760,7 +6760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6768,7 +6768,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6777,7 +6777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6785,15 +6785,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6802,7 +6802,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6810,7 +6810,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_int_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6819,71 +6819,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_eof"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_should_io_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_reason"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_method_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_method_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6906,7 +6906,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6914,68 +6914,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl_pending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_wpending"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_close"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_number_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_number_written"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_callback_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_callback_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_push"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_pop"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_next"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_free_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_find_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_copy_next_retry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_printf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6983,7 +6983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_indent"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6991,7 +6991,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_hexdump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7000,11 +7000,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_print_errors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7013,15 +7013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_mem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_mem_contents"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7029,11 +7029,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_mem_buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7041,22 +7041,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7064,30 +7064,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_fd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7095,89 +7095,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_read_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_write_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_append_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_rw_filename"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_tell"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_seek"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_socket"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_conn_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_do_connect"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_new_bio_pair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7186,34 +7186,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_shutdown_wr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7222,13 +7222,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7237,13 +7237,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7256,7 +7256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7269,7 +7269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7282,7 +7282,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_gets"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7294,7 +7294,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7308,7 +7308,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7321,7 +7321,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7334,7 +7334,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7346,23 +7346,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7372,7 +7372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7380,30 +7380,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_f_base64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_retry_special"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_get_shutdown"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_set_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7415,7 +7415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_meth_get_puts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7426,11 +7426,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_s_secmem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7796,197 +7796,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_value_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_negative"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bin2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2bin"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_le2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2le_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2bin_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2hex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_hex2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_dec2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_asc2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_marshal_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_start"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_end"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_uadd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_add_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_usub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sub_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7995,15 +7995,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mul_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_div"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8013,11 +8013,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_div_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8025,47 +8025,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_cmp_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_ucmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_equal_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_abs_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_one"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8073,11 +8073,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8085,43 +8085,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_clear_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_bit_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mask_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_nnmod_pow2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_nnmod"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8130,7 +8130,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8140,7 +8140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_add_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8149,7 +8149,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sub"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8159,7 +8159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sub_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8168,7 +8168,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8178,7 +8178,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sqr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8187,7 +8187,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8197,7 +8197,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8206,7 +8206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8215,7 +8215,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8223,7 +8223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_sqrt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8232,7 +8232,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8241,7 +8241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_pseudo_rand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8250,11 +8250,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_rand_range_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8262,7 +8262,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8390,15 +8390,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8412,7 +8412,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8420,11 +8420,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_generate_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8439,7 +8439,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8449,7 +8449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_primality_test"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8460,7 +8460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8470,7 +8470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_is_prime_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8479,7 +8479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_gcd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8488,7 +8488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_inverse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8497,7 +8497,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8507,7 +8507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8517,23 +8517,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_to_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8542,7 +8542,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_from_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8551,7 +8551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8561,7 +8561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8570,7 +8570,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8580,7 +8580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8591,7 +8591,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8602,7 +8602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_GENCB_set_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8616,15 +8616,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2mpi"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mpi2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8635,7 +8635,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8648,11 +8648,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8660,7 +8660,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_bn2binpad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8668,15 +8668,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_CTX_secure_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8836,15 +8836,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_num_bits_word"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_tag2bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_tag2str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8868,15 +8868,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8885,7 +8885,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8893,7 +8893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8901,14 +8901,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8916,7 +8916,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8924,7 +8924,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8932,7 +8932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8940,7 +8940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_i2d_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8948,14 +8948,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_unpack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_pack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8963,7 +8963,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8971,22 +8971,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9062,54 +9062,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9117,7 +9117,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9125,79 +9125,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9205,7 +9205,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9213,7 +9213,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9221,7 +9221,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9229,7 +9229,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9237,7 +9237,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9245,7 +9245,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9253,7 +9253,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9261,7 +9261,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9269,117 +9269,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9387,14 +9387,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9404,7 +9404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9416,7 +9416,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9426,7 +9426,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9436,15 +9436,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9452,26 +9452,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9479,23 +9479,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9503,14 +9503,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9518,25 +9518,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9544,7 +9544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9552,14 +9552,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9588,19 +9588,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9608,11 +9608,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9620,54 +9620,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9675,59 +9675,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9735,23 +9735,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9760,26 +9760,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9787,29 +9787,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9818,22 +9818,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9841,15 +9841,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_diff"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9858,15 +9858,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9875,52 +9875,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_NULL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_NULL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9928,11 +9928,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_NULL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9957,7 +9957,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9967,11 +9967,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9979,11 +9979,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9991,7 +9991,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10325,15 +10325,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10341,19 +10341,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ANY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10361,7 +10361,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10369,12 +10369,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10382,14 +10382,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10397,33 +10397,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_TIME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10431,7 +10431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10439,19 +10439,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10459,7 +10459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10467,7 +10467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10477,7 +10477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_put_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10487,11 +10487,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_put_eoc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_object_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10499,15 +10499,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10515,52 +10515,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11159,7 +11159,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11184,19 +11184,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodedLength"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeBase64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11206,19 +11206,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11228,7 +11228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11236,11 +11236,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11250,7 +11250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11258,7 +11258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecodeBlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11417,11 +11417,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11429,11 +11429,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BLAKE2B256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11488,19 +11488,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11509,7 +11509,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BF_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11570,23 +11570,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_skip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_stow"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11594,86 +11594,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_strdup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_mem_equal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_last_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_copy_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_until_first"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11681,7 +11681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11689,11 +11689,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_any_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11701,7 +11701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11710,7 +11710,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11721,22 +11721,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11745,7 +11745,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11754,7 +11754,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11763,7 +11763,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11772,37 +11772,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11810,7 +11810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_parse_utc_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11818,7 +11818,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12125,23 +12125,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_init_fixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12149,40 +12149,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_flush"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12190,15 +12190,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_zeros"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_space"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12206,55 +12206,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_reserve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_did_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u16"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u16le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u32"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u32le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_u64le"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_discard_child"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12262,11 +12262,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12274,7 +12274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12282,11 +12282,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12294,11 +12294,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12309,122 +12309,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_rc4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede3"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_xts"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_enc_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_rc2_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12435,7 +12435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12445,7 +12445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12455,7 +12455,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12465,7 +12465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12473,7 +12473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12483,7 +12483,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12491,7 +12491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12501,7 +12501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12509,47 +12509,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12558,49 +12558,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_BytesToKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12613,23 +12613,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12639,7 +12639,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12648,7 +12648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12657,7 +12657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CipherFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12665,7 +12665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_EncryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12673,7 +12673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DecryptFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12681,7 +12681,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_Cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12690,127 +12690,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_bf_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_bf_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_bf_cfb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_cast5_ecb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_cast5_cbc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13050,7 +13050,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AES_CMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13060,19 +13060,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13082,15 +13082,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13098,7 +13098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13189,15 +13189,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_load"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13205,7 +13205,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_load_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13213,14 +13213,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_get_section"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NCONF_get_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13228,7 +13228,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13236,31 +13236,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_unload"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CONF_modules_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_no_config"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13268,11 +13268,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13281,7 +13281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13291,15 +13291,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CTR_DRBG_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X25519"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13307,15 +13307,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X25519_public_from_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_keypair"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13324,7 +13324,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13333,7 +13333,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13344,7 +13344,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13354,11 +13354,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13369,7 +13369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SPAKE2_process_msg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13442,33 +13442,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_is_weak_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_set_key_unchecked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_key_sched"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_set_odd_parity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ecb_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13477,7 +13477,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13488,7 +13488,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13499,7 +13499,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13512,7 +13512,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13524,47 +13524,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_new_by_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13572,7 +13572,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13580,7 +13580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13589,7 +13589,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13598,44 +13598,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_set_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13644,11 +13644,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_compute_key_padded"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13656,7 +13656,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_compute_key_hashed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13667,19 +13667,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_num_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_check_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13687,19 +13687,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DHparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_generate_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13714,7 +13714,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13722,14 +13722,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13737,130 +13737,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_get_2048_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DH_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_ripemd160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha512_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha512_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_sha3_512"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_shake128"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_shake256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_blake2b256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md5_sha1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_digestbynid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13868,11 +13868,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13880,7 +13880,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13888,7 +13888,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13896,7 +13896,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_Digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13907,63 +13907,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_get_digestbyname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13971,15 +13971,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14088,39 +14088,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_add_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_md_null"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14128,7 +14128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14136,31 +14136,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_pub_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_priv_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_g"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14168,7 +14168,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14177,7 +14177,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14185,7 +14185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_set0_pqg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14194,7 +14194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14206,11 +14206,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSAparams_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14264,28 +14264,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14294,7 +14294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_do_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14304,7 +14304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14315,7 +14315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14326,7 +14326,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_check_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14337,47 +14337,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_marshal_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_dup_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14387,7 +14387,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14395,14 +14395,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14410,11 +14410,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14422,11 +14422,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14434,11 +14434,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14446,7 +14446,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14457,31 +14457,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p224"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p384"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_p521"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_group_secp256k1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14489,19 +14489,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14509,7 +14509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14519,53 +14519,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_curve_nid2nist"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_curve_nist2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14573,7 +14573,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14582,7 +14582,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14592,7 +14592,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14602,7 +14602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14612,7 +14612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14622,7 +14622,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_point2oct"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14633,7 +14633,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14643,7 +14643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_oct2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14653,7 +14653,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14663,7 +14663,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14673,7 +14673,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_dbl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14682,7 +14682,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_invert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14690,7 +14690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_mul"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14701,7 +14701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14712,7 +14712,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14723,15 +14723,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14740,7 +14740,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14749,7 +14749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_point2bn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14759,7 +14759,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_bn2point"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14768,7 +14768,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_order"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14826,28 +14826,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_get_builtin_curves"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_POINT_clear_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14855,15 +14855,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECPKParameters_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14877,122 +14877,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_GROUP_method_of"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_set_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_get_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_set_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_get_EC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ENGINE_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get0_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_group"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15000,7 +15000,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_key2buf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15009,15 +15009,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15025,11 +15025,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15037,22 +15037,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15062,7 +15062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15070,14 +15070,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15085,11 +15085,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15097,19 +15097,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_o2i_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15117,38 +15117,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2o_ECPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15175,7 +15175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15185,18 +15185,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDH_compute_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15213,7 +15213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15222,7 +15222,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15233,7 +15233,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15244,7 +15244,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15298,23 +15298,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15322,7 +15322,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15330,7 +15330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_do_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15338,7 +15338,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_do_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15347,19 +15347,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15367,11 +15367,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15381,7 +15381,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15389,83 +15389,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15603,11 +15603,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15616,11 +15616,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15631,11 +15631,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15650,7 +15650,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15665,7 +15665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15683,7 +15683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15698,70 +15698,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15772,7 +15772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15780,7 +15780,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15789,7 +15789,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15797,70 +15797,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_obj2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_cbs2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_sn2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_ln2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_txt2nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_get_undef"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2sn"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2ln"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_nid2cbb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_txt2obj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_obj2txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15869,7 +15869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15877,7 +15877,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15885,7 +15885,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15966,7 +15966,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15976,163 +15976,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OBJ_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16141,7 +16141,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16150,7 +16150,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16158,7 +16158,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16166,7 +16166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16176,7 +16176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16184,7 +16184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16192,7 +16192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestSign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16202,7 +16202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16212,7 +16212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16220,7 +16220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16228,7 +16228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_DigestVerify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16238,7 +16238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16246,11 +16246,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16258,7 +16258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_SignFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16267,7 +16267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16275,11 +16275,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyInit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16287,7 +16287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_VerifyFinal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16296,7 +16296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16305,7 +16305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16314,7 +16314,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16323,7 +16323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16336,7 +16336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16348,7 +16348,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16363,31 +16363,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16397,11 +16397,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16411,11 +16411,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16425,11 +16425,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16439,11 +16439,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16453,18 +16453,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_derive"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16472,18 +16472,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16493,7 +16493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16503,102 +16503,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16606,28 +16606,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16635,7 +16635,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16643,7 +16643,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16653,33 +16653,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16687,7 +16687,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16698,15 +16698,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16720,7 +16720,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16734,7 +16734,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_MD_do_all"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16748,15 +16748,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16765,7 +16765,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16773,7 +16773,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16782,14 +16782,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16797,40 +16797,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16838,11 +16838,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16850,11 +16850,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16862,11 +16862,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16874,7 +16874,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_assign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16882,7 +16882,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16891,45 +16891,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16939,26 +16939,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HKDF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16972,7 +16972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HKDF_extract"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16984,7 +16984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HKDF_expand"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16996,11 +16996,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17008,15 +17008,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD5_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17103,7 +17103,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17115,27 +17115,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Init_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17145,7 +17145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17153,7 +17153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17161,27 +17161,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_reset"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17189,7 +17189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17198,7 +17198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17207,7 +17207,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HMAC_CTX_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17383,86 +17383,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17471,18 +17471,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17491,7 +17491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17500,23 +17500,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17532,7 +17532,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17550,7 +17550,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17563,7 +17563,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17579,7 +17579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17597,7 +17597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17612,7 +17612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17625,7 +17625,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17638,7 +17638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17648,19 +17648,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17919,7 +17919,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17927,7 +17927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_encap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17936,7 +17936,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_decap"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17945,18 +17945,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_HRSS_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17972,7 +17972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSKDF_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17984,7 +17984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SSKDF_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17998,7 +17998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18010,21 +18010,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18032,7 +18032,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18040,7 +18040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18048,11 +18048,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18060,15 +18060,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_MD4_Transform"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18170,7 +18170,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18178,47 +18178,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18486,15 +18486,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18502,26 +18502,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18529,26 +18529,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18556,14 +18556,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18611,37 +18611,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18650,46 +18650,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_certificate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_add_signer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_content_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_set_cipher"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_set_content"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_set_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18698,31 +18698,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS7_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18748,15 +18748,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18764,18 +18764,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18783,31 +18783,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18820,59 +18820,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_bits"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_n"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_p"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_q"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_dmp1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_dmq1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_iqmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18881,11 +18881,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18894,7 +18894,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set0_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18903,12 +18903,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set0_factors"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set0_crt_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18917,44 +18917,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_default_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18969,7 +18969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18984,7 +18984,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -18999,7 +18999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19014,14 +19014,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_meth_set_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19037,7 +19037,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_generate_key_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19046,7 +19046,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_generate_key_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19054,7 +19054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19066,7 +19066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19078,7 +19078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19088,7 +19088,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19098,7 +19098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19109,7 +19109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19123,7 +19123,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_sign_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19135,7 +19135,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19146,7 +19146,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19159,7 +19159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_raw"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19171,7 +19171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19181,7 +19181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19191,31 +19191,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_size"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_is_opaque"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSAPublicKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_check_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_check_fips"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19226,7 +19226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19237,7 +19237,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19250,7 +19250,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS1_MGF1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19260,7 +19260,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19271,19 +19271,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_parse_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_marshal_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19291,19 +19291,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_parse_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_marshal_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19311,7 +19311,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19319,15 +19319,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19340,7 +19340,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19350,7 +19350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19358,34 +19358,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_test_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_blinding_on"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19395,7 +19395,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19404,7 +19404,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19412,11 +19412,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19424,11 +19424,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19438,7 +19438,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19448,7 +19448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19459,7 +19459,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19467,7 +19467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19475,11 +19475,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_get0_pss_params"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_new_method_no_e"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19498,27 +19498,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_chain_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19526,62 +19526,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_parse_from_buffer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_uids"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19589,27 +19589,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_extension_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_pathlen"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19635,11 +19635,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_authority_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19648,15 +19648,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19664,7 +19664,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19672,7 +19672,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19680,11 +19680,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19693,11 +19693,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_signature_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19707,7 +19707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19715,84 +19715,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get1_ocsp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_email_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_getm_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_getm_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19800,7 +19800,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19810,7 +19810,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19818,25 +19818,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19844,11 +19844,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19856,7 +19856,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_alias_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19864,7 +19864,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_keyid_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19872,33 +19872,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_alias_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_keyid_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add1_trust_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_add1_reject_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_trust_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_reject_clear"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19938,23 +19938,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19962,27 +19962,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19990,7 +19990,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19998,19 +19998,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20018,7 +20018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20026,7 +20026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20034,11 +20034,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20047,7 +20047,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20055,70 +20055,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_sort"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20126,7 +20126,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20136,7 +20136,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20144,25 +20144,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20170,26 +20170,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20197,45 +20197,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20243,7 +20243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20251,7 +20251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20259,21 +20259,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20281,7 +20281,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20290,7 +20290,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20300,19 +20300,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20320,45 +20320,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20366,7 +20366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20374,15 +20374,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20390,55 +20390,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_get1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set_version"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20448,7 +20448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20458,7 +20458,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20468,7 +20468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20476,14 +20476,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20491,22 +20491,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20556,19 +20556,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20576,19 +20576,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get0_der"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20596,15 +20596,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_entry_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20612,7 +20612,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20620,21 +20620,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20643,7 +20643,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20655,7 +20655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20667,7 +20667,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20679,19 +20679,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20699,33 +20699,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20734,11 +20734,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20748,7 +20748,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20758,7 +20758,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20768,19 +20768,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20788,23 +20788,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20815,7 +20815,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20825,23 +20825,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20849,18 +20849,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20869,7 +20869,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20878,33 +20878,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20928,11 +20928,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20940,18 +20940,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20959,7 +20959,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20967,7 +20967,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20975,21 +20975,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509v3_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21332,15 +21332,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21348,23 +21348,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21372,27 +21372,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OTHERNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OTHERNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21400,14 +21400,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21415,7 +21415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21444,23 +21444,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21468,11 +21468,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_set0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21481,7 +21481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21490,11 +21490,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21519,23 +21519,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21543,14 +21543,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21558,7 +21558,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21568,7 +21568,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21578,7 +21578,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21588,14 +21588,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21604,7 +21604,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21613,89 +21613,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_up_ref"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_add_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_add_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set1_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21704,92 +21704,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_verify_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21797,7 +21797,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21805,95 +21805,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21901,7 +21901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21909,14 +21909,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21924,7 +21924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21932,21 +21932,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22014,19 +22014,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22034,43 +22034,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22128,19 +22128,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22148,14 +22148,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22242,19 +22242,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22262,26 +22262,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22289,34 +22289,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22324,11 +22324,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_SIG"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22336,7 +22336,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_SIG_getm"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22344,7 +22344,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22353,7 +22353,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22362,23 +22362,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22387,15 +22387,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_print_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22404,7 +22404,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22412,7 +22412,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_oneline"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22420,7 +22420,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22429,7 +22429,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_signature_dump"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22437,7 +22437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_signature_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22445,7 +22445,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22454,7 +22454,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22463,7 +22463,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_extensions_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22473,11 +22473,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_NAME_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_pubkey_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22486,7 +22486,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22495,7 +22495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22504,7 +22504,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_REQ_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22513,7 +22513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22522,259 +22522,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DHparams_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22782,23 +22782,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_find_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp_time_posix"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp_current_time"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_time_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22806,7 +22806,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_time_adj_ex"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22815,40 +22815,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_gmtime_adj"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_subject_name_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_issuer_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_subject_name_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22858,7 +22858,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22866,14 +22866,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22883,7 +22883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22891,14 +22891,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22908,7 +22908,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22916,14 +22916,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22933,7 +22933,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_digest"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22943,7 +22943,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22953,7 +22953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22965,7 +22965,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22976,26 +22976,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_supported_extension"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_ca"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_issued"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_host"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23005,7 +23005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_email"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23014,7 +23014,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_ip"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23023,7 +23023,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_ip_asc"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23031,7 +23031,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23039,7 +23039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_purpose"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23047,7 +23047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_check_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23208,7 +23208,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_INFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23306,7 +23306,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_set_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23317,11 +23317,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_set_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23330,7 +23330,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23339,7 +23339,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23348,7 +23348,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23357,7 +23357,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23366,7 +23366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23375,7 +23375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23384,7 +23384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_conf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23393,14 +23393,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23408,32 +23408,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_conf_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23441,7 +23441,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23449,43 +23449,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_a2i_IPADDRESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_notBefore"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_set_notAfter"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_serialNumber"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23494,7 +23494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23503,31 +23503,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_parse_list"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23537,7 +23537,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23549,7 +23549,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23563,15 +23563,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23751,74 +23751,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_area"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_get_default_private_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_hash"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_NAME_hash_old"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_CRL_match"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23843,7 +23843,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23851,7 +23851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23859,79 +23859,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_lock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_unlock"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23940,7 +23940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23950,7 +23950,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_load_cert_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23958,7 +23958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_load_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23966,7 +23966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23974,7 +23974,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_load_locations"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23982,7 +23982,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25426,15 +25426,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25442,26 +25442,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25469,26 +25469,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25496,26 +25496,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25523,26 +25523,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25550,26 +25550,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_POLICYINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25577,26 +25577,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_USERNOTICE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_USERNOTICE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25604,26 +25604,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_USERNOTICE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_USERNOTICE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NOTICEREF_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NOTICEREF_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25631,26 +25631,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_NOTICEREF"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NOTICEREF_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25658,26 +25658,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25685,26 +25685,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25712,26 +25712,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25739,33 +25739,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25773,26 +25773,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25800,77 +25800,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25880,19 +25880,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_get"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_get_d2i"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25901,14 +25901,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25916,7 +25916,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509V3_add1_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25926,43 +25926,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_set"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26129,15 +26129,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26145,26 +26145,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26172,26 +26172,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26199,26 +26199,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26226,26 +26226,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26253,41 +26253,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26295,7 +26295,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_sendreq_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26304,26 +26304,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26331,14 +26331,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26346,7 +26346,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26354,15 +26354,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_add0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26370,7 +26370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26378,48 +26378,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_check_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_copy_nonce"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_set1_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_is_signed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26430,23 +26430,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_get0"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_single_get0_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26456,7 +26456,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_find"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26464,7 +26464,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_resp_find_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26476,7 +26476,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_check_validity"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26485,7 +26485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26494,7 +26494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_request_verify"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26503,7 +26503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_cert_id_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26512,7 +26512,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_cert_to_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26520,7 +26520,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_parse_url"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26530,18 +26530,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_id_cmp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_id_get0_info"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26551,14 +26551,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26570,7 +26570,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_basic_sign"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26581,36 +26581,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_response_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_cert_status_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26618,7 +26618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26626,7 +26626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26634,21 +26634,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26656,11 +26656,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26675,14 +26675,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_do_header"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26692,7 +26692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26702,7 +26702,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26712,7 +26712,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26724,7 +26724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26735,7 +26735,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26749,7 +26749,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26758,7 +26758,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26767,7 +26767,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26777,7 +26777,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26787,7 +26787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_read"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26798,7 +26798,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_ASN1_write"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26812,7 +26812,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_def_callback"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26821,7 +26821,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26830,7 +26830,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26839,15 +26839,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26856,7 +26856,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26865,15 +26865,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26882,7 +26882,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26891,23 +26891,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26916,7 +26916,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26925,15 +26925,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26942,7 +26942,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26951,15 +26951,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS7"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26968,7 +26968,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26977,15 +26977,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26994,7 +26994,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27003,21 +27003,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27026,7 +27026,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27035,7 +27035,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27047,7 +27047,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27059,7 +27059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27068,7 +27068,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27077,15 +27077,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27094,7 +27094,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27103,15 +27103,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27120,7 +27120,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27129,7 +27129,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27141,7 +27141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27153,7 +27153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27162,7 +27162,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27171,15 +27171,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27188,7 +27188,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27197,15 +27197,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DSAparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27214,7 +27214,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27223,7 +27223,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27235,7 +27235,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27247,7 +27247,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27256,7 +27256,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27265,15 +27265,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27282,7 +27282,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27291,15 +27291,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_DHparams"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27308,7 +27308,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27317,7 +27317,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27329,7 +27329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27341,7 +27341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27350,7 +27350,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27359,15 +27359,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27379,7 +27379,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27391,7 +27391,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27403,7 +27403,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27415,7 +27415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27424,7 +27424,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27436,7 +27436,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27448,7 +27448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27460,7 +27460,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27469,7 +27469,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27481,15 +27481,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27498,14 +27498,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27517,7 +27517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_encrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27530,7 +27530,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27544,7 +27544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_decrypt"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27552,7 +27552,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27560,7 +27560,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27569,11 +27569,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_PBE_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27581,27 +27581,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS12"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_parse"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27611,7 +27611,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_verify_mac"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27619,7 +27619,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_create"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27634,93 +27634,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_PKCS12_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_priv_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_seed"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_load_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_write_file"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_file_name"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_add"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_egd"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_egd_bytes"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_poll"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_status"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_cleanup"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27821,23 +27821,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_SSLeay"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_OpenSSL"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_get_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_set_rand_method"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27902,11 +27902,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RC4_set_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RC4"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27993,11 +27993,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160_Init"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160_Update"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28005,50 +28005,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160_Final"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_RIPEMD160"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_awslc_version_string"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_SIPHASH_24"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28123,15 +28123,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28144,7 +28144,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28159,18 +28159,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28179,14 +28179,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28195,7 +28195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28206,7 +28206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28215,7 +28215,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28227,7 +28227,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28239,18 +28239,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28258,14 +28258,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28273,7 +28273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28287,7 +28287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28300,7 +28300,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28315,7 +28315,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28327,7 +28327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_keygen_deterministic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_keygen_deterministic"]
     pub fn EVP_PKEY_keygen_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
@@ -28336,7 +28336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_EVP_PKEY_encapsulate_deterministic"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_EVP_PKEY_encapsulate_deterministic"]
     pub fn EVP_PKEY_encapsulate_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -28348,15 +28348,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}_aws_lc_fips_0_13_3_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}_aws_lc_fips_0_13_4_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_gnu_crypto.rs
@@ -4499,7 +4499,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4507,7 +4507,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4515,15 +4515,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4535,7 +4535,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4544,7 +4544,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4555,7 +4555,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4566,7 +4566,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4578,7 +4578,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4588,7 +4588,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4598,7 +4598,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4609,7 +4609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -5196,27 +5196,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -5224,29 +5224,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5254,7 +5254,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5262,11 +5262,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5274,15 +5274,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5369,11 +5369,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5381,19 +5381,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5401,19 +5401,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5511,11 +5511,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5523,19 +5523,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5543,15 +5543,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5649,11 +5649,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5661,19 +5661,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5681,42 +5681,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5724,62 +5724,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5787,7 +5787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5796,7 +5796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5805,7 +5805,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5813,7 +5813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5821,21 +5821,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5843,7 +5843,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5851,7 +5851,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5859,7 +5859,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5868,7 +5868,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5876,11 +5876,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5907,27 +5907,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 #[repr(C)]
@@ -5983,19 +5983,19 @@ impl Default for crypto_mutex_st {
 pub type CRYPTO_MUTEX = crypto_mutex_st;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6008,7 +6008,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6022,7 +6022,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6033,29 +6033,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -6111,7 +6111,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6122,7 +6122,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6135,7 +6135,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -6147,7 +6147,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -6156,7 +6156,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -6167,7 +6167,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -6177,30 +6177,30 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -6210,105 +6210,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6317,18 +6317,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6337,18 +6337,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6357,7 +6357,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6365,11 +6365,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6380,57 +6380,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6440,15 +6440,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6498,27 +6498,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6526,11 +6526,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6538,7 +6538,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6546,18 +6546,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6566,7 +6566,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6575,45 +6575,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6624,7 +6624,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6684,7 +6684,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6755,23 +6755,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6779,7 +6779,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6788,7 +6788,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6796,7 +6796,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6804,7 +6804,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6813,7 +6813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6821,15 +6821,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6838,7 +6838,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6846,7 +6846,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6855,71 +6855,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6942,7 +6942,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6950,68 +6950,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -7019,7 +7019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -7027,7 +7027,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -7036,11 +7036,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -7049,15 +7049,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -7065,11 +7065,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -7077,22 +7077,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -7100,30 +7100,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -7131,89 +7131,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -7222,34 +7222,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -7258,13 +7258,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -7273,13 +7273,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -7292,7 +7292,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -7305,7 +7305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7318,7 +7318,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7330,7 +7330,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7344,7 +7344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7357,7 +7357,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7370,7 +7370,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7382,23 +7382,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7408,7 +7408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7416,30 +7416,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7451,7 +7451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7462,11 +7462,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7832,197 +7832,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8031,15 +8031,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -8049,11 +8049,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -8061,47 +8061,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8109,11 +8109,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8121,43 +8121,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -8166,7 +8166,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8176,7 +8176,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8185,7 +8185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8195,7 +8195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8204,7 +8204,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8214,7 +8214,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8223,7 +8223,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8233,7 +8233,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8242,7 +8242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8251,7 +8251,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8259,7 +8259,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8268,7 +8268,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8277,7 +8277,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8286,11 +8286,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -8298,7 +8298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8426,15 +8426,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8448,7 +8448,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8456,11 +8456,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8475,7 +8475,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8485,7 +8485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8496,7 +8496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8506,7 +8506,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8515,7 +8515,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8524,7 +8524,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8533,7 +8533,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8543,7 +8543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8553,23 +8553,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8578,7 +8578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8587,7 +8587,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8597,7 +8597,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8606,7 +8606,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8616,7 +8616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8627,7 +8627,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8638,7 +8638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8652,15 +8652,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8671,7 +8671,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8684,11 +8684,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8696,7 +8696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8704,15 +8704,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8872,15 +8872,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8904,15 +8904,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8921,7 +8921,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8929,7 +8929,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8937,14 +8937,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8952,7 +8952,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8960,7 +8960,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8968,7 +8968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8976,7 +8976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8984,14 +8984,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8999,7 +8999,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -9007,22 +9007,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9098,54 +9098,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -9153,7 +9153,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -9161,79 +9161,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -9241,7 +9241,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -9249,7 +9249,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -9257,7 +9257,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -9265,7 +9265,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -9273,7 +9273,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -9281,7 +9281,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -9289,7 +9289,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -9297,7 +9297,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -9305,117 +9305,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9423,14 +9423,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9440,7 +9440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9452,7 +9452,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9462,7 +9462,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9472,15 +9472,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9488,26 +9488,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9515,23 +9515,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9539,14 +9539,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9554,25 +9554,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9580,7 +9580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9588,14 +9588,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9624,19 +9624,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9644,11 +9644,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9656,54 +9656,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9711,59 +9711,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9771,23 +9771,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9796,26 +9796,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9823,29 +9823,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9854,22 +9854,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9877,15 +9877,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9894,15 +9894,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9911,52 +9911,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9964,11 +9964,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9993,7 +9993,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -10003,11 +10003,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10015,11 +10015,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -10027,7 +10027,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10361,15 +10361,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10377,19 +10377,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10397,7 +10397,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10405,12 +10405,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10418,14 +10418,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10433,33 +10433,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10467,7 +10467,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10475,19 +10475,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10495,7 +10495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10503,7 +10503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10513,7 +10513,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10523,11 +10523,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10535,15 +10535,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10551,52 +10551,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -11195,7 +11195,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -11220,19 +11220,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -11242,19 +11242,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11264,7 +11264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11272,11 +11272,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11286,7 +11286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -11294,7 +11294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11453,11 +11453,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11465,11 +11465,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11524,19 +11524,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11545,7 +11545,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11606,23 +11606,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11630,86 +11630,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11717,7 +11717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11725,11 +11725,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11737,7 +11737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11746,7 +11746,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11757,22 +11757,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11781,7 +11781,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11790,7 +11790,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11799,7 +11799,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11808,37 +11808,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11846,7 +11846,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11854,7 +11854,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -12161,23 +12161,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12185,40 +12185,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -12226,15 +12226,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -12242,55 +12242,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -12298,11 +12298,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -12310,7 +12310,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12318,11 +12318,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12330,11 +12330,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12345,122 +12345,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12471,7 +12471,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12481,7 +12481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12491,7 +12491,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12501,7 +12501,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12509,7 +12509,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12519,7 +12519,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12527,7 +12527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12537,7 +12537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12545,47 +12545,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12594,49 +12594,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12649,23 +12649,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12675,7 +12675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12684,7 +12684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12693,7 +12693,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12701,7 +12701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12709,7 +12709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12717,7 +12717,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12726,127 +12726,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -13086,7 +13086,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -13096,19 +13096,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -13118,15 +13118,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -13134,7 +13134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -13225,15 +13225,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -13241,7 +13241,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -13249,14 +13249,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -13264,7 +13264,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -13272,31 +13272,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -13304,11 +13304,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13317,7 +13317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13327,15 +13327,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13343,15 +13343,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13360,7 +13360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13369,7 +13369,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13380,7 +13380,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13390,11 +13390,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13405,7 +13405,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13478,33 +13478,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13513,7 +13513,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13524,7 +13524,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13535,7 +13535,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13548,7 +13548,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13560,47 +13560,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13608,7 +13608,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13616,7 +13616,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13625,7 +13625,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13634,44 +13634,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13680,11 +13680,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13692,7 +13692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13703,19 +13703,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13723,19 +13723,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13750,7 +13750,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13758,14 +13758,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13773,130 +13773,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13904,11 +13904,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13916,7 +13916,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13924,7 +13924,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13932,7 +13932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13943,63 +13943,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -14007,15 +14007,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -14124,39 +14124,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -14164,7 +14164,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -14172,31 +14172,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -14204,7 +14204,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -14213,7 +14213,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -14221,7 +14221,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -14230,7 +14230,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -14242,11 +14242,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -14300,28 +14300,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14330,7 +14330,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14340,7 +14340,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14351,7 +14351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14362,7 +14362,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14373,47 +14373,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14423,7 +14423,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14431,14 +14431,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14446,11 +14446,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14458,11 +14458,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14470,11 +14470,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14482,7 +14482,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14493,31 +14493,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14525,19 +14525,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14545,7 +14545,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14555,53 +14555,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14609,7 +14609,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14618,7 +14618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14628,7 +14628,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14638,7 +14638,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14648,7 +14648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14658,7 +14658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14669,7 +14669,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14679,7 +14679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14689,7 +14689,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14699,7 +14699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14709,7 +14709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14718,7 +14718,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14726,7 +14726,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14737,7 +14737,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14748,7 +14748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14759,15 +14759,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14776,7 +14776,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14785,7 +14785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14795,7 +14795,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14804,7 +14804,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14862,28 +14862,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14891,15 +14891,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14913,122 +14913,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -15036,7 +15036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -15045,15 +15045,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -15061,11 +15061,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -15073,22 +15073,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -15098,7 +15098,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -15106,14 +15106,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15121,11 +15121,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15133,19 +15133,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -15153,38 +15153,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -15211,7 +15211,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -15221,18 +15221,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -15249,7 +15249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -15258,7 +15258,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15269,7 +15269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -15280,7 +15280,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15334,23 +15334,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15358,7 +15358,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15366,7 +15366,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15374,7 +15374,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15383,19 +15383,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15403,11 +15403,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15417,7 +15417,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15425,83 +15425,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15639,11 +15639,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15652,11 +15652,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15667,11 +15667,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15686,7 +15686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15701,7 +15701,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15719,7 +15719,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15734,70 +15734,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15808,7 +15808,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15816,7 +15816,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15825,7 +15825,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15833,70 +15833,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15905,7 +15905,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15913,7 +15913,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15921,7 +15921,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -16002,7 +16002,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -16012,163 +16012,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16177,7 +16177,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -16186,7 +16186,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16194,7 +16194,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -16202,7 +16202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16212,7 +16212,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16220,7 +16220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16228,7 +16228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -16238,7 +16238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -16248,7 +16248,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16256,7 +16256,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16264,7 +16264,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16274,7 +16274,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16282,11 +16282,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16294,7 +16294,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -16303,7 +16303,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16311,11 +16311,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16323,7 +16323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16332,7 +16332,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16341,7 +16341,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16350,7 +16350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16359,7 +16359,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16372,7 +16372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16384,7 +16384,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16399,31 +16399,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16433,11 +16433,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16447,11 +16447,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16461,11 +16461,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16475,11 +16475,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16489,18 +16489,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16508,18 +16508,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16529,7 +16529,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16539,102 +16539,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16642,28 +16642,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16671,7 +16671,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16679,7 +16679,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16689,33 +16689,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16723,7 +16723,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16734,15 +16734,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16756,7 +16756,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16770,7 +16770,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16784,15 +16784,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16801,7 +16801,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16809,7 +16809,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16818,14 +16818,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16833,40 +16833,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16874,11 +16874,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16886,11 +16886,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16898,11 +16898,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16910,7 +16910,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16918,7 +16918,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16927,45 +16927,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16975,26 +16975,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -17008,7 +17008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -17020,7 +17020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -17032,11 +17032,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17044,15 +17044,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17139,7 +17139,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -17151,27 +17151,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17181,7 +17181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -17189,7 +17189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17197,27 +17197,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -17225,7 +17225,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -17234,7 +17234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -17243,7 +17243,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17419,86 +17419,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17507,18 +17507,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17527,7 +17527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17536,23 +17536,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17568,7 +17568,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17586,7 +17586,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17599,7 +17599,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17615,7 +17615,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17633,7 +17633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17648,7 +17648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17661,7 +17661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17674,7 +17674,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17684,19 +17684,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17955,7 +17955,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17963,7 +17963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17972,7 +17972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17981,18 +17981,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -18008,7 +18008,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -18020,7 +18020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18034,7 +18034,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -18046,21 +18046,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -18068,7 +18068,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -18076,7 +18076,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -18084,11 +18084,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -18096,15 +18096,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -18206,7 +18206,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -18214,47 +18214,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18522,15 +18522,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18538,26 +18538,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18565,26 +18565,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18592,14 +18592,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18647,37 +18647,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18686,46 +18686,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18734,31 +18734,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18784,15 +18784,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18800,18 +18800,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18819,31 +18819,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18856,59 +18856,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18917,11 +18917,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18930,7 +18930,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18939,12 +18939,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18953,44 +18953,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -19005,7 +19005,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -19020,7 +19020,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -19035,7 +19035,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -19050,14 +19050,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -19073,7 +19073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19082,7 +19082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -19090,7 +19090,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19102,7 +19102,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19114,7 +19114,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -19124,7 +19124,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -19134,7 +19134,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19145,7 +19145,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19159,7 +19159,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19171,7 +19171,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -19182,7 +19182,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -19195,7 +19195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -19207,7 +19207,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -19217,7 +19217,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -19227,31 +19227,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19262,7 +19262,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19273,7 +19273,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -19286,7 +19286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -19296,7 +19296,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -19307,19 +19307,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19327,19 +19327,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19347,7 +19347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19355,15 +19355,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19376,7 +19376,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19386,7 +19386,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19394,34 +19394,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19431,7 +19431,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19440,7 +19440,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19448,11 +19448,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19460,11 +19460,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19474,7 +19474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19484,7 +19484,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19495,7 +19495,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19503,7 +19503,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19511,11 +19511,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19534,27 +19534,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19562,62 +19562,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19625,27 +19625,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19671,11 +19671,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19684,15 +19684,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19700,7 +19700,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19708,7 +19708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19716,11 +19716,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19729,11 +19729,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19743,7 +19743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19751,84 +19751,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19836,7 +19836,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19846,7 +19846,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19854,25 +19854,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19880,11 +19880,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19892,7 +19892,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19900,7 +19900,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19908,33 +19908,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19974,23 +19974,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19998,27 +19998,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20026,7 +20026,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -20034,19 +20034,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20054,7 +20054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -20062,7 +20062,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -20070,11 +20070,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20083,7 +20083,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20091,70 +20091,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -20162,7 +20162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -20172,7 +20172,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -20180,25 +20180,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -20206,26 +20206,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -20233,45 +20233,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20279,7 +20279,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -20287,7 +20287,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -20295,21 +20295,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20317,7 +20317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20326,7 +20326,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20336,19 +20336,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20356,45 +20356,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20402,7 +20402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20410,15 +20410,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20426,55 +20426,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20484,7 +20484,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20494,7 +20494,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20504,7 +20504,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20512,14 +20512,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20527,22 +20527,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20592,19 +20592,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20612,19 +20612,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20632,15 +20632,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20648,7 +20648,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20656,21 +20656,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20679,7 +20679,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20691,7 +20691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20703,7 +20703,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20715,19 +20715,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20735,33 +20735,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20770,11 +20770,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20784,7 +20784,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20794,7 +20794,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20804,19 +20804,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20824,23 +20824,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20851,7 +20851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20861,23 +20861,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20885,18 +20885,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20905,7 +20905,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20914,33 +20914,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20964,11 +20964,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20976,18 +20976,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20995,7 +20995,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -21003,7 +21003,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -21011,21 +21011,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21368,15 +21368,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21384,23 +21384,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21408,27 +21408,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21436,14 +21436,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21451,7 +21451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21480,23 +21480,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21504,11 +21504,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21517,7 +21517,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21526,11 +21526,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21555,23 +21555,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21579,14 +21579,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21594,7 +21594,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21604,7 +21604,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21614,7 +21614,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21624,14 +21624,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21640,7 +21640,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21649,89 +21649,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21740,92 +21740,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21833,7 +21833,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21841,95 +21841,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21937,7 +21937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21945,14 +21945,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21960,7 +21960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21968,21 +21968,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -22050,19 +22050,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -22070,43 +22070,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -22164,19 +22164,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -22184,14 +22184,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -22278,19 +22278,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -22298,26 +22298,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22325,34 +22325,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22360,11 +22360,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22372,7 +22372,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22380,7 +22380,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22389,7 +22389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22398,23 +22398,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22423,15 +22423,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22440,7 +22440,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22448,7 +22448,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22456,7 +22456,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22465,7 +22465,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22473,7 +22473,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22481,7 +22481,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22490,7 +22490,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22499,7 +22499,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22509,11 +22509,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22522,7 +22522,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22531,7 +22531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22540,7 +22540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22549,7 +22549,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22558,259 +22558,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22818,23 +22818,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22842,7 +22842,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22851,40 +22851,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22894,7 +22894,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22902,14 +22902,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22919,7 +22919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22927,14 +22927,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22944,7 +22944,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22952,14 +22952,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22969,7 +22969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22979,7 +22979,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22989,7 +22989,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23001,7 +23001,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -23012,26 +23012,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23041,7 +23041,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -23050,7 +23050,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -23059,7 +23059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -23067,7 +23067,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -23075,7 +23075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -23083,7 +23083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -23244,7 +23244,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23342,7 +23342,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23353,11 +23353,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23366,7 +23366,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23375,7 +23375,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23384,7 +23384,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23393,7 +23393,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23402,7 +23402,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23411,7 +23411,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23420,7 +23420,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23429,14 +23429,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23444,32 +23444,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23477,7 +23477,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23485,43 +23485,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23530,7 +23530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23539,31 +23539,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23573,7 +23573,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23585,7 +23585,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23599,15 +23599,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23787,74 +23787,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23879,7 +23879,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23887,7 +23887,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23895,79 +23895,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23976,7 +23976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23986,7 +23986,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23994,7 +23994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24002,7 +24002,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -24010,7 +24010,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -24018,7 +24018,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25462,15 +25462,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25478,26 +25478,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25505,26 +25505,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25532,26 +25532,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25559,26 +25559,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25586,26 +25586,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25613,26 +25613,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25640,26 +25640,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25667,26 +25667,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25694,26 +25694,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25721,26 +25721,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25748,26 +25748,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25775,33 +25775,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25809,26 +25809,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25836,77 +25836,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25916,19 +25916,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25937,14 +25937,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25952,7 +25952,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25962,43 +25962,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -26165,15 +26165,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26181,26 +26181,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26208,26 +26208,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26235,26 +26235,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26262,26 +26262,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -26289,41 +26289,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26331,7 +26331,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26340,26 +26340,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26367,14 +26367,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26382,7 +26382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26390,15 +26390,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26406,7 +26406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26414,48 +26414,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26466,23 +26466,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26492,7 +26492,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26500,7 +26500,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26512,7 +26512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26521,7 +26521,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26530,7 +26530,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26539,7 +26539,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26548,7 +26548,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26556,7 +26556,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26566,18 +26566,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26587,14 +26587,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26606,7 +26606,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26617,36 +26617,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26654,7 +26654,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26662,7 +26662,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26670,21 +26670,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26692,11 +26692,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26711,14 +26711,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26728,7 +26728,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26738,7 +26738,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26748,7 +26748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26760,7 +26760,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26771,7 +26771,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26785,7 +26785,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26794,7 +26794,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26803,7 +26803,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26813,7 +26813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26823,7 +26823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26834,7 +26834,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26848,7 +26848,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26857,7 +26857,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26866,7 +26866,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26875,15 +26875,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26892,7 +26892,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26901,15 +26901,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26918,7 +26918,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26927,23 +26927,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26952,7 +26952,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26961,15 +26961,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26978,7 +26978,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26987,15 +26987,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -27004,7 +27004,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -27013,15 +27013,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27030,7 +27030,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -27039,21 +27039,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27062,7 +27062,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27071,7 +27071,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -27083,7 +27083,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -27095,7 +27095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27104,7 +27104,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27113,15 +27113,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -27130,7 +27130,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -27139,15 +27139,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27156,7 +27156,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27165,7 +27165,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -27177,7 +27177,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -27189,7 +27189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27198,7 +27198,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27207,15 +27207,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -27224,7 +27224,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -27233,15 +27233,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27250,7 +27250,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27259,7 +27259,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -27271,7 +27271,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -27283,7 +27283,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -27292,7 +27292,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -27301,15 +27301,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27318,7 +27318,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27327,15 +27327,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27344,7 +27344,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27353,7 +27353,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27365,7 +27365,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27377,7 +27377,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27386,7 +27386,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27395,15 +27395,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27415,7 +27415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27427,7 +27427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27439,7 +27439,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27451,7 +27451,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27460,7 +27460,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27472,7 +27472,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27484,7 +27484,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27496,7 +27496,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27505,7 +27505,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27517,15 +27517,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27534,14 +27534,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27553,7 +27553,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27566,7 +27566,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27580,7 +27580,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27588,7 +27588,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27596,7 +27596,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27605,11 +27605,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27617,27 +27617,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27647,7 +27647,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27655,7 +27655,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27670,93 +27670,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27857,23 +27857,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27938,11 +27938,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -28029,11 +28029,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -28041,50 +28041,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -28159,15 +28159,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28180,7 +28180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -28195,18 +28195,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28215,14 +28215,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28231,7 +28231,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28242,7 +28242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -28251,7 +28251,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -28263,7 +28263,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -28275,18 +28275,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28294,14 +28294,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -28309,7 +28309,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28323,7 +28323,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28336,7 +28336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28351,7 +28351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28363,7 +28363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_deterministic"]
     pub fn EVP_PKEY_keygen_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
@@ -28372,7 +28372,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate_deterministic"]
     pub fn EVP_PKEY_encapsulate_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -28384,15 +28384,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];

--- a/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
+++ b/aws-lc-fips-sys/src/x86_64_unknown_linux_musl_crypto.rs
@@ -4597,7 +4597,7 @@ impl Default for aes_key_st {
 }
 pub type AES_KEY = aes_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_encrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_encrypt_key"]
     pub fn AES_set_encrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4605,7 +4605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_set_decrypt_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_set_decrypt_key"]
     pub fn AES_set_decrypt_key(
         key: *const u8,
         bits: ::std::os::raw::c_uint,
@@ -4613,15 +4613,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_encrypt"]
     pub fn AES_encrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_decrypt"]
     pub fn AES_decrypt(in_: *const u8, out: *mut u8, key: *const AES_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ctr128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ctr128_encrypt"]
     pub fn AES_ctr128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4633,7 +4633,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ecb_encrypt"]
     pub fn AES_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4642,7 +4642,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cbc_encrypt"]
     pub fn AES_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4653,7 +4653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_ofb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_ofb128_encrypt"]
     pub fn AES_ofb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4664,7 +4664,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_cfb128_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_cfb128_encrypt"]
     pub fn AES_cfb128_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -4676,7 +4676,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key"]
     pub fn AES_wrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4686,7 +4686,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key"]
     pub fn AES_unwrap_key(
         key: *const AES_KEY,
         iv: *const u8,
@@ -4696,7 +4696,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_wrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_wrap_key_padded"]
     pub fn AES_wrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4707,7 +4707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_unwrap_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_unwrap_key_padded"]
     pub fn AES_unwrap_key_padded(
         key: *const AES_KEY,
         out: *mut u8,
@@ -4935,27 +4935,27 @@ impl Default for buf_mem_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_new"]
     pub fn BUF_MEM_new() -> *mut BUF_MEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_free"]
     pub fn BUF_MEM_free(buf: *mut BUF_MEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_reserve"]
     pub fn BUF_MEM_reserve(buf: *mut BUF_MEM, cap: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow"]
     pub fn BUF_MEM_grow(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_grow_clean"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_grow_clean"]
     pub fn BUF_MEM_grow_clean(buf: *mut BUF_MEM, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_MEM_append"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_MEM_append"]
     pub fn BUF_MEM_append(
         buf: *mut BUF_MEM,
         in_: *const ::std::os::raw::c_void,
@@ -4963,29 +4963,29 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strdup"]
     pub fn BUF_strdup(str_: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strnlen"]
     pub fn BUF_strnlen(str_: *const ::std::os::raw::c_char, max_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strndup"]
     pub fn BUF_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_memdup"]
     pub fn BUF_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcpy"]
     pub fn BUF_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -4993,7 +4993,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BUF_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BUF_strlcat"]
     pub fn BUF_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5001,11 +5001,11 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Init"]
     pub fn SHA1_Init(sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Update"]
     pub fn SHA1_Update(
         sha: *mut SHA_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5013,15 +5013,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Final"]
     pub fn SHA1_Final(out: *mut u8, sha: *mut SHA_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1"]
     pub fn SHA1(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA1_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA1_Transform"]
     pub fn SHA1_Transform(sha: *mut SHA_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5108,11 +5108,11 @@ impl Default for sha_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Init"]
     pub fn SHA224_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Update"]
     pub fn SHA224_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5120,19 +5120,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224_Final"]
     pub fn SHA224_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA224"]
     pub fn SHA224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Init"]
     pub fn SHA256_Init(sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Update"]
     pub fn SHA256_Update(
         sha: *mut SHA256_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5140,19 +5140,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Final"]
     pub fn SHA256_Final(out: *mut u8, sha: *mut SHA256_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256"]
     pub fn SHA256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_Transform"]
     pub fn SHA256_Transform(sha: *mut SHA256_CTX, block: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA256_TransformBlocks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA256_TransformBlocks"]
     pub fn SHA256_TransformBlocks(state: *mut u32, data: *const u8, num_blocks: usize);
 }
 #[repr(C)]
@@ -5250,11 +5250,11 @@ impl Default for sha256_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Init"]
     pub fn SHA384_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Update"]
     pub fn SHA384_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5262,19 +5262,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384_Final"]
     pub fn SHA384_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA384"]
     pub fn SHA384(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Init"]
     pub fn SHA512_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Update"]
     pub fn SHA512_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5282,15 +5282,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Final"]
     pub fn SHA512_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512"]
     pub fn SHA512(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_Transform"]
     pub fn SHA512_Transform(sha: *mut SHA512_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -5388,11 +5388,11 @@ impl Default for sha512_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Init"]
     pub fn SHA512_224_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Update"]
     pub fn SHA512_224_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5400,19 +5400,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224_Final"]
     pub fn SHA512_224_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_224"]
     pub fn SHA512_224(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Init"]
     pub fn SHA512_256_Init(sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Update"]
     pub fn SHA512_256_Update(
         sha: *mut SHA512_CTX,
         data: *const ::std::os::raw::c_void,
@@ -5420,42 +5420,42 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256_Final"]
     pub fn SHA512_256_Final(out: *mut u8, sha: *mut SHA512_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SHA512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SHA512_256"]
     pub fn SHA512_256(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc"]
     pub fn OPENSSL_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_zalloc"]
     pub fn OPENSSL_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_calloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_calloc"]
     pub fn OPENSSL_calloc(num: usize, size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_realloc"]
     pub fn OPENSSL_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_free"]
     pub fn OPENSSL_free(ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanse"]
     pub fn OPENSSL_cleanse(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_memcmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_memcmp"]
     pub fn CRYPTO_memcmp(
         a: *const ::std::os::raw::c_void,
         b: *const ::std::os::raw::c_void,
@@ -5463,62 +5463,62 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hash32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hash32"]
     pub fn OPENSSL_hash32(ptr: *const ::std::os::raw::c_void, len: usize) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strhash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strhash"]
     pub fn OPENSSL_strhash(s: *const ::std::os::raw::c_char) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strdup"]
     pub fn OPENSSL_strdup(s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strnlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strnlen"]
     pub fn OPENSSL_strnlen(s: *const ::std::os::raw::c_char, len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalpha"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalpha"]
     pub fn OPENSSL_isalpha(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isdigit"]
     pub fn OPENSSL_isdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isxdigit"]
     pub fn OPENSSL_isxdigit(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_fromxdigit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_fromxdigit"]
     pub fn OPENSSL_fromxdigit(out: *mut u8, c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_hexstr2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_hexstr2buf"]
     pub fn OPENSSL_hexstr2buf(str_: *const ::std::os::raw::c_char, len: *mut usize) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isalnum"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isalnum"]
     pub fn OPENSSL_isalnum(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_tolower"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_tolower"]
     pub fn OPENSSL_tolower(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_isspace"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_isspace"]
     pub fn OPENSSL_isspace(c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strcasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strcasecmp"]
     pub fn OPENSSL_strcasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strncasecmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strncasecmp"]
     pub fn OPENSSL_strncasecmp(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -5526,7 +5526,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_snprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_snprintf"]
     pub fn BIO_snprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5535,7 +5535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vsnprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vsnprintf"]
     pub fn BIO_vsnprintf(
         buf: *mut ::std::os::raw::c_char,
         n: usize,
@@ -5544,7 +5544,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_vasprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_vasprintf"]
     pub fn OPENSSL_vasprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5552,7 +5552,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_asprintf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_asprintf"]
     pub fn OPENSSL_asprintf(
         str_: *mut *mut ::std::os::raw::c_char,
         format: *const ::std::os::raw::c_char,
@@ -5560,21 +5560,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strndup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strndup"]
     pub fn OPENSSL_strndup(
         str_: *const ::std::os::raw::c_char,
         size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_memdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_memdup"]
     pub fn OPENSSL_memdup(
         data: *const ::std::os::raw::c_void,
         size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcpy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcpy"]
     pub fn OPENSSL_strlcpy(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5582,7 +5582,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_strlcat"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_strlcat"]
     pub fn OPENSSL_strlcat(
         dst: *mut ::std::os::raw::c_char,
         src: *const ::std::os::raw::c_char,
@@ -5590,7 +5590,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc"]
     pub fn CRYPTO_malloc(
         size: usize,
         file: *const ::std::os::raw::c_char,
@@ -5598,7 +5598,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_realloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_realloc"]
     pub fn CRYPTO_realloc(
         ptr: *mut ::std::os::raw::c_void,
         new_size: usize,
@@ -5607,7 +5607,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_free"]
     pub fn CRYPTO_free(
         ptr: *mut ::std::os::raw::c_void,
         file: *const ::std::os::raw::c_char,
@@ -5615,11 +5615,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_clear_free"]
     pub fn OPENSSL_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_mem_functions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_mem_functions"]
     pub fn CRYPTO_set_mem_functions(
         m: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5646,45 +5646,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_init"]
     pub fn CRYPTO_secure_malloc_init(size: usize, min_size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_malloc_initialized"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_malloc_initialized"]
     pub fn CRYPTO_secure_malloc_initialized() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_secure_used"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_secure_used"]
     pub fn CRYPTO_secure_used() -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_malloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_malloc"]
     pub fn OPENSSL_secure_malloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_zalloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_zalloc"]
     pub fn OPENSSL_secure_zalloc(size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_secure_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_secure_clear_free"]
     pub fn OPENSSL_secure_clear_free(ptr: *mut ::std::os::raw::c_void, len: usize);
 }
 pub type CRYPTO_MUTEX = pthread_rwlock_t;
 pub type CRYPTO_refcount_t = u32;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_clear"]
     pub fn AWSLC_thread_local_clear() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AWSLC_thread_local_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AWSLC_thread_local_shutdown"]
     pub fn AWSLC_thread_local_shutdown() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_num_locks"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_num_locks"]
     pub fn CRYPTO_num_locks() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_locking_callback"]
     pub fn CRYPTO_set_locking_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5697,7 +5697,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_add_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_add_lock_callback"]
     pub fn CRYPTO_set_add_lock_callback(
         func: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5711,7 +5711,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_locking_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_locking_callback"]
     pub fn CRYPTO_get_locking_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5722,29 +5722,29 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_lock_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_lock_name"]
     pub fn CRYPTO_get_lock_name(lock_num: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_callback"]
     pub fn CRYPTO_THREADID_set_callback(
         threadid_func: ::std::option::Option<unsafe extern "C" fn(threadid: *mut CRYPTO_THREADID)>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_numeric"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_numeric"]
     pub fn CRYPTO_THREADID_set_numeric(id: *mut CRYPTO_THREADID, val: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_set_pointer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_set_pointer"]
     pub fn CRYPTO_THREADID_set_pointer(id: *mut CRYPTO_THREADID, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_THREADID_current"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_THREADID_current"]
     pub fn CRYPTO_THREADID_current(id: *mut CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_id_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_id_callback"]
     pub fn CRYPTO_set_id_callback(
         func: ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_ulong>,
     );
@@ -5800,7 +5800,7 @@ impl Default for CRYPTO_dynlock {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_create_callback"]
     pub fn CRYPTO_set_dynlock_create_callback(
         dyn_create_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5811,7 +5811,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_lock_callback"]
     pub fn CRYPTO_set_dynlock_lock_callback(
         dyn_lock_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5824,7 +5824,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_set_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_set_dynlock_destroy_callback"]
     pub fn CRYPTO_set_dynlock_destroy_callback(
         dyn_destroy_function: ::std::option::Option<
             unsafe extern "C" fn(
@@ -5836,7 +5836,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_create_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_create_callback"]
     pub fn CRYPTO_get_dynlock_create_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *const ::std::os::raw::c_char,
@@ -5845,7 +5845,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_lock_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_lock_callback"]
     pub fn CRYPTO_get_dynlock_lock_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -5856,7 +5856,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_get_dynlock_destroy_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_get_dynlock_destroy_callback"]
     pub fn CRYPTO_get_dynlock_destroy_callback() -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut CRYPTO_dynlock_value,
@@ -5866,30 +5866,30 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_library_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_library_init"]
     pub fn CRYPTO_library_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_is_confidential_build"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_is_confidential_build"]
     pub fn CRYPTO_is_confidential_build() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_has_asm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_has_asm"]
     pub fn CRYPTO_has_asm() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BORINGSSL_self_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BORINGSSL_self_test"]
     pub fn BORINGSSL_self_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn BORINGSSL_integrity_test() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_pre_sandbox_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_pre_sandbox_init"]
     pub fn CRYPTO_pre_sandbox_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode"]
     pub fn FIPS_mode() -> ::std::os::raw::c_int;
 }
 pub const fips_counter_t_fips_counter_evp_aes_128_gcm: fips_counter_t = 0;
@@ -5899,105 +5899,105 @@ pub const fips_counter_t_fips_counter_evp_aes_256_ctr: fips_counter_t = 3;
 pub const fips_counter_t_fips_counter_max: fips_counter_t = 3;
 pub type fips_counter_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_read_counter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_read_counter"]
     pub fn FIPS_read_counter(counter: fips_counter_t) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version"]
     pub fn OpenSSL_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay_version"]
     pub fn SSLeay_version(which: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSLeay"]
     pub fn SSLeay() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_version_num"]
     pub fn OpenSSL_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_api_version_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_api_version_num"]
     pub fn awslc_api_version_num() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_malloc_init"]
     pub fn CRYPTO_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_malloc_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_malloc_init"]
     pub fn OPENSSL_malloc_init() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_load_builtin_engines"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_load_builtin_engines"]
     pub fn ENGINE_load_builtin_engines();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_register_all_complete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_register_all_complete"]
     pub fn ENGINE_register_all_complete() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_load_builtin_modules"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_load_builtin_modules"]
     pub fn OPENSSL_load_builtin_modules();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init_crypto"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init_crypto"]
     pub fn OPENSSL_init_crypto(
         opts: u64,
         settings: *const OPENSSL_INIT_SETTINGS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_init"]
     pub fn OPENSSL_init();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_cleanup"]
     pub fn OPENSSL_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_mode_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_mode_set"]
     pub fn FIPS_mode_set(on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_BIO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_BIO_strings"]
     pub fn ERR_load_BIO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_ERR_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_ERR_strings"]
     pub fn ERR_load_ERR_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_CRYPTO_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_CRYPTO_strings"]
     pub fn ERR_load_CRYPTO_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_crypto_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_crypto_strings"]
     pub fn ERR_load_crypto_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_load_RAND_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_load_RAND_strings"]
     pub fn ERR_load_RAND_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_free_strings"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_free_strings"]
     pub fn ERR_free_strings();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error"]
     pub fn ERR_get_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line"]
     pub fn ERR_get_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_error_line_data"]
     pub fn ERR_get_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6006,18 +6006,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error"]
     pub fn ERR_peek_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line"]
     pub fn ERR_peek_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_error_line_data"]
     pub fn ERR_peek_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6026,18 +6026,18 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error"]
     pub fn ERR_peek_last_error() -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line"]
     pub fn ERR_peek_last_error_line(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_peek_last_error_line_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_peek_last_error_line_data"]
     pub fn ERR_peek_last_error_line_data(
         file: *mut *const ::std::os::raw::c_char,
         line: *mut ::std::os::raw::c_int,
@@ -6046,7 +6046,7 @@ extern "C" {
     ) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string_n"]
     pub fn ERR_error_string_n(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
@@ -6054,11 +6054,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_lib_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_lib_error_string"]
     pub fn ERR_lib_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_reason_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_reason_error_string"]
     pub fn ERR_reason_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 pub type ERR_print_errors_callback_t = ::std::option::Option<
@@ -6069,57 +6069,57 @@ pub type ERR_print_errors_callback_t = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_cb"]
     pub fn ERR_print_errors_cb(
         callback: ERR_print_errors_callback_t,
         ctx: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors_fp"]
     pub fn ERR_print_errors_fp(file: *mut FILE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_error"]
     pub fn ERR_clear_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_mark"]
     pub fn ERR_set_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_pop_to_mark"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_pop_to_mark"]
     pub fn ERR_pop_to_mark() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_get_next_error_library"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_get_next_error_library"]
     pub fn ERR_get_next_error_library() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_state"]
     pub fn ERR_remove_state(pid: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_remove_thread_state"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_remove_thread_state"]
     pub fn ERR_remove_thread_state(tid: *const CRYPTO_THREADID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_func_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_func_error_string"]
     pub fn ERR_func_error_string(packed_error: u32) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_error_string"]
     pub fn ERR_error_string(
         packed_error: u32,
         buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_clear_system_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_clear_system_error"]
     pub fn ERR_clear_system_error();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_put_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_put_error"]
     pub fn ERR_put_error(
         library: ::std::os::raw::c_int,
         unused: ::std::os::raw::c_int,
@@ -6129,15 +6129,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_data"]
     pub fn ERR_add_error_data(count: ::std::os::raw::c_uint, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_add_error_dataf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_add_error_dataf"]
     pub fn ERR_add_error_dataf(format: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_set_error_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_set_error_data"]
     pub fn ERR_set_error_data(data: *mut ::std::os::raw::c_char, flags: ::std::os::raw::c_int);
 }
 pub type OPENSSL_sk_free_func =
@@ -6187,27 +6187,27 @@ pub struct stack_st {
 }
 pub type OPENSSL_STACK = stack_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new"]
     pub fn OPENSSL_sk_new(comp: OPENSSL_sk_cmp_func) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_new_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_new_null"]
     pub fn OPENSSL_sk_new_null() -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_num"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_num"]
     pub fn OPENSSL_sk_num(sk: *const OPENSSL_STACK) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_zero"]
     pub fn OPENSSL_sk_zero(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_value"]
     pub fn OPENSSL_sk_value(sk: *const OPENSSL_STACK, i: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set"]
     pub fn OPENSSL_sk_set(
         sk: *mut OPENSSL_STACK,
         i: usize,
@@ -6215,11 +6215,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_free"]
     pub fn OPENSSL_sk_free(sk: *mut OPENSSL_STACK);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop_free_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop_free_ex"]
     pub fn OPENSSL_sk_pop_free_ex(
         sk: *mut OPENSSL_STACK,
         call_free_func: OPENSSL_sk_call_free_func,
@@ -6227,7 +6227,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_insert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_insert"]
     pub fn OPENSSL_sk_insert(
         sk: *mut OPENSSL_STACK,
         p: *mut ::std::os::raw::c_void,
@@ -6235,18 +6235,18 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete"]
     pub fn OPENSSL_sk_delete(sk: *mut OPENSSL_STACK, where_: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_ptr"]
     pub fn OPENSSL_sk_delete_ptr(
         sk: *mut OPENSSL_STACK,
         p: *const ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_delete_if"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_delete_if"]
     pub fn OPENSSL_sk_delete_if(
         sk: *mut OPENSSL_STACK,
         call_func: OPENSSL_sk_call_delete_if_func,
@@ -6255,7 +6255,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_find"]
     pub fn OPENSSL_sk_find(
         sk: *const OPENSSL_STACK,
         out_index: *mut usize,
@@ -6264,45 +6264,45 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_unshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_unshift"]
     pub fn OPENSSL_sk_unshift(
         sk: *mut OPENSSL_STACK,
         data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_shift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_shift"]
     pub fn OPENSSL_sk_shift(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_push"]
     pub fn OPENSSL_sk_push(sk: *mut OPENSSL_STACK, p: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_pop"]
     pub fn OPENSSL_sk_pop(sk: *mut OPENSSL_STACK) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_dup"]
     pub fn OPENSSL_sk_dup(sk: *const OPENSSL_STACK) -> *mut OPENSSL_STACK;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_sort"]
     pub fn OPENSSL_sk_sort(sk: *mut OPENSSL_STACK, call_cmp_func: OPENSSL_sk_call_cmp_func);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_is_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_is_sorted"]
     pub fn OPENSSL_sk_is_sorted(sk: *const OPENSSL_STACK) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_set_cmp_func"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_set_cmp_func"]
     pub fn OPENSSL_sk_set_cmp_func(
         sk: *mut OPENSSL_STACK,
         comp: OPENSSL_sk_cmp_func,
     ) -> OPENSSL_sk_cmp_func;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_sk_deep_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_sk_deep_copy"]
     pub fn OPENSSL_sk_deep_copy(
         sk: *const OPENSSL_STACK,
         call_copy_func: OPENSSL_sk_call_copy_func,
@@ -6313,7 +6313,7 @@ extern "C" {
 }
 pub type _STACK = OPENSSL_STACK;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_sk_pop_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_sk_pop_free"]
     pub fn sk_pop_free(sk: *mut OPENSSL_STACK, free_func: OPENSSL_sk_free_func);
 }
 pub type OPENSSL_STRING = *mut ::std::os::raw::c_char;
@@ -6373,7 +6373,7 @@ pub type CRYPTO_EX_free = ::std::option::Option<
     ),
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_cleanup_all_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_cleanup_all_ex_data"]
     pub fn CRYPTO_cleanup_all_ex_data();
 }
 pub type CRYPTO_EX_dup = ::std::option::Option<
@@ -6444,23 +6444,23 @@ pub type sk_BIO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new"]
     pub fn BIO_new(method: *const BIO_METHOD) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free"]
     pub fn BIO_free(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_vfree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_vfree"]
     pub fn BIO_vfree(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_up_ref"]
     pub fn BIO_up_ref(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read"]
     pub fn BIO_read(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6468,7 +6468,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_ex"]
     pub fn BIO_read_ex(
         bio: *mut BIO,
         data: *mut ::std::os::raw::c_void,
@@ -6477,7 +6477,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_gets"]
     pub fn BIO_gets(
         bio: *mut BIO,
         buf: *mut ::std::os::raw::c_char,
@@ -6485,7 +6485,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write"]
     pub fn BIO_write(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6493,7 +6493,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_ex"]
     pub fn BIO_write_ex(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6502,7 +6502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_all"]
     pub fn BIO_write_all(
         bio: *mut BIO,
         data: *const ::std::os::raw::c_void,
@@ -6510,15 +6510,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_puts"]
     pub fn BIO_puts(bio: *mut BIO, buf: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_flush"]
     pub fn BIO_flush(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl"]
     pub fn BIO_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6527,7 +6527,7 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ptr_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ptr_ctrl"]
     pub fn BIO_ptr_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6535,7 +6535,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_int_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_int_ctrl"]
     pub fn BIO_int_ctrl(
         bp: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6544,71 +6544,71 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_reset"]
     pub fn BIO_reset(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_eof"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_eof"]
     pub fn BIO_eof(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_flags"]
     pub fn BIO_set_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_test_flags"]
     pub fn BIO_test_flags(bio: *const BIO, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_read"]
     pub fn BIO_should_read(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_write"]
     pub fn BIO_should_write(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_retry"]
     pub fn BIO_should_retry(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_should_io_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_should_io_special"]
     pub fn BIO_should_io_special(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_reason"]
     pub fn BIO_get_retry_reason(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_reason"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_reason"]
     pub fn BIO_set_retry_reason(bio: *mut BIO, reason: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_flags"]
     pub fn BIO_clear_flags(bio: *mut BIO, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_read"]
     pub fn BIO_set_retry_read(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_write"]
     pub fn BIO_set_retry_write(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_retry_flags"]
     pub fn BIO_get_retry_flags(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_clear_retry_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_clear_retry_flags"]
     pub fn BIO_clear_retry_flags(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_type"]
     pub fn BIO_method_type(bio: *const BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_method_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_method_name"]
     pub fn BIO_method_name(b: *const BIO) -> *const ::std::os::raw::c_char;
 }
 pub type bio_info_cb = ::std::option::Option<
@@ -6631,7 +6631,7 @@ pub type BIO_callback_fn_ex = ::std::option::Option<
     ) -> ::std::os::raw::c_long,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_callback_ctrl"]
     pub fn BIO_callback_ctrl(
         bio: *mut BIO,
         cmd: ::std::os::raw::c_int,
@@ -6639,68 +6639,68 @@ extern "C" {
     ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pending"]
     pub fn BIO_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_pending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_pending"]
     pub fn BIO_ctrl_pending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_wpending"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_wpending"]
     pub fn BIO_wpending(bio: *const BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_close"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_close"]
     pub fn BIO_set_close(bio: *mut BIO, close_flag: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_read"]
     pub fn BIO_number_read(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_number_written"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_number_written"]
     pub fn BIO_number_written(bio: *const BIO) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_ex"]
     pub fn BIO_set_callback_ex(bio: *mut BIO, callback_ex: BIO_callback_fn_ex);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_callback_arg"]
     pub fn BIO_set_callback_arg(bio: *mut BIO, arg: *mut ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_callback_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_callback_arg"]
     pub fn BIO_get_callback_arg(bio: *const BIO) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_push"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_push"]
     pub fn BIO_push(bio: *mut BIO, appended_bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_pop"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_pop"]
     pub fn BIO_pop(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_next"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_next"]
     pub fn BIO_next(bio: *mut BIO) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_free_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_free_all"]
     pub fn BIO_free_all(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_find_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_find_type"]
     pub fn BIO_find_type(bio: *mut BIO, type_: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_copy_next_retry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_copy_next_retry"]
     pub fn BIO_copy_next_retry(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_printf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_printf"]
     pub fn BIO_printf(
         bio: *mut BIO,
         format: *const ::std::os::raw::c_char,
@@ -6708,7 +6708,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_indent"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_indent"]
     pub fn BIO_indent(
         bio: *mut BIO,
         indent: ::std::os::raw::c_uint,
@@ -6716,7 +6716,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_hexdump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_hexdump"]
     pub fn BIO_hexdump(
         bio: *mut BIO,
         data: *const u8,
@@ -6725,11 +6725,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_print_errors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_print_errors"]
     pub fn ERR_print_errors(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_asn1"]
     pub fn BIO_read_asn1(
         bio: *mut BIO,
         out: *mut *mut u8,
@@ -6738,15 +6738,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_mem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_mem"]
     pub fn BIO_s_mem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_mem_buf"]
     pub fn BIO_new_mem_buf(buf: *const ::std::os::raw::c_void, len: ossl_ssize_t) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_mem_contents"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_mem_contents"]
     pub fn BIO_mem_contents(
         bio: *const BIO,
         out_contents: *mut *const u8,
@@ -6754,11 +6754,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_mem_ptr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_mem_ptr"]
     pub fn BIO_get_mem_ptr(bio: *mut BIO, out: *mut *mut BUF_MEM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_buf"]
     pub fn BIO_set_mem_buf(
         bio: *mut BIO,
         b: *mut BUF_MEM,
@@ -6766,22 +6766,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_mem_eof_return"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_mem_eof_return"]
     pub fn BIO_set_mem_eof_return(
         bio: *mut BIO,
         eof_value: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_fd"]
     pub fn BIO_s_fd() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fd"]
     pub fn BIO_new_fd(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fd"]
     pub fn BIO_set_fd(
         bio: *mut BIO,
         fd: ::std::os::raw::c_int,
@@ -6789,30 +6789,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fd"]
     pub fn BIO_get_fd(bio: *mut BIO, out_fd: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_file"]
     pub fn BIO_s_file() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_file"]
     pub fn BIO_new_file(
         filename: *const ::std::os::raw::c_char,
         mode: *const ::std::os::raw::c_char,
     ) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_fp"]
     pub fn BIO_new_fp(stream: *mut FILE, close_flag: ::std::os::raw::c_int) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_fp"]
     pub fn BIO_get_fp(bio: *mut BIO, out_file: *mut *mut FILE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_fp"]
     pub fn BIO_set_fp(
         bio: *mut BIO,
         file: *mut FILE,
@@ -6820,89 +6820,89 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_read_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_read_filename"]
     pub fn BIO_read_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_write_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_write_filename"]
     pub fn BIO_write_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_append_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_append_filename"]
     pub fn BIO_append_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_rw_filename"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_rw_filename"]
     pub fn BIO_rw_filename(
         bio: *mut BIO,
         filename: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_tell"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_tell"]
     pub fn BIO_tell(bio: *mut BIO) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_seek"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_seek"]
     pub fn BIO_seek(bio: *mut BIO, offset: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_socket"]
     pub fn BIO_s_socket() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_socket"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_socket"]
     pub fn BIO_new_socket(fd: ::std::os::raw::c_int, close_flag: ::std::os::raw::c_int)
         -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_connect"]
     pub fn BIO_s_connect() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_connect"]
     pub fn BIO_new_connect(host_and_optional_port: *const ::std::os::raw::c_char) -> *mut BIO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_hostname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_hostname"]
     pub fn BIO_set_conn_hostname(
         bio: *mut BIO,
         host_and_optional_port: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_port"]
     pub fn BIO_set_conn_port(
         bio: *mut BIO,
         port_str: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_conn_int_port"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_conn_int_port"]
     pub fn BIO_set_conn_int_port(
         bio: *mut BIO,
         port: *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_nbio"]
     pub fn BIO_set_nbio(bio: *mut BIO, on: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_do_connect"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_do_connect"]
     pub fn BIO_do_connect(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_new_bio_pair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_new_bio_pair"]
     pub fn BIO_new_bio_pair(
         out1: *mut *mut BIO,
         writebuf1: usize,
@@ -6911,34 +6911,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_read_request"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_read_request"]
     pub fn BIO_ctrl_get_read_request(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_ctrl_get_write_guarantee"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_ctrl_get_write_guarantee"]
     pub fn BIO_ctrl_get_write_guarantee(bio: *mut BIO) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_shutdown_wr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_shutdown_wr"]
     pub fn BIO_shutdown_wr(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_new_index"]
     pub fn BIO_get_new_index() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_new"]
     pub fn BIO_meth_new(
         type_: ::std::os::raw::c_int,
         name: *const ::std::os::raw::c_char,
     ) -> *mut BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_free"]
     pub fn BIO_meth_free(method: *mut BIO_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_create"]
     pub fn BIO_meth_set_create(
         method: *mut BIO_METHOD,
         create: ::std::option::Option<
@@ -6947,13 +6947,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_create"]
     pub fn BIO_meth_get_create(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_destroy"]
     pub fn BIO_meth_set_destroy(
         method: *mut BIO_METHOD,
         destroy: ::std::option::Option<
@@ -6962,13 +6962,13 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_destroy"]
     pub fn BIO_meth_get_destroy(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<unsafe extern "C" fn(method: *mut BIO) -> ::std::os::raw::c_int>;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_write"]
     pub fn BIO_meth_set_write(
         method: *mut BIO_METHOD,
         write: ::std::option::Option<
@@ -6981,7 +6981,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_read"]
     pub fn BIO_meth_set_read(
         method: *mut BIO_METHOD,
         read: ::std::option::Option<
@@ -6994,7 +6994,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_gets"]
     pub fn BIO_meth_set_gets(
         method: *mut BIO_METHOD,
         gets: ::std::option::Option<
@@ -7007,7 +7007,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_gets"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_gets"]
     pub fn BIO_meth_get_gets(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7019,7 +7019,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_ctrl"]
     pub fn BIO_meth_set_ctrl(
         method: *mut BIO_METHOD,
         ctrl: ::std::option::Option<
@@ -7033,7 +7033,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_ctrl"]
     pub fn BIO_meth_get_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7046,7 +7046,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_callback_ctrl"]
     pub fn BIO_meth_set_callback_ctrl(
         method: *mut BIO_METHOD,
         callback_ctrl: ::std::option::Option<
@@ -7059,7 +7059,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_callback_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_callback_ctrl"]
     pub fn BIO_meth_get_callback_ctrl(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7071,23 +7071,23 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_data"]
     pub fn BIO_set_data(bio: *mut BIO, ptr: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_data"]
     pub fn BIO_get_data(bio: *mut BIO) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_init"]
     pub fn BIO_set_init(bio: *mut BIO, init: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_init"]
     pub fn BIO_get_init(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_new_index"]
     pub fn BIO_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -7097,7 +7097,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_ex_data"]
     pub fn BIO_set_ex_data(
         bio: *mut BIO,
         idx: ::std::os::raw::c_int,
@@ -7105,30 +7105,30 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_ex_data"]
     pub fn BIO_get_ex_data(
         bio: *const BIO,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_f_base64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_f_base64"]
     pub fn BIO_f_base64() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_retry_special"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_retry_special"]
     pub fn BIO_set_retry_special(bio: *mut BIO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_shutdown"]
     pub fn BIO_set_shutdown(bio: *mut BIO, shutdown: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_get_shutdown"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_get_shutdown"]
     pub fn BIO_get_shutdown(bio: *mut BIO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_set_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_set_puts"]
     pub fn BIO_meth_set_puts(
         method: *mut BIO_METHOD,
         puts: ::std::option::Option<
@@ -7140,7 +7140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_meth_get_puts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_meth_get_puts"]
     pub fn BIO_meth_get_puts(
         method: *const BIO_METHOD,
     ) -> ::std::option::Option<
@@ -7151,11 +7151,11 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_s_secmem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_s_secmem"]
     pub fn BIO_s_secmem() -> *const BIO_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BIO_set_write_buffer_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BIO_set_write_buffer_size"]
     pub fn BIO_set_write_buffer_size(
         bio: *mut BIO,
         buffer_size: ::std::os::raw::c_int,
@@ -7521,197 +7521,197 @@ impl Default for bio_st {
 }
 pub type BN_ULONG = u64;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_new"]
     pub fn BN_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_init"]
     pub fn BN_init(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_free"]
     pub fn BN_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_free"]
     pub fn BN_clear_free(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dup"]
     pub fn BN_dup(src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_copy"]
     pub fn BN_copy(dest: *mut BIGNUM, src: *const BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear"]
     pub fn BN_clear(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_value_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_value_one"]
     pub fn BN_value_one() -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits"]
     pub fn BN_num_bits(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bytes"]
     pub fn BN_num_bytes(bn: *const BIGNUM) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_zero"]
     pub fn BN_zero(bn: *mut BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_one"]
     pub fn BN_one(bn: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_word"]
     pub fn BN_set_word(bn: *mut BIGNUM, value: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_u64"]
     pub fn BN_set_u64(bn: *mut BIGNUM, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_negative"]
     pub fn BN_set_negative(bn: *mut BIGNUM, sign: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_negative"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_negative"]
     pub fn BN_is_negative(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bin2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bin2bn"]
     pub fn BN_bin2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin"]
     pub fn BN_bn2bin(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_le2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_le2bn"]
     pub fn BN_le2bn(in_: *const u8, len: usize, ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2le_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2le_padded"]
     pub fn BN_bn2le_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2bin_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2bin_padded"]
     pub fn BN_bn2bin_padded(out: *mut u8, len: usize, in_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2cbb_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2cbb_padded"]
     pub fn BN_bn2cbb_padded(out: *mut CBB, len: usize, in_: *const BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2hex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2hex"]
     pub fn BN_bn2hex(bn: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_hex2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_hex2bn"]
     pub fn BN_hex2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2dec"]
     pub fn BN_bn2dec(a: *const BIGNUM) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_dec2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_dec2bn"]
     pub fn BN_dec2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_asc2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_asc2bn"]
     pub fn BN_asc2bn(
         outp: *mut *mut BIGNUM,
         in_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print"]
     pub fn BN_print(bio: *mut BIO, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_print_fp"]
     pub fn BN_print_fp(fp: *mut FILE, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_word"]
     pub fn BN_get_word(bn: *const BIGNUM) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_u64"]
     pub fn BN_get_u64(bn: *const BIGNUM, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_flags"]
     pub fn BN_get_flags(bn: *const BIGNUM, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_parse_asn1_unsigned"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_parse_asn1_unsigned"]
     pub fn BN_parse_asn1_unsigned(cbs: *mut CBS, ret: *mut BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_marshal_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_marshal_asn1"]
     pub fn BN_marshal_asn1(cbb: *mut CBB, bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_new"]
     pub fn BN_CTX_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_free"]
     pub fn BN_CTX_free(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_start"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_start"]
     pub fn BN_CTX_start(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_get"]
     pub fn BN_CTX_get(ctx: *mut BN_CTX) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_end"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_end"]
     pub fn BN_CTX_end(ctx: *mut BN_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add"]
     pub fn BN_add(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_uadd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_uadd"]
     pub fn BN_uadd(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_add_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_add_word"]
     pub fn BN_add_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub"]
     pub fn BN_sub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_usub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_usub"]
     pub fn BN_usub(r: *mut BIGNUM, a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sub_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sub_word"]
     pub fn BN_sub_word(a: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul"]
     pub fn BN_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7720,15 +7720,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mul_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mul_word"]
     pub fn BN_mul_word(bn: *mut BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqr"]
     pub fn BN_sqr(r: *mut BIGNUM, a: *const BIGNUM, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div"]
     pub fn BN_div(
         quotient: *mut BIGNUM,
         rem: *mut BIGNUM,
@@ -7738,11 +7738,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_div_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_div_word"]
     pub fn BN_div_word(numerator: *mut BIGNUM, divisor: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_sqrt"]
     pub fn BN_sqrt(
         out_sqrt: *mut BIGNUM,
         in_: *const BIGNUM,
@@ -7750,47 +7750,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp"]
     pub fn BN_cmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_cmp_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_cmp_word"]
     pub fn BN_cmp_word(a: *const BIGNUM, b: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_ucmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_ucmp"]
     pub fn BN_ucmp(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_equal_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_equal_consttime"]
     pub fn BN_equal_consttime(a: *const BIGNUM, b: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_abs_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_abs_is_word"]
     pub fn BN_abs_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_zero"]
     pub fn BN_is_zero(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_one"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_one"]
     pub fn BN_is_one(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_word"]
     pub fn BN_is_word(bn: *const BIGNUM, w: BN_ULONG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_odd"]
     pub fn BN_is_odd(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_pow2"]
     pub fn BN_is_pow2(a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift"]
     pub fn BN_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7798,11 +7798,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_lshift1"]
     pub fn BN_lshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift"]
     pub fn BN_rshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7810,43 +7810,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rshift1"]
     pub fn BN_rshift1(r: *mut BIGNUM, a: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_set_bit"]
     pub fn BN_set_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_clear_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_clear_bit"]
     pub fn BN_clear_bit(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_bit_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_bit_set"]
     pub fn BN_is_bit_set(a: *const BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mask_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mask_bits"]
     pub fn BN_mask_bits(a: *mut BIGNUM, n: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_count_low_zero_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_count_low_zero_bits"]
     pub fn BN_count_low_zero_bits(bn: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_word"]
     pub fn BN_mod_word(a: *const BIGNUM, w: BN_ULONG) -> BN_ULONG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_pow2"]
     pub fn BN_mod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod_pow2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod_pow2"]
     pub fn BN_nnmod_pow2(r: *mut BIGNUM, a: *const BIGNUM, e: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_nnmod"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_nnmod"]
     pub fn BN_nnmod(
         rem: *mut BIGNUM,
         numerator: *const BIGNUM,
@@ -7855,7 +7855,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add"]
     pub fn BN_mod_add(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7865,7 +7865,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_add_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_add_quick"]
     pub fn BN_mod_add_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7874,7 +7874,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub"]
     pub fn BN_mod_sub(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7884,7 +7884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sub_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sub_quick"]
     pub fn BN_mod_sub_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7893,7 +7893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul"]
     pub fn BN_mod_mul(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7903,7 +7903,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqr"]
     pub fn BN_mod_sqr(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7912,7 +7912,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift"]
     pub fn BN_mod_lshift(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7922,7 +7922,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift_quick"]
     pub fn BN_mod_lshift_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7931,7 +7931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1"]
     pub fn BN_mod_lshift1(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7940,7 +7940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_lshift1_quick"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_lshift1_quick"]
     pub fn BN_mod_lshift1_quick(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7948,7 +7948,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_sqrt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_sqrt"]
     pub fn BN_mod_sqrt(
         in_: *mut BIGNUM,
         a: *const BIGNUM,
@@ -7957,7 +7957,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand"]
     pub fn BN_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7966,7 +7966,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand"]
     pub fn BN_pseudo_rand(
         rnd: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -7975,11 +7975,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range"]
     pub fn BN_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_rand_range_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_rand_range_ex"]
     pub fn BN_rand_range_ex(
         r: *mut BIGNUM,
         min_inclusive: BN_ULONG,
@@ -7987,7 +7987,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_pseudo_rand_range"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_pseudo_rand_range"]
     pub fn BN_pseudo_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -8115,15 +8115,15 @@ impl Default for bn_gencb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_new"]
     pub fn BN_GENCB_new() -> *mut BN_GENCB;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_free"]
     pub fn BN_GENCB_free(callback: *mut BN_GENCB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set"]
     pub fn BN_GENCB_set(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8137,7 +8137,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_call"]
     pub fn BN_GENCB_call(
         callback: *mut BN_GENCB,
         event: ::std::os::raw::c_int,
@@ -8145,11 +8145,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_get_arg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_get_arg"]
     pub fn BN_GENCB_get_arg(callback: *const BN_GENCB) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_generate_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_generate_prime_ex"]
     pub fn BN_generate_prime_ex(
         ret: *mut BIGNUM,
         bits: ::std::os::raw::c_int,
@@ -8164,7 +8164,7 @@ pub const bn_primality_result_t_bn_composite: bn_primality_result_t = 1;
 pub const bn_primality_result_t_bn_non_prime_power_composite: bn_primality_result_t = 2;
 pub type bn_primality_result_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_enhanced_miller_rabin_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_enhanced_miller_rabin_primality_test"]
     pub fn BN_enhanced_miller_rabin_primality_test(
         out_result: *mut bn_primality_result_t,
         w: *const BIGNUM,
@@ -8174,7 +8174,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_primality_test"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_primality_test"]
     pub fn BN_primality_test(
         is_probably_prime: *mut ::std::os::raw::c_int,
         candidate: *const BIGNUM,
@@ -8185,7 +8185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_fasttest_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_fasttest_ex"]
     pub fn BN_is_prime_fasttest_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8195,7 +8195,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_is_prime_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_is_prime_ex"]
     pub fn BN_is_prime_ex(
         candidate: *const BIGNUM,
         checks: ::std::os::raw::c_int,
@@ -8204,7 +8204,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_gcd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_gcd"]
     pub fn BN_gcd(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8213,7 +8213,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse"]
     pub fn BN_mod_inverse(
         out: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8222,7 +8222,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_blinded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_blinded"]
     pub fn BN_mod_inverse_blinded(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8232,7 +8232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_inverse_odd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_inverse_odd"]
     pub fn BN_mod_inverse_odd(
         out: *mut BIGNUM,
         out_no_inverse: *mut ::std::os::raw::c_int,
@@ -8242,23 +8242,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_for_modulus"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_for_modulus"]
     pub fn BN_MONT_CTX_new_for_modulus(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new_consttime"]
     pub fn BN_MONT_CTX_new_consttime(mod_: *const BIGNUM, ctx: *mut BN_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_free"]
     pub fn BN_MONT_CTX_free(mont: *mut BN_MONT_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_copy"]
     pub fn BN_MONT_CTX_copy(to: *mut BN_MONT_CTX, from: *const BN_MONT_CTX) -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_montgomery"]
     pub fn BN_to_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8267,7 +8267,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_from_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_from_montgomery"]
     pub fn BN_from_montgomery(
         ret: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8276,7 +8276,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_mul_montgomery"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_mul_montgomery"]
     pub fn BN_mod_mul_montgomery(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8286,7 +8286,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_exp"]
     pub fn BN_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8295,7 +8295,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp"]
     pub fn BN_mod_exp(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8305,7 +8305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont"]
     pub fn BN_mod_exp_mont(
         r: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8316,7 +8316,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime"]
     pub fn BN_mod_exp_mont_consttime(
         rr: *mut BIGNUM,
         a: *const BIGNUM,
@@ -8327,7 +8327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_GENCB_set_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_GENCB_set_old"]
     pub fn BN_GENCB_set_old(
         callback: *mut BN_GENCB,
         f: ::std::option::Option<
@@ -8341,15 +8341,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2mpi"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2mpi"]
     pub fn BN_bn2mpi(in_: *const BIGNUM, out: *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mpi2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mpi2bn"]
     pub fn BN_mpi2bn(in_: *const u8, len: usize, out: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_word"]
     pub fn BN_mod_exp_mont_word(
         r: *mut BIGNUM,
         a: BN_ULONG,
@@ -8360,7 +8360,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp2_mont"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp2_mont"]
     pub fn BN_mod_exp2_mont(
         r: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8373,11 +8373,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_new"]
     pub fn BN_MONT_CTX_new() -> *mut BN_MONT_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_MONT_CTX_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_MONT_CTX_set"]
     pub fn BN_MONT_CTX_set(
         mont: *mut BN_MONT_CTX,
         mod_: *const BIGNUM,
@@ -8385,7 +8385,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_bn2binpad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_bn2binpad"]
     pub fn BN_bn2binpad(
         in_: *const BIGNUM,
         out: *mut u8,
@@ -8393,15 +8393,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_secure_new"]
     pub fn BN_secure_new() -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_CTX_secure_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_CTX_secure_new"]
     pub fn BN_CTX_secure_new() -> *mut BN_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_mod_exp_mont_consttime_x2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_mod_exp_mont_consttime_x2"]
     pub fn BN_mod_exp_mont_consttime_x2(
         rr1: *mut BIGNUM,
         a1: *const BIGNUM,
@@ -8561,15 +8561,15 @@ impl Default for bn_mont_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_num_bits_word"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_num_bits_word"]
     pub fn BN_num_bits_word(l: BN_ULONG) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2bit"]
     pub fn ASN1_tag2bit(tag: ::std::os::raw::c_int) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_tag2str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_tag2str"]
     pub fn ASN1_tag2str(tag: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 pub type d2i_of_void = ::std::option::Option<
@@ -8593,15 +8593,15 @@ pub struct ASN1_VALUE_st {
 }
 pub type ASN1_VALUE = ASN1_VALUE_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_new"]
     pub fn ASN1_item_new(it: *const ASN1_ITEM) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_free"]
     pub fn ASN1_item_free(val: *mut ASN1_VALUE, it: *const ASN1_ITEM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i"]
     pub fn ASN1_item_d2i(
         out: *mut *mut ASN1_VALUE,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8610,7 +8610,7 @@ extern "C" {
     ) -> *mut ASN1_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d"]
     pub fn ASN1_item_i2d(
         val: *mut ASN1_VALUE,
         outp: *mut *mut ::std::os::raw::c_uchar,
@@ -8618,7 +8618,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_dup"]
     pub fn ASN1_dup(
         i2d: i2d_of_void,
         d2i: d2i_of_void,
@@ -8626,14 +8626,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_dup"]
     pub fn ASN1_item_dup(
         it: *const ASN1_ITEM,
         x: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_fp"]
     pub fn ASN1_item_d2i_fp(
         it: *const ASN1_ITEM,
         in_: *mut FILE,
@@ -8641,7 +8641,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_d2i_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_d2i_bio"]
     pub fn ASN1_item_d2i_bio(
         it: *const ASN1_ITEM,
         in_: *mut BIO,
@@ -8649,7 +8649,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_fp"]
     pub fn ASN1_item_i2d_fp(
         it: *const ASN1_ITEM,
         out: *mut FILE,
@@ -8657,7 +8657,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_i2d_bio"]
     pub fn ASN1_item_i2d_bio(
         it: *const ASN1_ITEM,
         out: *mut BIO,
@@ -8665,7 +8665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_i2d_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_i2d_bio"]
     pub fn ASN1_i2d_bio(
         i2d: i2d_of_void,
         out: *mut BIO,
@@ -8673,14 +8673,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_unpack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_unpack"]
     pub fn ASN1_item_unpack(
         oct: *const ASN1_STRING,
         it: *const ASN1_ITEM,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_pack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_pack"]
     pub fn ASN1_item_pack(
         obj: *mut ::std::os::raw::c_void,
         it: *const ASN1_ITEM,
@@ -8688,7 +8688,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BOOLEAN"]
     pub fn d2i_ASN1_BOOLEAN(
         out: *mut ASN1_BOOLEAN,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -8696,22 +8696,22 @@ extern "C" {
     ) -> ASN1_BOOLEAN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BOOLEAN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BOOLEAN"]
     pub fn i2d_ASN1_BOOLEAN(
         a: ASN1_BOOLEAN,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BOOLEAN_it"]
     pub static ASN1_BOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TBOOLEAN_it"]
     pub static ASN1_TBOOLEAN_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_FBOOLEAN_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_FBOOLEAN_it"]
     pub static ASN1_FBOOLEAN_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -8787,54 +8787,54 @@ impl Default for asn1_string_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type_new"]
     pub fn ASN1_STRING_type_new(type_: ::std::os::raw::c_int) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_new"]
     pub fn ASN1_STRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_free"]
     pub fn ASN1_STRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_clear_free"]
     pub fn ASN1_STRING_clear_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_copy"]
     pub fn ASN1_STRING_copy(
         dst: *mut ASN1_STRING,
         str_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_dup"]
     pub fn ASN1_STRING_dup(str_: *const ASN1_STRING) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_type"]
     pub fn ASN1_STRING_type(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get0_data"]
     pub fn ASN1_STRING_get0_data(str_: *const ASN1_STRING) -> *const ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_data"]
     pub fn ASN1_STRING_data(str_: *mut ASN1_STRING) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_length"]
     pub fn ASN1_STRING_length(str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_cmp"]
     pub fn ASN1_STRING_cmp(a: *const ASN1_STRING, b: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set"]
     pub fn ASN1_STRING_set(
         str_: *mut ASN1_STRING,
         data: *const ::std::os::raw::c_void,
@@ -8842,7 +8842,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set0"]
     pub fn ASN1_STRING_set0(
         str_: *mut ASN1_STRING,
         data: *mut ::std::os::raw::c_void,
@@ -8850,79 +8850,79 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_new"]
     pub fn ASN1_BMPSTRING_new() -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_new"]
     pub fn ASN1_GENERALSTRING_new() -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_new"]
     pub fn ASN1_IA5STRING_new() -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_new"]
     pub fn ASN1_OCTET_STRING_new() -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_new"]
     pub fn ASN1_PRINTABLESTRING_new() -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_new"]
     pub fn ASN1_T61STRING_new() -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_new"]
     pub fn ASN1_UNIVERSALSTRING_new() -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_new"]
     pub fn ASN1_UTF8STRING_new() -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_new"]
     pub fn ASN1_VISIBLESTRING_new() -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_free"]
     pub fn ASN1_BMPSTRING_free(str_: *mut ASN1_BMPSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_free"]
     pub fn ASN1_GENERALSTRING_free(str_: *mut ASN1_GENERALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_free"]
     pub fn ASN1_IA5STRING_free(str_: *mut ASN1_IA5STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_free"]
     pub fn ASN1_OCTET_STRING_free(str_: *mut ASN1_OCTET_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_free"]
     pub fn ASN1_PRINTABLESTRING_free(str_: *mut ASN1_PRINTABLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_free"]
     pub fn ASN1_T61STRING_free(str_: *mut ASN1_T61STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_free"]
     pub fn ASN1_UNIVERSALSTRING_free(str_: *mut ASN1_UNIVERSALSTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_free"]
     pub fn ASN1_UTF8STRING_free(str_: *mut ASN1_UTF8STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_free"]
     pub fn ASN1_VISIBLESTRING_free(str_: *mut ASN1_VISIBLESTRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BMPSTRING"]
     pub fn d2i_ASN1_BMPSTRING(
         out: *mut *mut ASN1_BMPSTRING,
         inp: *mut *const u8,
@@ -8930,7 +8930,7 @@ extern "C" {
     ) -> *mut ASN1_BMPSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALSTRING"]
     pub fn d2i_ASN1_GENERALSTRING(
         out: *mut *mut ASN1_GENERALSTRING,
         inp: *mut *const u8,
@@ -8938,7 +8938,7 @@ extern "C" {
     ) -> *mut ASN1_GENERALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_IA5STRING"]
     pub fn d2i_ASN1_IA5STRING(
         out: *mut *mut ASN1_IA5STRING,
         inp: *mut *const u8,
@@ -8946,7 +8946,7 @@ extern "C" {
     ) -> *mut ASN1_IA5STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OCTET_STRING"]
     pub fn d2i_ASN1_OCTET_STRING(
         out: *mut *mut ASN1_OCTET_STRING,
         inp: *mut *const u8,
@@ -8954,7 +8954,7 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLESTRING"]
     pub fn d2i_ASN1_PRINTABLESTRING(
         out: *mut *mut ASN1_PRINTABLESTRING,
         inp: *mut *const u8,
@@ -8962,7 +8962,7 @@ extern "C" {
     ) -> *mut ASN1_PRINTABLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_T61STRING"]
     pub fn d2i_ASN1_T61STRING(
         out: *mut *mut ASN1_T61STRING,
         inp: *mut *const u8,
@@ -8970,7 +8970,7 @@ extern "C" {
     ) -> *mut ASN1_T61STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UNIVERSALSTRING"]
     pub fn d2i_ASN1_UNIVERSALSTRING(
         out: *mut *mut ASN1_UNIVERSALSTRING,
         inp: *mut *const u8,
@@ -8978,7 +8978,7 @@ extern "C" {
     ) -> *mut ASN1_UNIVERSALSTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTF8STRING"]
     pub fn d2i_ASN1_UTF8STRING(
         out: *mut *mut ASN1_UTF8STRING,
         inp: *mut *const u8,
@@ -8986,7 +8986,7 @@ extern "C" {
     ) -> *mut ASN1_UTF8STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_VISIBLESTRING"]
     pub fn d2i_ASN1_VISIBLESTRING(
         out: *mut *mut ASN1_VISIBLESTRING,
         inp: *mut *const u8,
@@ -8994,117 +8994,117 @@ extern "C" {
     ) -> *mut ASN1_VISIBLESTRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BMPSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BMPSTRING"]
     pub fn i2d_ASN1_BMPSTRING(
         in_: *const ASN1_BMPSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALSTRING"]
     pub fn i2d_ASN1_GENERALSTRING(
         in_: *const ASN1_GENERALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_IA5STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_IA5STRING"]
     pub fn i2d_ASN1_IA5STRING(
         in_: *const ASN1_IA5STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OCTET_STRING"]
     pub fn i2d_ASN1_OCTET_STRING(
         in_: *const ASN1_OCTET_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLESTRING"]
     pub fn i2d_ASN1_PRINTABLESTRING(
         in_: *const ASN1_PRINTABLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_T61STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_T61STRING"]
     pub fn i2d_ASN1_T61STRING(
         in_: *const ASN1_T61STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UNIVERSALSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UNIVERSALSTRING"]
     pub fn i2d_ASN1_UNIVERSALSTRING(
         in_: *const ASN1_UNIVERSALSTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTF8STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTF8STRING"]
     pub fn i2d_ASN1_UTF8STRING(
         in_: *const ASN1_UTF8STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_VISIBLESTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_VISIBLESTRING"]
     pub fn i2d_ASN1_VISIBLESTRING(
         in_: *const ASN1_VISIBLESTRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BMPSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BMPSTRING_it"]
     pub static ASN1_BMPSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALSTRING_it"]
     pub static ASN1_GENERALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_IA5STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_IA5STRING_it"]
     pub static ASN1_IA5STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_it"]
     pub static ASN1_OCTET_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLESTRING_it"]
     pub static ASN1_PRINTABLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_T61STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_T61STRING_it"]
     pub static ASN1_T61STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UNIVERSALSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UNIVERSALSTRING_it"]
     pub static ASN1_UNIVERSALSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTF8STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTF8STRING_it"]
     pub static ASN1_UTF8STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_VISIBLESTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_VISIBLESTRING_it"]
     pub static ASN1_VISIBLESTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_dup"]
     pub fn ASN1_OCTET_STRING_dup(a: *const ASN1_OCTET_STRING) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_cmp"]
     pub fn ASN1_OCTET_STRING_cmp(
         a: *const ASN1_OCTET_STRING,
         b: *const ASN1_OCTET_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OCTET_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OCTET_STRING_set"]
     pub fn ASN1_OCTET_STRING_set(
         str_: *mut ASN1_OCTET_STRING,
         data: *const ::std::os::raw::c_uchar,
@@ -9112,14 +9112,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_to_UTF8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_to_UTF8"]
     pub fn ASN1_STRING_to_UTF8(
         out: *mut *mut ::std::os::raw::c_uchar,
         in_: *const ASN1_STRING,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_copy"]
     pub fn ASN1_mbstring_copy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9129,7 +9129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_mbstring_ncopy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_mbstring_ncopy"]
     pub fn ASN1_mbstring_ncopy(
         out: *mut *mut ASN1_STRING,
         in_: *const u8,
@@ -9141,7 +9141,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_by_NID"]
     pub fn ASN1_STRING_set_by_NID(
         out: *mut *mut ASN1_STRING,
         in_: *const ::std::os::raw::c_uchar,
@@ -9151,7 +9151,7 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_add"]
     pub fn ASN1_STRING_TABLE_add(
         nid: ::std::os::raw::c_int,
         minsize: ::std::os::raw::c_long,
@@ -9161,15 +9161,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_new"]
     pub fn DIRECTORYSTRING_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_free"]
     pub fn DIRECTORYSTRING_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIRECTORYSTRING"]
     pub fn d2i_DIRECTORYSTRING(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9177,26 +9177,26 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIRECTORYSTRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIRECTORYSTRING"]
     pub fn i2d_DIRECTORYSTRING(
         in_: *const ASN1_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIRECTORYSTRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIRECTORYSTRING_it"]
     pub static DIRECTORYSTRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_new"]
     pub fn DISPLAYTEXT_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_free"]
     pub fn DISPLAYTEXT_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DISPLAYTEXT"]
     pub fn d2i_DISPLAYTEXT(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -9204,23 +9204,23 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DISPLAYTEXT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DISPLAYTEXT"]
     pub fn i2d_DISPLAYTEXT(in_: *const ASN1_STRING, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DISPLAYTEXT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DISPLAYTEXT_it"]
     pub static DISPLAYTEXT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_new"]
     pub fn ASN1_BIT_STRING_new() -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_free"]
     pub fn ASN1_BIT_STRING_free(str_: *mut ASN1_BIT_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_BIT_STRING"]
     pub fn d2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9228,14 +9228,14 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_BIT_STRING"]
     pub fn i2d_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_BIT_STRING"]
     pub fn c2i_ASN1_BIT_STRING(
         out: *mut *mut ASN1_BIT_STRING,
         inp: *mut *const u8,
@@ -9243,25 +9243,25 @@ extern "C" {
     ) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_BIT_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_BIT_STRING"]
     pub fn i2c_ASN1_BIT_STRING(
         in_: *const ASN1_BIT_STRING,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_it"]
     pub static ASN1_BIT_STRING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_num_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_num_bytes"]
     pub fn ASN1_BIT_STRING_num_bytes(
         str_: *const ASN1_BIT_STRING,
         out: *mut usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set"]
     pub fn ASN1_BIT_STRING_set(
         str_: *mut ASN1_BIT_STRING,
         d: *const ::std::os::raw::c_uchar,
@@ -9269,7 +9269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_set_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_set_bit"]
     pub fn ASN1_BIT_STRING_set_bit(
         str_: *mut ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
@@ -9277,14 +9277,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_get_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_get_bit"]
     pub fn ASN1_BIT_STRING_get_bit(
         str_: *const ASN1_BIT_STRING,
         n: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_BIT_STRING_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_BIT_STRING_check"]
     pub fn ASN1_BIT_STRING_check(
         str_: *const ASN1_BIT_STRING,
         flags: *const ::std::os::raw::c_uchar,
@@ -9313,19 +9313,19 @@ pub type sk_ASN1_INTEGER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_new"]
     pub fn ASN1_INTEGER_new() -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_free"]
     pub fn ASN1_INTEGER_free(str_: *mut ASN1_INTEGER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_dup"]
     pub fn ASN1_INTEGER_dup(x: *const ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_INTEGER"]
     pub fn d2i_ASN1_INTEGER(
         out: *mut *mut ASN1_INTEGER,
         inp: *mut *const u8,
@@ -9333,11 +9333,11 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_INTEGER"]
     pub fn i2d_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_INTEGER"]
     pub fn c2i_ASN1_INTEGER(
         in_: *mut *mut ASN1_INTEGER,
         outp: *mut *const u8,
@@ -9345,54 +9345,54 @@ extern "C" {
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2c_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2c_ASN1_INTEGER"]
     pub fn i2c_ASN1_INTEGER(in_: *const ASN1_INTEGER, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_it"]
     pub static ASN1_INTEGER_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_uint64"]
     pub fn ASN1_INTEGER_set_uint64(out: *mut ASN1_INTEGER, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set_int64"]
     pub fn ASN1_INTEGER_set_int64(out: *mut ASN1_INTEGER, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_uint64"]
     pub fn ASN1_INTEGER_get_uint64(out: *mut u64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get_int64"]
     pub fn ASN1_INTEGER_get_int64(out: *mut i64, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_INTEGER"]
     pub fn BN_to_ASN1_INTEGER(bn: *const BIGNUM, ai: *mut ASN1_INTEGER) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_to_BN"]
     pub fn ASN1_INTEGER_to_BN(ai: *const ASN1_INTEGER, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_cmp"]
     pub fn ASN1_INTEGER_cmp(
         x: *const ASN1_INTEGER,
         y: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_new"]
     pub fn ASN1_ENUMERATED_new() -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_free"]
     pub fn ASN1_ENUMERATED_free(str_: *mut ASN1_ENUMERATED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_ENUMERATED"]
     pub fn d2i_ASN1_ENUMERATED(
         out: *mut *mut ASN1_ENUMERATED,
         inp: *mut *const u8,
@@ -9400,59 +9400,59 @@ extern "C" {
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_ENUMERATED"]
     pub fn i2d_ASN1_ENUMERATED(
         in_: *const ASN1_ENUMERATED,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_it"]
     pub static ASN1_ENUMERATED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_uint64"]
     pub fn ASN1_ENUMERATED_set_uint64(out: *mut ASN1_ENUMERATED, v: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set_int64"]
     pub fn ASN1_ENUMERATED_set_int64(out: *mut ASN1_ENUMERATED, v: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_uint64"]
     pub fn ASN1_ENUMERATED_get_uint64(
         out: *mut u64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get_int64"]
     pub fn ASN1_ENUMERATED_get_int64(
         out: *mut i64,
         a: *const ASN1_ENUMERATED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_to_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_to_ASN1_ENUMERATED"]
     pub fn BN_to_ASN1_ENUMERATED(
         bn: *const BIGNUM,
         ai: *mut ASN1_ENUMERATED,
     ) -> *mut ASN1_ENUMERATED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_to_BN"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_to_BN"]
     pub fn ASN1_ENUMERATED_to_BN(ai: *const ASN1_ENUMERATED, bn: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_new"]
     pub fn ASN1_UTCTIME_new() -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_free"]
     pub fn ASN1_UTCTIME_free(str_: *mut ASN1_UTCTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_UTCTIME"]
     pub fn d2i_ASN1_UTCTIME(
         out: *mut *mut ASN1_UTCTIME,
         inp: *mut *const u8,
@@ -9460,23 +9460,23 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_UTCTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_UTCTIME"]
     pub fn i2d_ASN1_UTCTIME(in_: *const ASN1_UTCTIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_it"]
     pub static ASN1_UTCTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_check"]
     pub fn ASN1_UTCTIME_check(a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set"]
     pub fn ASN1_UTCTIME_set(s: *mut ASN1_UTCTIME, posix_time: i64) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_adj"]
     pub fn ASN1_UTCTIME_adj(
         s: *mut ASN1_UTCTIME,
         posix_time: i64,
@@ -9485,26 +9485,26 @@ extern "C" {
     ) -> *mut ASN1_UTCTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_set_string"]
     pub fn ASN1_UTCTIME_set_string(
         s: *mut ASN1_UTCTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_cmp_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_cmp_time_t"]
     pub fn ASN1_UTCTIME_cmp_time_t(s: *const ASN1_UTCTIME, t: time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_new"]
     pub fn ASN1_GENERALIZEDTIME_new() -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_free"]
     pub fn ASN1_GENERALIZEDTIME_free(str_: *mut ASN1_GENERALIZEDTIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_GENERALIZEDTIME"]
     pub fn d2i_ASN1_GENERALIZEDTIME(
         out: *mut *mut ASN1_GENERALIZEDTIME,
         inp: *mut *const u8,
@@ -9512,29 +9512,29 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_GENERALIZEDTIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_GENERALIZEDTIME"]
     pub fn i2d_ASN1_GENERALIZEDTIME(
         in_: *const ASN1_GENERALIZEDTIME,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_it"]
     pub static ASN1_GENERALIZEDTIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_check"]
     pub fn ASN1_GENERALIZEDTIME_check(a: *const ASN1_GENERALIZEDTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set"]
     pub fn ASN1_GENERALIZEDTIME_set(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_adj"]
     pub fn ASN1_GENERALIZEDTIME_adj(
         s: *mut ASN1_GENERALIZEDTIME,
         posix_time: i64,
@@ -9543,22 +9543,22 @@ extern "C" {
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_set_string"]
     pub fn ASN1_GENERALIZEDTIME_set_string(
         s: *mut ASN1_GENERALIZEDTIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_new"]
     pub fn ASN1_TIME_new() -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_free"]
     pub fn ASN1_TIME_free(str_: *mut ASN1_TIME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TIME"]
     pub fn d2i_ASN1_TIME(
         out: *mut *mut ASN1_TIME,
         inp: *mut *const u8,
@@ -9566,15 +9566,15 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TIME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TIME"]
     pub fn i2d_ASN1_TIME(in_: *const ASN1_TIME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_it"]
     pub static ASN1_TIME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_diff"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_diff"]
     pub fn ASN1_TIME_diff(
         out_days: *mut ::std::os::raw::c_int,
         out_seconds: *mut ::std::os::raw::c_int,
@@ -9583,15 +9583,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_posix"]
     pub fn ASN1_TIME_set_posix(s: *mut ASN1_TIME, posix_time: i64) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set"]
     pub fn ASN1_TIME_set(s: *mut ASN1_TIME, time: time_t) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_adj"]
     pub fn ASN1_TIME_adj(
         s: *mut ASN1_TIME,
         posix_time: i64,
@@ -9600,52 +9600,52 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_check"]
     pub fn ASN1_TIME_check(t: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_generalizedtime"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_generalizedtime"]
     pub fn ASN1_TIME_to_generalizedtime(
         t: *const ASN1_TIME,
         out: *mut *mut ASN1_GENERALIZEDTIME,
     ) -> *mut ASN1_GENERALIZEDTIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string"]
     pub fn ASN1_TIME_set_string(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_tm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_tm"]
     pub fn ASN1_TIME_to_tm(t: *const ASN1_TIME, out: *mut tm) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_set_string_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_set_string_X509"]
     pub fn ASN1_TIME_set_string_X509(
         s: *mut ASN1_TIME,
         str_: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_time_t"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_time_t"]
     pub fn ASN1_TIME_to_time_t(t: *const ASN1_TIME, out: *mut time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_to_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_to_posix"]
     pub fn ASN1_TIME_to_posix(t: *const ASN1_TIME, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_new"]
     pub fn ASN1_NULL_new() -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_free"]
     pub fn ASN1_NULL_free(null: *mut ASN1_NULL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_NULL"]
     pub fn d2i_ASN1_NULL(
         out: *mut *mut ASN1_NULL,
         inp: *mut *const u8,
@@ -9653,11 +9653,11 @@ extern "C" {
     ) -> *mut ASN1_NULL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_NULL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_NULL"]
     pub fn i2d_ASN1_NULL(in_: *const ASN1_NULL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_NULL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_NULL_it"]
     pub static ASN1_NULL_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -9682,7 +9682,7 @@ pub type sk_ASN1_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_create"]
     pub fn ASN1_OBJECT_create(
         nid: ::std::os::raw::c_int,
         data: *const u8,
@@ -9692,11 +9692,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_free"]
     pub fn ASN1_OBJECT_free(a: *mut ASN1_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_OBJECT"]
     pub fn d2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9704,11 +9704,11 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_OBJECT"]
     pub fn i2d_ASN1_OBJECT(in_: *const ASN1_OBJECT, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_c2i_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_c2i_ASN1_OBJECT"]
     pub fn c2i_ASN1_OBJECT(
         out: *mut *mut ASN1_OBJECT,
         inp: *mut *const u8,
@@ -9716,7 +9716,7 @@ extern "C" {
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_OBJECT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_OBJECT_it"]
     pub static ASN1_OBJECT_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10050,15 +10050,15 @@ pub type sk_ASN1_TYPE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_new"]
     pub fn ASN1_TYPE_new() -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_free"]
     pub fn ASN1_TYPE_free(a: *mut ASN1_TYPE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_TYPE"]
     pub fn d2i_ASN1_TYPE(
         out: *mut *mut ASN1_TYPE,
         inp: *mut *const u8,
@@ -10066,19 +10066,19 @@ extern "C" {
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_TYPE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_TYPE"]
     pub fn i2d_ASN1_TYPE(in_: *const ASN1_TYPE, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ANY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ANY_it"]
     pub static ASN1_ANY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_get"]
     pub fn ASN1_TYPE_get(a: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set"]
     pub fn ASN1_TYPE_set(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10086,7 +10086,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_set1"]
     pub fn ASN1_TYPE_set1(
         a: *mut ASN1_TYPE,
         type_: ::std::os::raw::c_int,
@@ -10094,12 +10094,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TYPE_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TYPE_cmp"]
     pub fn ASN1_TYPE_cmp(a: *const ASN1_TYPE, b: *const ASN1_TYPE) -> ::std::os::raw::c_int;
 }
 pub type ASN1_SEQUENCE_ANY = stack_st_ASN1_TYPE;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SEQUENCE_ANY"]
     pub fn d2i_ASN1_SEQUENCE_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10107,14 +10107,14 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SEQUENCE_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SEQUENCE_ANY"]
     pub fn i2d_ASN1_SEQUENCE_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_SET_ANY"]
     pub fn d2i_ASN1_SET_ANY(
         out: *mut *mut ASN1_SEQUENCE_ANY,
         inp: *mut *const u8,
@@ -10122,33 +10122,33 @@ extern "C" {
     ) -> *mut ASN1_SEQUENCE_ANY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_SET_ANY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_SET_ANY"]
     pub fn i2d_ASN1_SET_ANY(
         in_: *const ASN1_SEQUENCE_ANY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_UTCTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_UTCTIME_print"]
     pub fn ASN1_UTCTIME_print(out: *mut BIO, a: *const ASN1_UTCTIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_GENERALIZEDTIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_GENERALIZEDTIME_print"]
     pub fn ASN1_GENERALIZEDTIME_print(
         out: *mut BIO,
         a: *const ASN1_GENERALIZEDTIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_TIME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_TIME_print"]
     pub fn ASN1_TIME_print(out: *mut BIO, a: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print"]
     pub fn ASN1_STRING_print(out: *mut BIO, str_: *const ASN1_STRING) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex"]
     pub fn ASN1_STRING_print_ex(
         out: *mut BIO,
         str_: *const ASN1_STRING,
@@ -10156,7 +10156,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_print_ex_fp"]
     pub fn ASN1_STRING_print_ex_fp(
         fp: *mut FILE,
         str_: *const ASN1_STRING,
@@ -10164,19 +10164,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_INTEGER"]
     pub fn i2a_ASN1_INTEGER(bp: *mut BIO, a: *const ASN1_INTEGER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_ENUMERATED"]
     pub fn i2a_ASN1_ENUMERATED(bp: *mut BIO, a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_OBJECT"]
     pub fn i2a_ASN1_OBJECT(bp: *mut BIO, a: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2a_ASN1_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2a_ASN1_STRING"]
     pub fn i2a_ASN1_STRING(
         bp: *mut BIO,
         a: *const ASN1_STRING,
@@ -10184,7 +10184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2t_ASN1_OBJECT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2t_ASN1_OBJECT"]
     pub fn i2t_ASN1_OBJECT(
         buf: *mut ::std::os::raw::c_char,
         buf_len: ::std::os::raw::c_int,
@@ -10192,7 +10192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_get_object"]
     pub fn ASN1_get_object(
         inp: *mut *const ::std::os::raw::c_uchar,
         out_length: *mut ::std::os::raw::c_long,
@@ -10202,7 +10202,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_object"]
     pub fn ASN1_put_object(
         outp: *mut *mut ::std::os::raw::c_uchar,
         constructed: ::std::os::raw::c_int,
@@ -10212,11 +10212,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_put_eoc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_put_eoc"]
     pub fn ASN1_put_eoc(outp: *mut *mut ::std::os::raw::c_uchar) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_object_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_object_size"]
     pub fn ASN1_object_size(
         constructed: ::std::os::raw::c_int,
         length: ::std::os::raw::c_int,
@@ -10224,15 +10224,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_new"]
     pub fn ASN1_PRINTABLE_new() -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_free"]
     pub fn ASN1_PRINTABLE_free(str_: *mut ASN1_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ASN1_PRINTABLE"]
     pub fn d2i_ASN1_PRINTABLE(
         out: *mut *mut ASN1_STRING,
         inp: *mut *const u8,
@@ -10240,52 +10240,52 @@ extern "C" {
     ) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ASN1_PRINTABLE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ASN1_PRINTABLE"]
     pub fn i2d_ASN1_PRINTABLE(in_: *const ASN1_STRING, outp: *mut *mut u8)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_PRINTABLE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_PRINTABLE_it"]
     pub static ASN1_PRINTABLE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_set"]
     pub fn ASN1_INTEGER_set(
         a: *mut ASN1_INTEGER,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_set"]
     pub fn ASN1_ENUMERATED_set(
         a: *mut ASN1_ENUMERATED,
         v: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_INTEGER_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_INTEGER_get"]
     pub fn ASN1_INTEGER_get(a: *const ASN1_INTEGER) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_ENUMERATED_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_ENUMERATED_get"]
     pub fn ASN1_ENUMERATED_get(a: *const ASN1_ENUMERATED) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask"]
     pub fn ASN1_STRING_set_default_mask(mask: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_set_default_mask_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_set_default_mask_asc"]
     pub fn ASN1_STRING_set_default_mask_asc(
         p: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_get_default_mask"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_get_default_mask"]
     pub fn ASN1_STRING_get_default_mask() -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_STRING_TABLE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_STRING_TABLE_cleanup"]
     pub fn ASN1_STRING_TABLE_cleanup();
 }
 pub type ASN1_TEMPLATE = ASN1_TEMPLATE_st;
@@ -10884,7 +10884,7 @@ impl Default for ASN1_AUX_st {
 }
 pub type ASN1_AUX = ASN1_AUX_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_SEQUENCE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_SEQUENCE_it"]
     pub static ASN1_SEQUENCE_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -10909,19 +10909,19 @@ pub type sk_ASN1_VALUE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeBlock"]
     pub fn EVP_EncodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodedLength"]
     pub fn EVP_EncodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodedLength"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodedLength"]
     pub fn EVP_DecodedLength(out_len: *mut usize, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBase64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBase64"]
     pub fn EVP_DecodeBase64(
         out: *mut u8,
         out_len: *mut usize,
@@ -10931,19 +10931,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_new"]
     pub fn EVP_ENCODE_CTX_new() -> *mut EVP_ENCODE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ENCODE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ENCODE_CTX_free"]
     pub fn EVP_ENCODE_CTX_free(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeInit"]
     pub fn EVP_EncodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeUpdate"]
     pub fn EVP_EncodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10953,7 +10953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncodeFinal"]
     pub fn EVP_EncodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10961,11 +10961,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeInit"]
     pub fn EVP_DecodeInit(ctx: *mut EVP_ENCODE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeUpdate"]
     pub fn EVP_DecodeUpdate(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10975,7 +10975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeFinal"]
     pub fn EVP_DecodeFinal(
         ctx: *mut EVP_ENCODE_CTX,
         out: *mut u8,
@@ -10983,7 +10983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecodeBlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecodeBlock"]
     pub fn EVP_DecodeBlock(dst: *mut u8, src: *const u8, src_len: usize) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -11142,11 +11142,11 @@ impl Default for blake2b_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Init"]
     pub fn BLAKE2B256_Init(b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Update"]
     pub fn BLAKE2B256_Update(
         b2b: *mut BLAKE2B_CTX,
         data: *const ::std::os::raw::c_void,
@@ -11154,11 +11154,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256_Final"]
     pub fn BLAKE2B256_Final(out: *mut u8, b2b: *mut BLAKE2B_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BLAKE2B256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BLAKE2B256"]
     pub fn BLAKE2B256(data: *const u8, len: usize, out: *mut u8);
 }
 #[repr(C)]
@@ -11213,19 +11213,19 @@ impl Default for bf_key_st {
 }
 pub type BF_KEY = bf_key_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_set_key"]
     pub fn BF_set_key(key: *mut BF_KEY, len: usize, data: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_encrypt"]
     pub fn BF_encrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_decrypt"]
     pub fn BF_decrypt(data: *mut u32, key: *const BF_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_ecb_encrypt"]
     pub fn BF_ecb_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11234,7 +11234,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BF_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BF_cbc_encrypt"]
     pub fn BF_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -11295,23 +11295,23 @@ impl Default for cbs_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_init"]
     pub fn CBS_init(cbs: *mut CBS, data: *const u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_skip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_skip"]
     pub fn CBS_skip(cbs: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_data"]
     pub fn CBS_data(cbs: *const CBS) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_len"]
     pub fn CBS_len(cbs: *const CBS) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_stow"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_stow"]
     pub fn CBS_stow(
         cbs: *const CBS,
         out_ptr: *mut *mut u8,
@@ -11319,86 +11319,86 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_strdup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_strdup"]
     pub fn CBS_strdup(
         cbs: *const CBS,
         out_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_contains_zero_byte"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_contains_zero_byte"]
     pub fn CBS_contains_zero_byte(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_mem_equal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_mem_equal"]
     pub fn CBS_mem_equal(cbs: *const CBS, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8"]
     pub fn CBS_get_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16"]
     pub fn CBS_get_u16(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16le"]
     pub fn CBS_get_u16le(cbs: *mut CBS, out: *mut u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24"]
     pub fn CBS_get_u24(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32"]
     pub fn CBS_get_u32(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u32le"]
     pub fn CBS_get_u32le(cbs: *mut CBS, out: *mut u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64"]
     pub fn CBS_get_u64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64le"]
     pub fn CBS_get_u64le(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_last_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_last_u8"]
     pub fn CBS_get_last_u8(cbs: *mut CBS, out: *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_bytes"]
     pub fn CBS_get_bytes(cbs: *mut CBS, out: *mut CBS, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_copy_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_copy_bytes"]
     pub fn CBS_copy_bytes(cbs: *mut CBS, out: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u8_length_prefixed"]
     pub fn CBS_get_u8_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u16_length_prefixed"]
     pub fn CBS_get_u16_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u24_length_prefixed"]
     pub fn CBS_get_u24_length_prefixed(cbs: *mut CBS, out: *mut CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_until_first"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_until_first"]
     pub fn CBS_get_until_first(cbs: *mut CBS, out: *mut CBS, c: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_u64_decimal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_u64_decimal"]
     pub fn CBS_get_u64_decimal(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1"]
     pub fn CBS_get_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11406,7 +11406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_element"]
     pub fn CBS_get_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11414,11 +11414,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_peek_asn1_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_peek_asn1_tag"]
     pub fn CBS_peek_asn1_tag(cbs: *const CBS, tag_value: CBS_ASN1_TAG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1"]
     pub fn CBS_get_any_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11426,7 +11426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_asn1_element"]
     pub fn CBS_get_any_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11435,7 +11435,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_any_ber_asn1_element"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_any_ber_asn1_element"]
     pub fn CBS_get_any_ber_asn1_element(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11446,22 +11446,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_uint64"]
     pub fn CBS_get_asn1_uint64(cbs: *mut CBS, out: *mut u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_int64"]
     pub fn CBS_get_asn1_int64(cbs: *mut CBS, out: *mut i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_asn1_bool"]
     pub fn CBS_get_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1"]
     pub fn CBS_get_optional_asn1(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11470,7 +11470,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_octet_string"]
     pub fn CBS_get_optional_asn1_octet_string(
         cbs: *mut CBS,
         out: *mut CBS,
@@ -11479,7 +11479,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_uint64"]
     pub fn CBS_get_optional_asn1_uint64(
         cbs: *mut CBS,
         out: *mut u64,
@@ -11488,7 +11488,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_bool"]
     pub fn CBS_get_optional_asn1_bool(
         cbs: *mut CBS,
         out: *mut ::std::os::raw::c_int,
@@ -11497,37 +11497,37 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_bitstring"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_bitstring"]
     pub fn CBS_is_valid_asn1_bitstring(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_bitstring_has_bit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_bitstring_has_bit"]
     pub fn CBS_asn1_bitstring_has_bit(
         cbs: *const CBS,
         bit: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_integer"]
     pub fn CBS_is_valid_asn1_integer(
         cbs: *const CBS,
         out_is_negative: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_unsigned_asn1_integer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_unsigned_asn1_integer"]
     pub fn CBS_is_unsigned_asn1_integer(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_is_valid_asn1_oid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_is_valid_asn1_oid"]
     pub fn CBS_is_valid_asn1_oid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_asn1_oid_to_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_asn1_oid_to_text"]
     pub fn CBS_asn1_oid_to_text(cbs: *const CBS) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_generalized_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_generalized_time"]
     pub fn CBS_parse_generalized_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11535,7 +11535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_parse_utc_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_parse_utc_time"]
     pub fn CBS_parse_utc_time(
         cbs: *const CBS,
         out_tm: *mut tm,
@@ -11543,7 +11543,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBS_get_optional_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBS_get_optional_asn1_int64"]
     pub fn CBS_get_optional_asn1_int64(
         cbs: *mut CBS,
         out: *mut i64,
@@ -11850,23 +11850,23 @@ impl Default for cbb_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_zero"]
     pub fn CBB_zero(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init"]
     pub fn CBB_init(cbb: *mut CBB, initial_capacity: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_init_fixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_init_fixed"]
     pub fn CBB_init_fixed(cbb: *mut CBB, buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_cleanup"]
     pub fn CBB_cleanup(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_finish"]
     pub fn CBB_finish(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11874,40 +11874,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush"]
     pub fn CBB_flush(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_data"]
     pub fn CBB_data(cbb: *const CBB) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_len"]
     pub fn CBB_len(cbb: *const CBB) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8_length_prefixed"]
     pub fn CBB_add_u8_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16_length_prefixed"]
     pub fn CBB_add_u16_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24_length_prefixed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24_length_prefixed"]
     pub fn CBB_add_u24_length_prefixed(
         cbb: *mut CBB,
         out_contents: *mut CBB,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1"]
     pub fn CBB_add_asn1(
         cbb: *mut CBB,
         out_contents: *mut CBB,
@@ -11915,15 +11915,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_bytes"]
     pub fn CBB_add_bytes(cbb: *mut CBB, data: *const u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_zeros"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_zeros"]
     pub fn CBB_add_zeros(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_space"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_space"]
     pub fn CBB_add_space(
         cbb: *mut CBB,
         out_data: *mut *mut u8,
@@ -11931,55 +11931,55 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_reserve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_reserve"]
     pub fn CBB_reserve(cbb: *mut CBB, out_data: *mut *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_did_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_did_write"]
     pub fn CBB_did_write(cbb: *mut CBB, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u8"]
     pub fn CBB_add_u8(cbb: *mut CBB, value: u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16"]
     pub fn CBB_add_u16(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u16le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u16le"]
     pub fn CBB_add_u16le(cbb: *mut CBB, value: u16) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u24"]
     pub fn CBB_add_u24(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32"]
     pub fn CBB_add_u32(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u32le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u32le"]
     pub fn CBB_add_u32le(cbb: *mut CBB, value: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64"]
     pub fn CBB_add_u64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_u64le"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_u64le"]
     pub fn CBB_add_u64le(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_discard_child"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_discard_child"]
     pub fn CBB_discard_child(cbb: *mut CBB);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64"]
     pub fn CBB_add_asn1_uint64(cbb: *mut CBB, value: u64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_uint64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_uint64_with_tag"]
     pub fn CBB_add_asn1_uint64_with_tag(
         cbb: *mut CBB,
         value: u64,
@@ -11987,11 +11987,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64"]
     pub fn CBB_add_asn1_int64(cbb: *mut CBB, value: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_int64_with_tag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_int64_with_tag"]
     pub fn CBB_add_asn1_int64_with_tag(
         cbb: *mut CBB,
         value: i64,
@@ -11999,7 +11999,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_octet_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_octet_string"]
     pub fn CBB_add_asn1_octet_string(
         cbb: *mut CBB,
         data: *const u8,
@@ -12007,11 +12007,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_bool"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_bool"]
     pub fn CBB_add_asn1_bool(cbb: *mut CBB, value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_add_asn1_oid_from_text"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_add_asn1_oid_from_text"]
     pub fn CBB_add_asn1_oid_from_text(
         cbb: *mut CBB,
         text: *const ::std::os::raw::c_char,
@@ -12019,11 +12019,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CBB_flush_asn1_set_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CBB_flush_asn1_set_of"]
     pub fn CBB_flush_asn1_set_of(cbb: *mut CBB) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_chacha_20"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_chacha_20"]
     pub fn CRYPTO_chacha_20(
         out: *mut u8,
         in_: *const u8,
@@ -12034,122 +12034,122 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc4"]
     pub fn EVP_rc4() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_cbc"]
     pub fn EVP_des_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ecb"]
     pub fn EVP_des_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede"]
     pub fn EVP_des_ede() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3"]
     pub fn EVP_des_ede3() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede_cbc"]
     pub fn EVP_des_ede_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_cbc"]
     pub fn EVP_des_ede3_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ecb"]
     pub fn EVP_aes_128_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc"]
     pub fn EVP_aes_128_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ctr"]
     pub fn EVP_aes_128_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ofb"]
     pub fn EVP_aes_128_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ecb"]
     pub fn EVP_aes_256_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc"]
     pub fn EVP_aes_256_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ctr"]
     pub fn EVP_aes_256_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ofb"]
     pub fn EVP_aes_256_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_xts"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_xts"]
     pub fn EVP_aes_256_xts() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_wrap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_wrap"]
     pub fn EVP_aes_256_wrap() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_enc_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_enc_null"]
     pub fn EVP_enc_null() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_cbc"]
     pub fn EVP_rc2_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_rc2_40_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_rc2_40_cbc"]
     pub fn EVP_rc2_40_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_chacha20_poly1305"]
     pub fn EVP_chacha20_poly1305() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbynid"]
     pub fn EVP_get_cipherbynid(nid: ::std::os::raw::c_int) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_init"]
     pub fn EVP_CIPHER_CTX_init(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_new"]
     pub fn EVP_CIPHER_CTX_new() -> *mut EVP_CIPHER_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cleanup"]
     pub fn EVP_CIPHER_CTX_cleanup(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_free"]
     pub fn EVP_CIPHER_CTX_free(ctx: *mut EVP_CIPHER_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_copy"]
     pub fn EVP_CIPHER_CTX_copy(
         out: *mut EVP_CIPHER_CTX,
         in_: *const EVP_CIPHER_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_reset"]
     pub fn EVP_CIPHER_CTX_reset(ctx: *mut EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit_ex"]
     pub fn EVP_CipherInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12160,7 +12160,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit_ex"]
     pub fn EVP_EncryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12170,7 +12170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit_ex"]
     pub fn EVP_DecryptInit_ex(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12180,7 +12180,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptUpdate"]
     pub fn EVP_EncryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12190,7 +12190,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal_ex"]
     pub fn EVP_EncryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12198,7 +12198,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptUpdate"]
     pub fn EVP_DecryptUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12208,7 +12208,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal_ex"]
     pub fn EVP_DecryptFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12216,7 +12216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherUpdate"]
     pub fn EVP_CipherUpdate(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12226,7 +12226,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal_ex"]
     pub fn EVP_CipherFinal_ex(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12234,47 +12234,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_cipher"]
     pub fn EVP_CIPHER_CTX_cipher(ctx: *const EVP_CIPHER_CTX) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_nid"]
     pub fn EVP_CIPHER_CTX_nid(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_encrypting"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_encrypting"]
     pub fn EVP_CIPHER_CTX_encrypting(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_block_size"]
     pub fn EVP_CIPHER_CTX_block_size(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_key_length"]
     pub fn EVP_CIPHER_CTX_key_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_iv_length"]
     pub fn EVP_CIPHER_CTX_iv_length(ctx: *const EVP_CIPHER_CTX) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_get_app_data"]
     pub fn EVP_CIPHER_CTX_get_app_data(ctx: *const EVP_CIPHER_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_app_data"]
     pub fn EVP_CIPHER_CTX_set_app_data(ctx: *mut EVP_CIPHER_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_flags"]
     pub fn EVP_CIPHER_CTX_flags(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_mode"]
     pub fn EVP_CIPHER_CTX_mode(ctx: *const EVP_CIPHER_CTX) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_ctrl"]
     pub fn EVP_CIPHER_CTX_ctrl(
         ctx: *mut EVP_CIPHER_CTX,
         command: ::std::os::raw::c_int,
@@ -12283,49 +12283,49 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_padding"]
     pub fn EVP_CIPHER_CTX_set_padding(
         ctx: *mut EVP_CIPHER_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_key_length"]
     pub fn EVP_CIPHER_CTX_set_key_length(
         ctx: *mut EVP_CIPHER_CTX,
         key_len: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_nid"]
     pub fn EVP_CIPHER_nid(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_name"]
     pub fn EVP_CIPHER_name(cipher: *const EVP_CIPHER) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_block_size"]
     pub fn EVP_CIPHER_block_size(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_key_length"]
     pub fn EVP_CIPHER_key_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_iv_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_iv_length"]
     pub fn EVP_CIPHER_iv_length(cipher: *const EVP_CIPHER) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_flags"]
     pub fn EVP_CIPHER_flags(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_mode"]
     pub fn EVP_CIPHER_mode(cipher: *const EVP_CIPHER) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_BytesToKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_BytesToKey"]
     pub fn EVP_BytesToKey(
         type_: *const EVP_CIPHER,
         md: *const EVP_MD,
@@ -12338,23 +12338,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha1"]
     pub fn EVP_aes_128_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha1"]
     pub fn EVP_aes_256_cbc_hmac_sha1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cbc_hmac_sha256"]
     pub fn EVP_aes_128_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cbc_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cbc_hmac_sha256"]
     pub fn EVP_aes_256_cbc_hmac_sha256() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherInit"]
     pub fn EVP_CipherInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12364,7 +12364,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptInit"]
     pub fn EVP_EncryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12373,7 +12373,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptInit"]
     pub fn EVP_DecryptInit(
         ctx: *mut EVP_CIPHER_CTX,
         cipher: *const EVP_CIPHER,
@@ -12382,7 +12382,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CipherFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CipherFinal"]
     pub fn EVP_CipherFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12390,7 +12390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_EncryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_EncryptFinal"]
     pub fn EVP_EncryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12398,7 +12398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DecryptFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DecryptFinal"]
     pub fn EVP_DecryptFinal(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12406,7 +12406,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Cipher"]
     pub fn EVP_Cipher(
         ctx: *mut EVP_CIPHER_CTX,
         out: *mut u8,
@@ -12415,127 +12415,127 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_cipherbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_cipherbyname"]
     pub fn EVP_get_cipherbyname(name: *const ::std::os::raw::c_char) -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_gcm"]
     pub fn EVP_aes_128_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_gcm"]
     pub fn EVP_aes_256_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_ccm"]
     pub fn EVP_aes_128_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ccm"]
     pub fn EVP_aes_192_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_ccm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_ccm"]
     pub fn EVP_aes_256_ccm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ecb"]
     pub fn EVP_aes_192_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cbc"]
     pub fn EVP_aes_192_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ctr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ctr"]
     pub fn EVP_aes_192_ctr() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_gcm"]
     pub fn EVP_aes_192_gcm() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_ofb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_ofb"]
     pub fn EVP_aes_192_ofb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_des_ede3_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_des_ede3_ecb"]
     pub fn EVP_des_ede3_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb128"]
     pub fn EVP_aes_128_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb"]
     pub fn EVP_aes_128_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb1"]
     pub fn EVP_aes_128_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_128_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_128_cfb8"]
     pub fn EVP_aes_128_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb128"]
     pub fn EVP_aes_192_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb"]
     pub fn EVP_aes_192_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb1"]
     pub fn EVP_aes_192_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_192_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_192_cfb8"]
     pub fn EVP_aes_192_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb128"]
     pub fn EVP_aes_256_cfb128() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb"]
     pub fn EVP_aes_256_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb1"]
     pub fn EVP_aes_256_cfb1() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aes_256_cfb8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aes_256_cfb8"]
     pub fn EVP_aes_256_cfb8() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_ecb"]
     pub fn EVP_bf_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cbc"]
     pub fn EVP_bf_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_bf_cfb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_bf_cfb"]
     pub fn EVP_bf_cfb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_ecb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_ecb"]
     pub fn EVP_cast5_ecb() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cast5_cbc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cast5_cbc"]
     pub fn EVP_cast5_cbc() -> *const EVP_CIPHER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_CTX_set_flags"]
     pub fn EVP_CIPHER_CTX_set_flags(ctx: *const EVP_CIPHER_CTX, flags: u32);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_cipher_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_cipher_alias"]
     pub fn EVP_add_cipher_alias(
         a: *const ::std::os::raw::c_char,
         b: *const ::std::os::raw::c_char,
@@ -12775,7 +12775,7 @@ impl Default for evp_cipher_info_st {
 }
 pub type EVP_CIPHER_INFO = evp_cipher_info_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AES_CMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AES_CMAC"]
     pub fn AES_CMAC(
         out: *mut u8,
         key: *const u8,
@@ -12785,19 +12785,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_new"]
     pub fn CMAC_CTX_new() -> *mut CMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_free"]
     pub fn CMAC_CTX_free(ctx: *mut CMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_copy"]
     pub fn CMAC_CTX_copy(out: *mut CMAC_CTX, in_: *const CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Init"]
     pub fn CMAC_Init(
         ctx: *mut CMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -12807,15 +12807,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Reset"]
     pub fn CMAC_Reset(ctx: *mut CMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Update"]
     pub fn CMAC_Update(ctx: *mut CMAC_CTX, in_: *const u8, in_len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_Final"]
     pub fn CMAC_Final(
         ctx: *mut CMAC_CTX,
         out: *mut u8,
@@ -12823,7 +12823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CMAC_CTX_get0_cipher_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CMAC_CTX_get0_cipher_ctx"]
     pub fn CMAC_CTX_get0_cipher_ctx(ctx: *mut CMAC_CTX) -> *mut EVP_CIPHER_CTX;
 }
 #[repr(C)]
@@ -12914,15 +12914,15 @@ pub struct lhash_st_CONF_VALUE {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_new"]
     pub fn NCONF_new(method: *mut ::std::os::raw::c_void) -> *mut CONF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_free"]
     pub fn NCONF_free(conf: *mut CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load"]
     pub fn NCONF_load(
         conf: *mut CONF,
         filename: *const ::std::os::raw::c_char,
@@ -12930,7 +12930,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_load_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_load_bio"]
     pub fn NCONF_load_bio(
         conf: *mut CONF,
         bio: *mut BIO,
@@ -12938,14 +12938,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_section"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_section"]
     pub fn NCONF_get_section(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
     ) -> *const stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NCONF_get_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NCONF_get_string"]
     pub fn NCONF_get_string(
         conf: *const CONF,
         section: *const ::std::os::raw::c_char,
@@ -12953,7 +12953,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_load_file"]
     pub fn CONF_modules_load_file(
         filename: *const ::std::os::raw::c_char,
         appname: *const ::std::os::raw::c_char,
@@ -12961,31 +12961,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_get1_default_config_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_get1_default_config_file"]
     pub fn CONF_get1_default_config_file() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_free"]
     pub fn CONF_modules_free();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_unload"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_unload"]
     pub fn CONF_modules_unload(all: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CONF_modules_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CONF_modules_finish"]
     pub fn CONF_modules_finish();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_config"]
     pub fn OPENSSL_config(config_name: *const ::std::os::raw::c_char);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_no_config"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_no_config"]
     pub fn OPENSSL_no_config();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_new"]
     pub fn CTR_DRBG_new(
         entropy: *const u8,
         personalization: *const u8,
@@ -12993,11 +12993,11 @@ extern "C" {
     ) -> *mut CTR_DRBG_STATE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_free"]
     pub fn CTR_DRBG_free(state: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_reseed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_reseed"]
     pub fn CTR_DRBG_reseed(
         drbg: *mut CTR_DRBG_STATE,
         entropy: *const u8,
@@ -13006,7 +13006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_generate"]
     pub fn CTR_DRBG_generate(
         drbg: *mut CTR_DRBG_STATE,
         out: *mut u8,
@@ -13016,15 +13016,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CTR_DRBG_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CTR_DRBG_clear"]
     pub fn CTR_DRBG_clear(drbg: *mut CTR_DRBG_STATE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_keypair"]
     pub fn X25519_keypair(out_public_value: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519"]
     pub fn X25519(
         out_shared_key: *mut u8,
         private_key: *const u8,
@@ -13032,15 +13032,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X25519_public_from_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X25519_public_from_private"]
     pub fn X25519_public_from_private(out_public_value: *mut u8, private_key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair"]
     pub fn ED25519_keypair(out_public_key: *mut u8, out_private_key: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_sign"]
     pub fn ED25519_sign(
         out_sig: *mut u8,
         message: *const u8,
@@ -13049,7 +13049,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_verify"]
     pub fn ED25519_verify(
         message: *const u8,
         message_len: usize,
@@ -13058,7 +13058,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ED25519_keypair_from_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ED25519_keypair_from_seed"]
     pub fn ED25519_keypair_from_seed(
         out_public_key: *mut u8,
         out_private_key: *mut u8,
@@ -13069,7 +13069,7 @@ pub const spake2_role_t_spake2_role_alice: spake2_role_t = 0;
 pub const spake2_role_t_spake2_role_bob: spake2_role_t = 1;
 pub type spake2_role_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_new"]
     pub fn SPAKE2_CTX_new(
         my_role: spake2_role_t,
         my_name: *const u8,
@@ -13079,11 +13079,11 @@ extern "C" {
     ) -> *mut SPAKE2_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_CTX_free"]
     pub fn SPAKE2_CTX_free(ctx: *mut SPAKE2_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_generate_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_generate_msg"]
     pub fn SPAKE2_generate_msg(
         ctx: *mut SPAKE2_CTX,
         out: *mut u8,
@@ -13094,7 +13094,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SPAKE2_process_msg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SPAKE2_process_msg"]
     pub fn SPAKE2_process_msg(
         ctx: *mut SPAKE2_CTX,
         out_key: *mut u8,
@@ -13167,33 +13167,33 @@ fn bindgen_test_layout_DES_ks() {
 }
 pub type DES_key_schedule = DES_ks;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_is_weak_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_is_weak_key"]
     pub fn DES_is_weak_key(key: *const DES_cblock) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key"]
     pub fn DES_set_key(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_key_unchecked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_key_unchecked"]
     pub fn DES_set_key_unchecked(key: *const DES_cblock, schedule: *mut DES_key_schedule);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_key_sched"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_key_sched"]
     pub fn DES_key_sched(
         key: *const DES_cblock,
         schedule: *mut DES_key_schedule,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_set_odd_parity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_set_odd_parity"]
     pub fn DES_set_odd_parity(key: *mut DES_cblock);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb_encrypt"]
     pub fn DES_ecb_encrypt(
         in_: *const DES_cblock,
         out: *mut DES_cblock,
@@ -13202,7 +13202,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ncbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ncbc_encrypt"]
     pub fn DES_ncbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13213,7 +13213,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ecb3_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ecb3_encrypt"]
     pub fn DES_ecb3_encrypt(
         input: *const DES_cblock,
         output: *mut DES_cblock,
@@ -13224,7 +13224,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede3_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede3_cbc_encrypt"]
     pub fn DES_ede3_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13237,7 +13237,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DES_ede2_cbc_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DES_ede2_cbc_encrypt"]
     pub fn DES_ede2_cbc_encrypt(
         in_: *const u8,
         out: *mut u8,
@@ -13249,47 +13249,47 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new"]
     pub fn DH_new() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_new_by_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_new_by_nid"]
     pub fn DH_new_by_nid(nid: ::std::os::raw::c_int) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_free"]
     pub fn DH_free(dh: *mut DH);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_up_ref"]
     pub fn DH_up_ref(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_bits"]
     pub fn DH_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pub_key"]
     pub fn DH_get0_pub_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_priv_key"]
     pub fn DH_get0_priv_key(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_p"]
     pub fn DH_get0_p(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_q"]
     pub fn DH_get0_q(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_g"]
     pub fn DH_get0_g(dh: *const DH) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_key"]
     pub fn DH_get0_key(
         dh: *const DH,
         out_pub_key: *mut *const BIGNUM,
@@ -13297,7 +13297,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_key"]
     pub fn DH_set0_key(
         dh: *mut DH,
         pub_key: *mut BIGNUM,
@@ -13305,7 +13305,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get0_pqg"]
     pub fn DH_get0_pqg(
         dh: *const DH,
         out_p: *mut *const BIGNUM,
@@ -13314,7 +13314,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set0_pqg"]
     pub fn DH_set0_pqg(
         dh: *mut DH,
         p: *mut BIGNUM,
@@ -13323,44 +13323,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_set_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_set_length"]
     pub fn DH_set_length(dh: *mut DH, priv_length: ::std::os::raw::c_uint)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_2048"]
     pub fn DH_get_rfc7919_2048() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_rfc7919_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_rfc7919_4096"]
     pub fn DH_get_rfc7919_4096() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_1536"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_1536"]
     pub fn BN_get_rfc3526_prime_1536(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_2048"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_2048"]
     pub fn BN_get_rfc3526_prime_2048(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_3072"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_3072"]
     pub fn BN_get_rfc3526_prime_3072(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_4096"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_4096"]
     pub fn BN_get_rfc3526_prime_4096(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_6144"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_6144"]
     pub fn BN_get_rfc3526_prime_6144(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BN_get_rfc3526_prime_8192"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BN_get_rfc3526_prime_8192"]
     pub fn BN_get_rfc3526_prime_8192(ret: *mut BIGNUM) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters_ex"]
     pub fn DH_generate_parameters_ex(
         dh: *mut DH,
         prime_bits: ::std::os::raw::c_int,
@@ -13369,11 +13369,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_key"]
     pub fn DH_generate_key(dh: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_padded"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_padded"]
     pub fn DH_compute_key_padded(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13381,7 +13381,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key_hashed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key_hashed"]
     pub fn DH_compute_key_hashed(
         dh: *mut DH,
         out: *mut u8,
@@ -13392,19 +13392,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_size"]
     pub fn DH_size(dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_num_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_num_bits"]
     pub fn DH_num_bits(dh: *const DH) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check"]
     pub fn DH_check(dh: *const DH, out_flags: *mut ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_check_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_check_pub_key"]
     pub fn DH_check_pub_key(
         dh: *const DH,
         pub_key: *const BIGNUM,
@@ -13412,19 +13412,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DHparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DHparams_dup"]
     pub fn DHparams_dup(dh: *const DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_parse_parameters"]
     pub fn DH_parse_parameters(cbs: *mut CBS) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_marshal_parameters"]
     pub fn DH_marshal_parameters(cbb: *mut CBB, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_generate_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_generate_parameters"]
     pub fn DH_generate_parameters(
         prime_len: ::std::os::raw::c_int,
         generator: ::std::os::raw::c_int,
@@ -13439,7 +13439,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams"]
     pub fn d2i_DHparams(
         ret: *mut *mut DH,
         inp: *mut *const ::std::os::raw::c_uchar,
@@ -13447,14 +13447,14 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams"]
     pub fn i2d_DHparams(
         in_: *const DH,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_compute_key"]
     pub fn DH_compute_key(
         out: *mut u8,
         peers_key: *const BIGNUM,
@@ -13462,130 +13462,130 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_get_2048_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_get_2048_256"]
     pub fn DH_get_2048_256() -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DH_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DH_clear_flags"]
     pub fn DH_clear_flags(dh: *mut DH, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md4"]
     pub fn EVP_md4() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5"]
     pub fn EVP_md5() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_ripemd160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_ripemd160"]
     pub fn EVP_ripemd160() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha1"]
     pub fn EVP_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha224"]
     pub fn EVP_sha224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha256"]
     pub fn EVP_sha256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha384"]
     pub fn EVP_sha384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512"]
     pub fn EVP_sha512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_224"]
     pub fn EVP_sha512_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha512_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha512_256"]
     pub fn EVP_sha512_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_224"]
     pub fn EVP_sha3_224() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_256"]
     pub fn EVP_sha3_256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_384"]
     pub fn EVP_sha3_384() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_sha3_512"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_sha3_512"]
     pub fn EVP_sha3_512() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake128"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake128"]
     pub fn EVP_shake128() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_shake256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_shake256"]
     pub fn EVP_shake256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_blake2b256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_blake2b256"]
     pub fn EVP_blake2b256() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md5_sha1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md5_sha1"]
     pub fn EVP_md5_sha1() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbynid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbynid"]
     pub fn EVP_get_digestbynid(nid: ::std::os::raw::c_int) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyobj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyobj"]
     pub fn EVP_get_digestbyobj(obj: *const ASN1_OBJECT) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_init"]
     pub fn EVP_MD_CTX_init(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_new"]
     pub fn EVP_MD_CTX_new() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanup"]
     pub fn EVP_MD_CTX_cleanup(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_cleanse"]
     pub fn EVP_MD_CTX_cleanse(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_free"]
     pub fn EVP_MD_CTX_free(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy_ex"]
     pub fn EVP_MD_CTX_copy_ex(
         out: *mut EVP_MD_CTX,
         in_: *const EVP_MD_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_move"]
     pub fn EVP_MD_CTX_move(out: *mut EVP_MD_CTX, in_: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_reset"]
     pub fn EVP_MD_CTX_reset(ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit_ex"]
     pub fn EVP_DigestInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -13593,11 +13593,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestInit"]
     pub fn EVP_DigestInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestUpdate"]
     pub fn EVP_DigestUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -13605,7 +13605,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal_ex"]
     pub fn EVP_DigestFinal_ex(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13613,7 +13613,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinal"]
     pub fn EVP_DigestFinal(
         ctx: *mut EVP_MD_CTX,
         md_out: *mut u8,
@@ -13621,7 +13621,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_Digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_Digest"]
     pub fn EVP_Digest(
         data: *const ::std::os::raw::c_void,
         len: usize,
@@ -13632,63 +13632,63 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_type"]
     pub fn EVP_MD_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_flags"]
     pub fn EVP_MD_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_size"]
     pub fn EVP_MD_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_block_size"]
     pub fn EVP_MD_block_size(md: *const EVP_MD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_md"]
     pub fn EVP_MD_CTX_md(ctx: *const EVP_MD_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_size"]
     pub fn EVP_MD_CTX_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_block_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_block_size"]
     pub fn EVP_MD_CTX_block_size(ctx: *const EVP_MD_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_type"]
     pub fn EVP_MD_CTX_type(ctx: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_digest_algorithm"]
     pub fn EVP_parse_digest_algorithm(cbs: *mut CBS) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_digest_algorithm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_digest_algorithm"]
     pub fn EVP_marshal_digest_algorithm(cbb: *mut CBB, md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_copy"]
     pub fn EVP_MD_CTX_copy(out: *mut EVP_MD_CTX, in_: *const EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_get_digestbyname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_get_digestbyname"]
     pub fn EVP_get_digestbyname(arg1: *const ::std::os::raw::c_char) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_create"]
     pub fn EVP_MD_CTX_create() -> *mut EVP_MD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_destroy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_destroy"]
     pub fn EVP_MD_CTX_destroy(ctx: *mut EVP_MD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestFinalXOF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestFinalXOF"]
     pub fn EVP_DigestFinalXOF(
         ctx: *mut EVP_MD_CTX,
         out: *mut u8,
@@ -13696,15 +13696,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_meth_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_meth_get_flags"]
     pub fn EVP_MD_meth_get_flags(md: *const EVP_MD) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_nid"]
     pub fn EVP_MD_nid(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_pkey_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_pkey_ctx"]
     pub fn EVP_MD_CTX_set_pkey_ctx(ctx: *mut EVP_MD_CTX, pctx: *mut EVP_PKEY_CTX);
 }
 #[repr(C)]
@@ -13813,39 +13813,39 @@ impl Default for env_md_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_enable"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_enable"]
     pub fn EVP_MD_unstable_sha3_enable(enable: bool);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_unstable_sha3_is_enabled"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_unstable_sha3_is_enabled"]
     pub fn EVP_MD_unstable_sha3_is_enabled() -> bool;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_CTX_set_flags"]
     pub fn EVP_MD_CTX_set_flags(ctx: *mut EVP_MD_CTX, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_add_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_add_digest"]
     pub fn EVP_add_digest(digest: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_md_null"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_md_null"]
     pub fn EVP_md_null() -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_new"]
     pub fn DSA_new() -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_free"]
     pub fn DSA_free(dsa: *mut DSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_up_ref"]
     pub fn DSA_up_ref(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print"]
     pub fn DSA_print(
         bio: *mut BIO,
         dsa: *const DSA,
@@ -13853,7 +13853,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_print_fp"]
     pub fn DSA_print_fp(
         fp: *mut FILE,
         dsa: *const DSA,
@@ -13861,31 +13861,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_bits"]
     pub fn DSA_bits(dsa: *const DSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pub_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pub_key"]
     pub fn DSA_get0_pub_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_priv_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_priv_key"]
     pub fn DSA_get0_priv_key(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_p"]
     pub fn DSA_get0_p(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_q"]
     pub fn DSA_get0_q(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_g"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_g"]
     pub fn DSA_get0_g(dsa: *const DSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_key"]
     pub fn DSA_get0_key(
         dsa: *const DSA,
         out_pub_key: *mut *const BIGNUM,
@@ -13893,7 +13893,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get0_pqg"]
     pub fn DSA_get0_pqg(
         dsa: *const DSA,
         out_p: *mut *const BIGNUM,
@@ -13902,7 +13902,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_key"]
     pub fn DSA_set0_key(
         dsa: *mut DSA,
         pub_key: *mut BIGNUM,
@@ -13910,7 +13910,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set0_pqg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set0_pqg"]
     pub fn DSA_set0_pqg(
         dsa: *mut DSA,
         p: *mut BIGNUM,
@@ -13919,7 +13919,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_parameters_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_parameters_ex"]
     pub fn DSA_generate_parameters_ex(
         dsa: *mut DSA,
         bits: ::std::os::raw::c_uint,
@@ -13931,11 +13931,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSAparams_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSAparams_dup"]
     pub fn DSAparams_dup(dsa: *const DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_generate_key"]
     pub fn DSA_generate_key(dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -13989,28 +13989,28 @@ impl Default for DSA_SIG_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_new"]
     pub fn DSA_SIG_new() -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_free"]
     pub fn DSA_SIG_free(sig: *mut DSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_get0"]
     pub fn DSA_SIG_get0(sig: *const DSA_SIG, out_r: *mut *const BIGNUM, out_s: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_set0"]
     pub fn DSA_SIG_set0(sig: *mut DSA_SIG, r: *mut BIGNUM, s: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_sign"]
     pub fn DSA_do_sign(digest: *const u8, digest_len: usize, dsa: *const DSA) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_verify"]
     pub fn DSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -14019,7 +14019,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_do_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_do_check_signature"]
     pub fn DSA_do_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14029,7 +14029,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_sign"]
     pub fn DSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14040,7 +14040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_verify"]
     pub fn DSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14051,7 +14051,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_check_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_check_signature"]
     pub fn DSA_check_signature(
         out_valid: *mut ::std::os::raw::c_int,
         digest: *const u8,
@@ -14062,47 +14062,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_size"]
     pub fn DSA_size(dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_parse"]
     pub fn DSA_SIG_parse(cbs: *mut CBS) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_SIG_marshal"]
     pub fn DSA_SIG_marshal(cbb: *mut CBB, sig: *const DSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_public_key"]
     pub fn DSA_parse_public_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_public_key"]
     pub fn DSA_marshal_public_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_private_key"]
     pub fn DSA_parse_private_key(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_private_key"]
     pub fn DSA_marshal_private_key(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_parse_parameters"]
     pub fn DSA_parse_parameters(cbs: *mut CBS) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_marshal_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_marshal_parameters"]
     pub fn DSA_marshal_parameters(cbb: *mut CBB, dsa: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_dup_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_dup_DH"]
     pub fn DSA_dup_DH(dsa: *const DSA) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_new_index"]
     pub fn DSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14112,7 +14112,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_set_ex_data"]
     pub fn DSA_set_ex_data(
         dsa: *mut DSA,
         idx: ::std::os::raw::c_int,
@@ -14120,14 +14120,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DSA_get_ex_data"]
     pub fn DSA_get_ex_data(
         dsa: *const DSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_SIG"]
     pub fn d2i_DSA_SIG(
         out_sig: *mut *mut DSA_SIG,
         inp: *mut *const u8,
@@ -14135,11 +14135,11 @@ extern "C" {
     ) -> *mut DSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_SIG"]
     pub fn i2d_DSA_SIG(in_: *const DSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPublicKey"]
     pub fn d2i_DSAPublicKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14147,11 +14147,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPublicKey"]
     pub fn i2d_DSAPublicKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey"]
     pub fn d2i_DSAPrivateKey(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14159,11 +14159,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey"]
     pub fn i2d_DSAPrivateKey(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAparams"]
     pub fn d2i_DSAparams(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -14171,7 +14171,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAparams"]
     pub fn i2d_DSAparams(in_: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 #[repr(u32)]
@@ -14182,31 +14182,31 @@ pub enum point_conversion_form_t {
     POINT_CONVERSION_HYBRID = 6,
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p224"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p224"]
     pub fn EC_group_p224() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p256"]
     pub fn EC_group_p256() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p384"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p384"]
     pub fn EC_group_p384() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_p521"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_p521"]
     pub fn EC_group_p521() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_group_secp256k1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_group_secp256k1"]
     pub fn EC_group_secp256k1() -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_by_curve_name"]
     pub fn EC_GROUP_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_cmp"]
     pub fn EC_GROUP_cmp(
         a: *const EC_GROUP,
         b: *const EC_GROUP,
@@ -14214,19 +14214,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_generator"]
     pub fn EC_GROUP_get0_generator(group: *const EC_GROUP) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_order"]
     pub fn EC_GROUP_get0_order(group: *const EC_GROUP) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_order_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_order_bits"]
     pub fn EC_GROUP_order_bits(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_cofactor"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_cofactor"]
     pub fn EC_GROUP_get_cofactor(
         group: *const EC_GROUP,
         cofactor: *mut BIGNUM,
@@ -14234,7 +14234,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_GFp"]
     pub fn EC_GROUP_get_curve_GFp(
         group: *const EC_GROUP,
         out_p: *mut BIGNUM,
@@ -14244,53 +14244,53 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_curve_name"]
     pub fn EC_GROUP_get_curve_name(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_degree"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_degree"]
     pub fn EC_GROUP_get_degree(group: *const EC_GROUP) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nid2nist"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nid2nist"]
     pub fn EC_curve_nid2nist(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_curve_nist2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_curve_nist2nid"]
     pub fn EC_curve_nist2nid(name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_new"]
     pub fn EC_POINT_new(group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_free"]
     pub fn EC_POINT_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_copy"]
     pub fn EC_POINT_copy(dest: *mut EC_POINT, src: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dup"]
     pub fn EC_POINT_dup(src: *const EC_POINT, group: *const EC_GROUP) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_to_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_to_infinity"]
     pub fn EC_POINT_set_to_infinity(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_at_infinity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_at_infinity"]
     pub fn EC_POINT_is_at_infinity(
         group: *const EC_GROUP,
         point: *const EC_POINT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_is_on_curve"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_is_on_curve"]
     pub fn EC_POINT_is_on_curve(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14298,7 +14298,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_cmp"]
     pub fn EC_POINT_cmp(
         group: *const EC_GROUP,
         a: *const EC_POINT,
@@ -14307,7 +14307,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates_GFp"]
     pub fn EC_POINT_get_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14317,7 +14317,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_get_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_get_affine_coordinates"]
     pub fn EC_POINT_get_affine_coordinates(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14327,7 +14327,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates_GFp"]
     pub fn EC_POINT_set_affine_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14337,7 +14337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_affine_coordinates"]
     pub fn EC_POINT_set_affine_coordinates(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14347,7 +14347,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2oct"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2oct"]
     pub fn EC_POINT_point2oct(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14358,7 +14358,7 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2cbb"]
     pub fn EC_POINT_point2cbb(
         out: *mut CBB,
         group: *const EC_GROUP,
@@ -14368,7 +14368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_oct2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_oct2point"]
     pub fn EC_POINT_oct2point(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14378,7 +14378,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_set_compressed_coordinates_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_set_compressed_coordinates_GFp"]
     pub fn EC_POINT_set_compressed_coordinates_GFp(
         group: *const EC_GROUP,
         point: *mut EC_POINT,
@@ -14388,7 +14388,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_add"]
     pub fn EC_POINT_add(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14398,7 +14398,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_dbl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_dbl"]
     pub fn EC_POINT_dbl(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14407,7 +14407,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_invert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_invert"]
     pub fn EC_POINT_invert(
         group: *const EC_GROUP,
         a: *mut EC_POINT,
@@ -14415,7 +14415,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_mul"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_mul"]
     pub fn EC_POINT_mul(
         group: *const EC_GROUP,
         r: *mut EC_POINT,
@@ -14426,7 +14426,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p256_xmd_sha256_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p256_xmd_sha256_sswu"]
     pub fn EC_hash_to_curve_p256_xmd_sha256_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14437,7 +14437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_hash_to_curve_p384_xmd_sha384_sswu"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_hash_to_curve_p384_xmd_sha384_sswu"]
     pub fn EC_hash_to_curve_p384_xmd_sha384_sswu(
         group: *const EC_GROUP,
         out: *mut EC_POINT,
@@ -14448,15 +14448,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_free"]
     pub fn EC_GROUP_free(group: *mut EC_GROUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_dup"]
     pub fn EC_GROUP_dup(group: *const EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_new_curve_GFp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_new_curve_GFp"]
     pub fn EC_GROUP_new_curve_GFp(
         p: *const BIGNUM,
         a: *const BIGNUM,
@@ -14465,7 +14465,7 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_generator"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_generator"]
     pub fn EC_GROUP_set_generator(
         group: *mut EC_GROUP,
         generator: *const EC_POINT,
@@ -14474,7 +14474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_point2bn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_point2bn"]
     pub fn EC_POINT_point2bn(
         group: *const EC_GROUP,
         point: *const EC_POINT,
@@ -14484,7 +14484,7 @@ extern "C" {
     ) -> *mut BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_bn2point"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_bn2point"]
     pub fn EC_POINT_bn2point(
         group: *const EC_GROUP,
         bn: *const BIGNUM,
@@ -14493,7 +14493,7 @@ extern "C" {
     ) -> *mut EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_order"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_order"]
     pub fn EC_GROUP_get_order(
         group: *const EC_GROUP,
         order: *mut BIGNUM,
@@ -14551,28 +14551,28 @@ impl Default for EC_builtin_curve {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_get_builtin_curves"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_get_builtin_curves"]
     pub fn EC_get_builtin_curves(out_curves: *mut EC_builtin_curve, max_num_curves: usize)
         -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_POINT_clear_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_POINT_clear_free"]
     pub fn EC_POINT_clear_free(point: *mut EC_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_asn1_flag"]
     pub fn EC_GROUP_set_asn1_flag(group: *mut EC_GROUP, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_asn1_flag"]
     pub fn EC_GROUP_get_asn1_flag(group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_point_conversion_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_point_conversion_form"]
     pub fn EC_GROUP_set_point_conversion_form(group: *mut EC_GROUP, form: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_set_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_set_seed"]
     pub fn EC_GROUP_set_seed(
         group: *mut EC_GROUP,
         p: *const ::std::os::raw::c_uchar,
@@ -14580,15 +14580,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get0_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get0_seed"]
     pub fn EC_GROUP_get0_seed(group: *const EC_GROUP) -> *mut ::std::os::raw::c_uchar;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_get_seed_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_get_seed_len"]
     pub fn EC_GROUP_get_seed_len(group: *const EC_GROUP) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECPKParameters_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECPKParameters_print"]
     pub fn ECPKParameters_print(
         bio: *mut BIO,
         group: *const EC_GROUP,
@@ -14602,122 +14602,122 @@ pub struct ec_method_st {
 }
 pub type EC_METHOD = ec_method_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_GROUP_method_of"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_GROUP_method_of"]
     pub fn EC_GROUP_method_of(group: *const EC_GROUP) -> *const EC_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_METHOD_get_field_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_METHOD_get_field_type"]
     pub fn EC_METHOD_get_field_type(meth: *const EC_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_new"]
     pub fn ENGINE_new() -> *mut ENGINE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_free"]
     pub fn ENGINE_free(engine: *mut ENGINE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_RSA"]
     pub fn ENGINE_set_RSA(engine: *mut ENGINE, method: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_RSA"]
     pub fn ENGINE_get_RSA(engine: *const ENGINE) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_set_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_set_EC"]
     pub fn ENGINE_set_EC(
         engine: *mut ENGINE,
         method: *const EC_KEY_METHOD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_get_EC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_get_EC"]
     pub fn ENGINE_get_EC(engine: *const ENGINE) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ENGINE_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ENGINE_cleanup"]
     pub fn ENGINE_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new"]
     pub fn EC_KEY_new() -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_method"]
     pub fn EC_KEY_new_method(engine: *const ENGINE) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_new_by_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_new_by_curve_name"]
     pub fn EC_KEY_new_by_curve_name(nid: ::std::os::raw::c_int) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_free"]
     pub fn EC_KEY_free(key: *mut EC_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_dup"]
     pub fn EC_KEY_dup(src: *const EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_up_ref"]
     pub fn EC_KEY_up_ref(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_is_opaque"]
     pub fn EC_KEY_is_opaque(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_group"]
     pub fn EC_KEY_get0_group(key: *const EC_KEY) -> *const EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_group"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_group"]
     pub fn EC_KEY_set_group(key: *mut EC_KEY, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_private_key"]
     pub fn EC_KEY_get0_private_key(key: *const EC_KEY) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_private_key"]
     pub fn EC_KEY_set_private_key(key: *mut EC_KEY, priv_: *const BIGNUM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get0_public_key"]
     pub fn EC_KEY_get0_public_key(key: *const EC_KEY) -> *const EC_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key"]
     pub fn EC_KEY_set_public_key(key: *mut EC_KEY, pub_: *const EC_POINT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_enc_flags"]
     pub fn EC_KEY_get_enc_flags(key: *const EC_KEY) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_enc_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_enc_flags"]
     pub fn EC_KEY_set_enc_flags(key: *mut EC_KEY, flags: ::std::os::raw::c_uint);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_conv_form"]
     pub fn EC_KEY_get_conv_form(key: *const EC_KEY) -> point_conversion_form_t;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_conv_form"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_conv_form"]
     pub fn EC_KEY_set_conv_form(key: *mut EC_KEY, cform: point_conversion_form_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_key"]
     pub fn EC_KEY_check_key(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_check_fips"]
     pub fn EC_KEY_check_fips(key: *const EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_public_key_affine_coordinates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_public_key_affine_coordinates"]
     pub fn EC_KEY_set_public_key_affine_coordinates(
         key: *mut EC_KEY,
         x: *const BIGNUM,
@@ -14725,7 +14725,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_key2buf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_key2buf"]
     pub fn EC_KEY_key2buf(
         key: *const EC_KEY,
         form: point_conversion_form_t,
@@ -14734,15 +14734,15 @@ extern "C" {
     ) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key"]
     pub fn EC_KEY_generate_key(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_generate_key_fips"]
     pub fn EC_KEY_generate_key_fips(key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_derive_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_derive_from_secret"]
     pub fn EC_KEY_derive_from_secret(
         group: *const EC_GROUP,
         secret: *const u8,
@@ -14750,11 +14750,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_private_key"]
     pub fn EC_KEY_parse_private_key(cbs: *mut CBS, group: *const EC_GROUP) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_private_key"]
     pub fn EC_KEY_marshal_private_key(
         cbb: *mut CBB,
         key: *const EC_KEY,
@@ -14762,22 +14762,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_curve_name"]
     pub fn EC_KEY_parse_curve_name(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_marshal_curve_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_marshal_curve_name"]
     pub fn EC_KEY_marshal_curve_name(
         cbb: *mut CBB,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_parse_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_parse_parameters"]
     pub fn EC_KEY_parse_parameters(cbs: *mut CBS) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_new_index"]
     pub fn EC_KEY_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -14787,7 +14787,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_ex_data"]
     pub fn EC_KEY_set_ex_data(
         r: *mut EC_KEY,
         idx: ::std::os::raw::c_int,
@@ -14795,14 +14795,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_ex_data"]
     pub fn EC_KEY_get_ex_data(
         r: *const EC_KEY,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey"]
     pub fn d2i_ECPrivateKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14810,11 +14810,11 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey"]
     pub fn i2d_ECPrivateKey(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECParameters"]
     pub fn d2i_ECParameters(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14822,19 +14822,19 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECParameters"]
     pub fn i2d_ECParameters(key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPKParameters_bio"]
     pub fn d2i_ECPKParameters_bio(bio: *mut BIO, out_group: *mut *mut EC_GROUP) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPKParameters_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPKParameters_bio"]
     pub fn i2d_ECPKParameters_bio(bio: *mut BIO, group: *const EC_GROUP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_o2i_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_o2i_ECPublicKey"]
     pub fn o2i_ECPublicKey(
         out_key: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -14842,38 +14842,38 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2o_ECPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2o_ECPublicKey"]
     pub fn i2o_ECPublicKey(
         key: *const EC_KEY,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_default_method"]
     pub fn EC_KEY_get_default_method() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_OpenSSL"]
     pub fn EC_KEY_OpenSSL() -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_new"]
     pub fn EC_KEY_METHOD_new(eckey_meth: *const EC_KEY_METHOD) -> *mut EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_free"]
     pub fn EC_KEY_METHOD_free(eckey_meth: *mut EC_KEY_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_method"]
     pub fn EC_KEY_set_method(ec: *mut EC_KEY, meth: *const EC_KEY_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_get_method"]
     pub fn EC_KEY_get_method(ec: *const EC_KEY) -> *const EC_KEY_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_sign_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_sign_awslc"]
     pub fn EC_KEY_METHOD_set_sign_awslc(
         meth: *mut EC_KEY_METHOD,
         sign: ::std::option::Option<
@@ -14900,7 +14900,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_init_awslc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_init_awslc"]
     pub fn EC_KEY_METHOD_set_init_awslc(
         meth: *mut EC_KEY_METHOD,
         init: ::std::option::Option<
@@ -14910,18 +14910,18 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_METHOD_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_METHOD_set_flags"]
     pub fn EC_KEY_METHOD_set_flags(
         meth: *mut EC_KEY_METHOD,
         flags: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EC_KEY_set_asn1_flag"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EC_KEY_set_asn1_flag"]
     pub fn EC_KEY_set_asn1_flag(key: *mut EC_KEY, flag: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key"]
     pub fn ECDH_compute_key(
         out: *mut ::std::os::raw::c_void,
         outlen: usize,
@@ -14938,7 +14938,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDH_compute_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDH_compute_key_fips"]
     pub fn ECDH_compute_key_fips(
         out: *mut u8,
         out_len: usize,
@@ -14947,7 +14947,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign"]
     pub fn ECDSA_sign(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14958,7 +14958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_verify"]
     pub fn ECDSA_verify(
         type_: ::std::os::raw::c_int,
         digest: *const u8,
@@ -14969,7 +14969,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_size"]
     pub fn ECDSA_size(key: *const EC_KEY) -> usize;
 }
 #[repr(C)]
@@ -15023,23 +15023,23 @@ impl Default for ecdsa_sig_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_new"]
     pub fn ECDSA_SIG_new() -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_free"]
     pub fn ECDSA_SIG_free(sig: *mut ECDSA_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_r"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_r"]
     pub fn ECDSA_SIG_get0_r(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0_s"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0_s"]
     pub fn ECDSA_SIG_get0_s(sig: *const ECDSA_SIG) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_get0"]
     pub fn ECDSA_SIG_get0(
         sig: *const ECDSA_SIG,
         out_r: *mut *const BIGNUM,
@@ -15047,7 +15047,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_set0"]
     pub fn ECDSA_SIG_set0(
         sig: *mut ECDSA_SIG,
         r: *mut BIGNUM,
@@ -15055,7 +15055,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_sign"]
     pub fn ECDSA_do_sign(
         digest: *const u8,
         digest_len: usize,
@@ -15063,7 +15063,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_do_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_do_verify"]
     pub fn ECDSA_do_verify(
         digest: *const u8,
         digest_len: usize,
@@ -15072,19 +15072,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_parse"]
     pub fn ECDSA_SIG_parse(cbs: *mut CBS) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_from_bytes"]
     pub fn ECDSA_SIG_from_bytes(in_: *const u8, in_len: usize) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_marshal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_marshal"]
     pub fn ECDSA_SIG_marshal(cbb: *mut CBB, sig: *const ECDSA_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_to_bytes"]
     pub fn ECDSA_SIG_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -15092,11 +15092,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_SIG_max_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_SIG_max_len"]
     pub fn ECDSA_SIG_max_len(order_len: usize) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ECDSA_sign_with_nonce_and_leak_private_key_for_testing"]
     pub fn ECDSA_sign_with_nonce_and_leak_private_key_for_testing(
         digest: *const u8,
         digest_len: usize,
@@ -15106,7 +15106,7 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECDSA_SIG"]
     pub fn d2i_ECDSA_SIG(
         out: *mut *mut ECDSA_SIG,
         inp: *mut *const u8,
@@ -15114,83 +15114,83 @@ extern "C" {
     ) -> *mut ECDSA_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECDSA_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECDSA_SIG"]
     pub fn i2d_ECDSA_SIG(sig: *const ECDSA_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm"]
     pub fn EVP_aead_aes_128_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_192_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_192_gcm"]
     pub fn EVP_aead_aes_192_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm"]
     pub fn EVP_aead_aes_256_gcm() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_chacha20_poly1305"]
     pub fn EVP_aead_chacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_xchacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_xchacha20_poly1305"]
     pub fn EVP_aead_xchacha20_poly1305() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_128_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_ctr_hmac_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_ctr_hmac_sha256"]
     pub fn EVP_aead_aes_256_ctr_hmac_sha256() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_siv"]
     pub fn EVP_aead_aes_128_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_siv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_siv"]
     pub fn EVP_aead_aes_256_gcm_siv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_randnonce"]
     pub fn EVP_aead_aes_128_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_randnonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_randnonce"]
     pub fn EVP_aead_aes_256_gcm_randnonce() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth"]
     pub fn EVP_aead_aes_128_ccm_bluetooth() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_bluetooth_8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_bluetooth_8"]
     pub fn EVP_aead_aes_128_ccm_bluetooth_8() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_ccm_matter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_ccm_matter"]
     pub fn EVP_aead_aes_128_ccm_matter() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_has_aes_hardware"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_has_aes_hardware"]
     pub fn EVP_has_aes_hardware() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_key_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_key_length"]
     pub fn EVP_AEAD_key_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_nonce_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_nonce_length"]
     pub fn EVP_AEAD_nonce_length(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_overhead"]
     pub fn EVP_AEAD_max_overhead(aead: *const EVP_AEAD) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_max_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_max_tag_len"]
     pub fn EVP_AEAD_max_tag_len(aead: *const EVP_AEAD) -> usize;
 }
 #[repr(C)]
@@ -15328,11 +15328,11 @@ impl Default for evp_aead_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_zero"]
     pub fn EVP_AEAD_CTX_zero(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_new"]
     pub fn EVP_AEAD_CTX_new(
         aead: *const EVP_AEAD,
         key: *const u8,
@@ -15341,11 +15341,11 @@ extern "C" {
     ) -> *mut EVP_AEAD_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_free"]
     pub fn EVP_AEAD_CTX_free(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init"]
     pub fn EVP_AEAD_CTX_init(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15356,11 +15356,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_cleanup"]
     pub fn EVP_AEAD_CTX_cleanup(ctx: *mut EVP_AEAD_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal"]
     pub fn EVP_AEAD_CTX_seal(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15375,7 +15375,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open"]
     pub fn EVP_AEAD_CTX_open(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15390,7 +15390,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_seal_scatter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_seal_scatter"]
     pub fn EVP_AEAD_CTX_seal_scatter(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15408,7 +15408,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_open_gather"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_open_gather"]
     pub fn EVP_AEAD_CTX_open_gather(
         ctx: *const EVP_AEAD_CTX,
         out: *mut u8,
@@ -15423,70 +15423,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_aead"]
     pub fn EVP_AEAD_CTX_aead(ctx: *const EVP_AEAD_CTX) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_aes_256_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_cbc_sha256_tls_implicit_iv"]
     pub fn EVP_aead_aes_128_cbc_sha256_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_cbc_sha384_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_cbc_sha384_tls"]
     pub fn EVP_aead_aes_256_cbc_sha384_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv"]
     pub fn EVP_aead_des_ede3_cbc_sha1_tls_implicit_iv() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_null_sha1_tls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_null_sha1_tls"]
     pub fn EVP_aead_null_sha1_tls() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls12"]
     pub fn EVP_aead_aes_128_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls12"]
     pub fn EVP_aead_aes_256_gcm_tls12() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_128_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_128_gcm_tls13"]
     pub fn EVP_aead_aes_128_gcm_tls13() -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_aead_aes_256_gcm_tls13"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_aead_aes_256_gcm_tls13"]
     pub fn EVP_aead_aes_256_gcm_tls13() -> *const EVP_AEAD;
 }
 pub const evp_aead_direction_t_evp_aead_open: evp_aead_direction_t = 0;
 pub const evp_aead_direction_t_evp_aead_seal: evp_aead_direction_t = 1;
 pub type evp_aead_direction_t = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_init_with_direction"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_init_with_direction"]
     pub fn EVP_AEAD_CTX_init_with_direction(
         ctx: *mut EVP_AEAD_CTX,
         aead: *const EVP_AEAD,
@@ -15497,7 +15497,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_get_iv"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_get_iv"]
     pub fn EVP_AEAD_CTX_get_iv(
         ctx: *const EVP_AEAD_CTX,
         out_iv: *mut *const u8,
@@ -15505,7 +15505,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_CTX_tag_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_CTX_tag_len"]
     pub fn EVP_AEAD_CTX_tag_len(
         ctx: *const EVP_AEAD_CTX,
         out_tag_len: *mut usize,
@@ -15514,7 +15514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_AEAD_get_iv_from_ipv4_nanosecs"]
     pub fn EVP_AEAD_get_iv_from_ipv4_nanosecs(
         ipv4_address: u32,
         nanosecs: u64,
@@ -15522,70 +15522,70 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_dup"]
     pub fn OBJ_dup(obj: *const ASN1_OBJECT) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cmp"]
     pub fn OBJ_cmp(a: *const ASN1_OBJECT, b: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get0_data"]
     pub fn OBJ_get0_data(obj: *const ASN1_OBJECT) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_length"]
     pub fn OBJ_length(obj: *const ASN1_OBJECT) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2nid"]
     pub fn OBJ_obj2nid(obj: *const ASN1_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cbs2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cbs2nid"]
     pub fn OBJ_cbs2nid(cbs: *const CBS) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_sn2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_sn2nid"]
     pub fn OBJ_sn2nid(short_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_ln2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_ln2nid"]
     pub fn OBJ_ln2nid(long_name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2nid"]
     pub fn OBJ_txt2nid(s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2obj"]
     pub fn OBJ_nid2obj(nid: ::std::os::raw::c_int) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_get_undef"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_get_undef"]
     pub fn OBJ_get_undef() -> *const ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2sn"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2sn"]
     pub fn OBJ_nid2sn(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2ln"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2ln"]
     pub fn OBJ_nid2ln(nid: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_nid2cbb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_nid2cbb"]
     pub fn OBJ_nid2cbb(out: *mut CBB, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_txt2obj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_txt2obj"]
     pub fn OBJ_txt2obj(
         s: *const ::std::os::raw::c_char,
         dont_search_names: ::std::os::raw::c_int,
     ) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_obj2txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_obj2txt"]
     pub fn OBJ_obj2txt(
         out: *mut ::std::os::raw::c_char,
         out_len: ::std::os::raw::c_int,
@@ -15594,7 +15594,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_create"]
     pub fn OBJ_create(
         oid: *const ::std::os::raw::c_char,
         short_name: *const ::std::os::raw::c_char,
@@ -15602,7 +15602,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_algs"]
     pub fn OBJ_find_sigid_algs(
         sign_nid: ::std::os::raw::c_int,
         out_digest_nid: *mut ::std::os::raw::c_int,
@@ -15610,7 +15610,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_find_sigid_by_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_find_sigid_by_algs"]
     pub fn OBJ_find_sigid_by_algs(
         out_sign_nid: *mut ::std::os::raw::c_int,
         digest_nid: ::std::os::raw::c_int,
@@ -15691,7 +15691,7 @@ impl Default for obj_name_st {
 }
 pub type OBJ_NAME = obj_name_st;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_NAME_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_NAME_do_all_sorted"]
     pub fn OBJ_NAME_do_all_sorted(
         type_: ::std::os::raw::c_int,
         callback: ::std::option::Option<
@@ -15701,163 +15701,163 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OBJ_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OBJ_cleanup"]
     pub fn OBJ_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new"]
     pub fn EVP_PKEY_new() -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_free"]
     pub fn EVP_PKEY_free(pkey: *mut EVP_PKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_up_ref"]
     pub fn EVP_PKEY_up_ref(pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_is_opaque"]
     pub fn EVP_PKEY_is_opaque(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp"]
     pub fn EVP_PKEY_cmp(a: *const EVP_PKEY, b: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_copy_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_copy_parameters"]
     pub fn EVP_PKEY_copy_parameters(
         to: *mut EVP_PKEY,
         from: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_missing_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_missing_parameters"]
     pub fn EVP_PKEY_missing_parameters(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_size"]
     pub fn EVP_PKEY_size(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_bits"]
     pub fn EVP_PKEY_bits(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_id"]
     pub fn EVP_PKEY_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_type"]
     pub fn EVP_PKEY_type(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get0_name"]
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_name"]
     pub fn EVP_MD_name(md: *const EVP_MD) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_RSA"]
     pub fn EVP_PKEY_set1_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_RSA"]
     pub fn EVP_PKEY_assign_RSA(pkey: *mut EVP_PKEY, key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_RSA"]
     pub fn EVP_PKEY_get0_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_RSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_RSA"]
     pub fn EVP_PKEY_get1_RSA(pkey: *const EVP_PKEY) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DSA"]
     pub fn EVP_PKEY_set1_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DSA"]
     pub fn EVP_PKEY_assign_DSA(pkey: *mut EVP_PKEY, key: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DSA"]
     pub fn EVP_PKEY_get0_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DSA"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DSA"]
     pub fn EVP_PKEY_get1_DSA(pkey: *const EVP_PKEY) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_EC_KEY"]
     pub fn EVP_PKEY_set1_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_EC_KEY"]
     pub fn EVP_PKEY_assign_EC_KEY(pkey: *mut EVP_PKEY, key: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_EC_KEY"]
     pub fn EVP_PKEY_get0_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_EC_KEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_EC_KEY"]
     pub fn EVP_PKEY_get1_EC_KEY(pkey: *const EVP_PKEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_DH"]
     pub fn EVP_PKEY_set1_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign_DH"]
     pub fn EVP_PKEY_assign_DH(pkey: *mut EVP_PKEY, key: *mut DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0_DH"]
     pub fn EVP_PKEY_get0_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_DH"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_DH"]
     pub fn EVP_PKEY_get1_DH(pkey: *const EVP_PKEY) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set_type"]
     pub fn EVP_PKEY_set_type(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_cmp_parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_cmp_parameters"]
     pub fn EVP_PKEY_cmp_parameters(a: *const EVP_PKEY, b: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_public_key"]
     pub fn EVP_parse_public_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_public_key"]
     pub fn EVP_marshal_public_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_parse_private_key"]
     pub fn EVP_parse_private_key(cbs: *mut CBS) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key"]
     pub fn EVP_marshal_private_key(cbb: *mut CBB, key: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_marshal_private_key_v2"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_marshal_private_key_v2"]
     pub fn EVP_marshal_private_key_v2(cbb: *mut CBB, key: *const EVP_PKEY)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_private_key"]
     pub fn EVP_PKEY_new_raw_private_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15866,7 +15866,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_raw_public_key"]
     pub fn EVP_PKEY_new_raw_public_key(
         type_: ::std::os::raw::c_int,
         unused: *mut ENGINE,
@@ -15875,7 +15875,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_private_key"]
     pub fn EVP_PKEY_get_raw_private_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15883,7 +15883,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get_raw_public_key"]
     pub fn EVP_PKEY_get_raw_public_key(
         pkey: *const EVP_PKEY,
         out: *mut u8,
@@ -15891,7 +15891,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignInit"]
     pub fn EVP_DigestSignInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15901,7 +15901,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignUpdate"]
     pub fn EVP_DigestSignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15909,7 +15909,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSignFinal"]
     pub fn EVP_DigestSignFinal(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15917,7 +15917,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestSign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestSign"]
     pub fn EVP_DigestSign(
         ctx: *mut EVP_MD_CTX,
         out_sig: *mut u8,
@@ -15927,7 +15927,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyInit"]
     pub fn EVP_DigestVerifyInit(
         ctx: *mut EVP_MD_CTX,
         pctx: *mut *mut EVP_PKEY_CTX,
@@ -15937,7 +15937,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyUpdate"]
     pub fn EVP_DigestVerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15945,7 +15945,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerifyFinal"]
     pub fn EVP_DigestVerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15953,7 +15953,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_DigestVerify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_DigestVerify"]
     pub fn EVP_DigestVerify(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -15963,7 +15963,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit_ex"]
     pub fn EVP_SignInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -15971,11 +15971,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignInit"]
     pub fn EVP_SignInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignUpdate"]
     pub fn EVP_SignUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -15983,7 +15983,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_SignFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_SignFinal"]
     pub fn EVP_SignFinal(
         ctx: *const EVP_MD_CTX,
         sig: *mut u8,
@@ -15992,7 +15992,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit_ex"]
     pub fn EVP_VerifyInit_ex(
         ctx: *mut EVP_MD_CTX,
         type_: *const EVP_MD,
@@ -16000,11 +16000,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyInit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyInit"]
     pub fn EVP_VerifyInit(ctx: *mut EVP_MD_CTX, type_: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyUpdate"]
     pub fn EVP_VerifyUpdate(
         ctx: *mut EVP_MD_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16012,7 +16012,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_VerifyFinal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_VerifyFinal"]
     pub fn EVP_VerifyFinal(
         ctx: *mut EVP_MD_CTX,
         sig: *const u8,
@@ -16021,7 +16021,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_public"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_public"]
     pub fn EVP_PKEY_print_public(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16030,7 +16030,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_private"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_private"]
     pub fn EVP_PKEY_print_private(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16039,7 +16039,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_print_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_print_params"]
     pub fn EVP_PKEY_print_params(
         out: *mut BIO,
         pkey: *const EVP_PKEY,
@@ -16048,7 +16048,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC"]
     pub fn PKCS5_PBKDF2_HMAC(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16061,7 +16061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS5_PBKDF2_HMAC_SHA1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS5_PBKDF2_HMAC_SHA1"]
     pub fn PKCS5_PBKDF2_HMAC_SHA1(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16073,7 +16073,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PBE_scrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PBE_scrypt"]
     pub fn EVP_PBE_scrypt(
         password: *const ::std::os::raw::c_char,
         password_len: usize,
@@ -16088,31 +16088,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new"]
     pub fn EVP_PKEY_CTX_new(pkey: *mut EVP_PKEY, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_new_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_new_id"]
     pub fn EVP_PKEY_CTX_new_id(id: ::std::os::raw::c_int, e: *mut ENGINE) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_free"]
     pub fn EVP_PKEY_CTX_free(ctx: *mut EVP_PKEY_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_dup"]
     pub fn EVP_PKEY_CTX_dup(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_pkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_pkey"]
     pub fn EVP_PKEY_CTX_get0_pkey(ctx: *mut EVP_PKEY_CTX) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign_init"]
     pub fn EVP_PKEY_sign_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_sign"]
     pub fn EVP_PKEY_sign(
         ctx: *mut EVP_PKEY_CTX,
         sig: *mut u8,
@@ -16122,11 +16122,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_init"]
     pub fn EVP_PKEY_verify_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify"]
     pub fn EVP_PKEY_verify(
         ctx: *mut EVP_PKEY_CTX,
         sig: *const u8,
@@ -16136,11 +16136,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt_init"]
     pub fn EVP_PKEY_encrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encrypt"]
     pub fn EVP_PKEY_encrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16150,11 +16150,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt_init"]
     pub fn EVP_PKEY_decrypt_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decrypt"]
     pub fn EVP_PKEY_decrypt(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16164,11 +16164,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover_init"]
     pub fn EVP_PKEY_verify_recover_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_verify_recover"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_verify_recover"]
     pub fn EVP_PKEY_verify_recover(
         ctx: *mut EVP_PKEY_CTX,
         out: *mut u8,
@@ -16178,18 +16178,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_init"]
     pub fn EVP_PKEY_derive_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive_set_peer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive_set_peer"]
     pub fn EVP_PKEY_derive_set_peer(
         ctx: *mut EVP_PKEY_CTX,
         peer: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_derive"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_derive"]
     pub fn EVP_PKEY_derive(
         ctx: *mut EVP_PKEY_CTX,
         key: *mut u8,
@@ -16197,18 +16197,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_init"]
     pub fn EVP_PKEY_keygen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen"]
     pub fn EVP_PKEY_keygen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate"]
     pub fn EVP_PKEY_encapsulate(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -16218,7 +16218,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_decapsulate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_decapsulate"]
     pub fn EVP_PKEY_decapsulate(
         ctx: *mut EVP_PKEY_CTX,
         shared_secret: *mut u8,
@@ -16228,102 +16228,102 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen_init"]
     pub fn EVP_PKEY_paramgen_init(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_paramgen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_paramgen"]
     pub fn EVP_PKEY_paramgen(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_signature_md"]
     pub fn EVP_PKEY_CTX_set_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_signature_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_signature_md"]
     pub fn EVP_PKEY_CTX_get_signature_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_padding"]
     pub fn EVP_PKEY_CTX_set_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         padding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_padding"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_padding"]
     pub fn EVP_PKEY_CTX_get_rsa_padding(
         ctx: *mut EVP_PKEY_CTX,
         out_padding: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_pss_saltlen"]
     pub fn EVP_PKEY_CTX_get_rsa_pss_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         out_salt_len: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_bits"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_bits(
         ctx: *mut EVP_PKEY_CTX,
         bits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_keygen_pubexp"]
     pub fn EVP_PKEY_CTX_set_rsa_keygen_pubexp(
         ctx: *mut EVP_PKEY_CTX,
         e: *mut BIGNUM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_set_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_oaep_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_oaep_md"]
     pub fn EVP_PKEY_CTX_get_rsa_oaep_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_rsa_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_rsa_mgf1_md"]
     pub fn EVP_PKEY_CTX_get_rsa_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         out_md: *mut *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_set0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         label: *mut u8,
@@ -16331,28 +16331,28 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get0_rsa_oaep_label"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get0_rsa_oaep_label"]
     pub fn EVP_PKEY_CTX_get0_rsa_oaep_label(
         ctx: *mut EVP_PKEY_CTX,
         out_label: *mut *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_paramgen_curve_nid"]
     pub fn EVP_PKEY_CTX_set_ec_paramgen_curve_nid(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_kem_set_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_kem_set_params"]
     pub fn EVP_PKEY_CTX_kem_set_params(
         ctx: *mut EVP_PKEY_CTX,
         nid: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_public_key"]
     pub fn EVP_PKEY_kem_new_raw_public_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16360,7 +16360,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_secret_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_secret_key"]
     pub fn EVP_PKEY_kem_new_raw_secret_key(
         nid: ::std::os::raw::c_int,
         in_: *const u8,
@@ -16368,7 +16368,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_new_raw_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_new_raw_key"]
     pub fn EVP_PKEY_kem_new_raw_key(
         nid: ::std::os::raw::c_int,
         in_public: *const u8,
@@ -16378,33 +16378,33 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_kem_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_kem_check_key"]
     pub fn EVP_PKEY_kem_check_key(key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dh_pad"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dh_pad"]
     pub fn EVP_PKEY_CTX_set_dh_pad(
         ctx: *mut EVP_PKEY_CTX,
         pad: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get_count"]
     pub fn EVP_PKEY_asn1_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0"]
     pub fn EVP_PKEY_asn1_get0(idx: ::std::os::raw::c_int) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find"]
     pub fn EVP_PKEY_asn1_find(
         _pe: *mut *mut ENGINE,
         type_: ::std::os::raw::c_int,
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_find_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_find_str"]
     pub fn EVP_PKEY_asn1_find_str(
         _pe: *mut *mut ENGINE,
         name: *const ::std::os::raw::c_char,
@@ -16412,7 +16412,7 @@ extern "C" {
     ) -> *const EVP_PKEY_ASN1_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_asn1_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_asn1_get0_info"]
     pub fn EVP_PKEY_asn1_get0_info(
         ppkey_id: *mut ::std::os::raw::c_int,
         pkey_base_id: *mut ::std::os::raw::c_int,
@@ -16423,15 +16423,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_get_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_get_pkey_type"]
     pub fn EVP_MD_get_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_pkey_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_pkey_type"]
     pub fn EVP_MD_pkey_type(md: *const EVP_MD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_CIPHER_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_CIPHER_do_all_sorted"]
     pub fn EVP_CIPHER_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16445,7 +16445,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all_sorted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all_sorted"]
     pub fn EVP_MD_do_all_sorted(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16459,7 +16459,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_MD_do_all"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_MD_do_all"]
     pub fn EVP_MD_do_all(
         callback: ::std::option::Option<
             unsafe extern "C" fn(
@@ -16473,15 +16473,15 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey"]
     pub fn i2d_PrivateKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PublicKey"]
     pub fn i2d_PublicKey(key: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey"]
     pub fn d2i_PrivateKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16490,7 +16490,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AutoPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AutoPrivateKey"]
     pub fn d2i_AutoPrivateKey(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16498,7 +16498,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PublicKey"]
     pub fn d2i_PublicKey(
         type_: ::std::os::raw::c_int,
         out: *mut *mut EVP_PKEY,
@@ -16507,14 +16507,14 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_ec_param_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_ec_param_enc"]
     pub fn EVP_PKEY_CTX_set_ec_param_enc(
         ctx: *mut EVP_PKEY_CTX,
         encoding: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_set1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_set1_tls_encodedpoint"]
     pub fn EVP_PKEY_set1_tls_encodedpoint(
         pkey: *mut EVP_PKEY,
         in_: *const u8,
@@ -16522,40 +16522,40 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get1_tls_encodedpoint"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get1_tls_encodedpoint"]
     pub fn EVP_PKEY_get1_tls_encodedpoint(pkey: *const EVP_PKEY, out_ptr: *mut *mut u8) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_base_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_base_id"]
     pub fn EVP_PKEY_base_id(pkey: *const EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_saltlen(
         ctx: *mut EVP_PKEY_CTX,
         salt_len: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md"]
     pub fn EVP_PKEY_CTX_set_rsa_pss_keygen_mgf1_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY"]
     pub fn i2d_PUBKEY(pkey: *const EVP_PKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY"]
     pub fn d2i_PUBKEY(
         out: *mut *mut EVP_PKEY,
         inp: *mut *const u8,
@@ -16563,11 +16563,11 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY"]
     pub fn i2d_RSA_PUBKEY(rsa: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY"]
     pub fn d2i_RSA_PUBKEY(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -16575,11 +16575,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY"]
     pub fn i2d_DSA_PUBKEY(dsa: *const DSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY"]
     pub fn d2i_DSA_PUBKEY(
         out: *mut *mut DSA,
         inp: *mut *const u8,
@@ -16587,11 +16587,11 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY"]
     pub fn i2d_EC_PUBKEY(ec_key: *const EC_KEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY"]
     pub fn d2i_EC_PUBKEY(
         out: *mut *mut EC_KEY,
         inp: *mut *const u8,
@@ -16599,7 +16599,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_assign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_assign"]
     pub fn EVP_PKEY_assign(
         pkey: *mut EVP_PKEY,
         type_: ::std::os::raw::c_int,
@@ -16607,7 +16607,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_new_mac_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_new_mac_key"]
     pub fn EVP_PKEY_new_mac_key(
         type_: ::std::os::raw::c_int,
         engine: *mut ENGINE,
@@ -16616,45 +16616,45 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_get0"]
     pub fn EVP_PKEY_get0(pkey: *const EVP_PKEY) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_algorithms"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_algorithms"]
     pub fn OpenSSL_add_all_algorithms();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OPENSSL_add_all_algorithms_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OPENSSL_add_all_algorithms_conf"]
     pub fn OPENSSL_add_all_algorithms_conf();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_ciphers"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_ciphers"]
     pub fn OpenSSL_add_all_ciphers();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OpenSSL_add_all_digests"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OpenSSL_add_all_digests"]
     pub fn OpenSSL_add_all_digests();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_cleanup"]
     pub fn EVP_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_bits(
         ctx: *mut EVP_PKEY_CTX,
         nbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_dsa_paramgen_q_bits"]
     pub fn EVP_PKEY_CTX_set_dsa_paramgen_q_bits(
         ctx: *mut EVP_PKEY_CTX,
         qbits: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_ctrl_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_ctrl_str"]
     pub fn EVP_PKEY_CTX_ctrl_str(
         ctx: *mut EVP_PKEY_CTX,
         type_: *const ::std::os::raw::c_char,
@@ -16664,26 +16664,26 @@ extern "C" {
 pub type EVP_PKEY_gen_cb =
     ::std::option::Option<unsafe extern "C" fn(ctx: *mut EVP_PKEY_CTX) -> ::std::os::raw::c_int>;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_cb"]
     pub fn EVP_PKEY_CTX_set_cb(ctx: *mut EVP_PKEY_CTX, cb: EVP_PKEY_gen_cb);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_app_data"]
     pub fn EVP_PKEY_CTX_set_app_data(ctx: *mut EVP_PKEY_CTX, data: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_app_data"]
     pub fn EVP_PKEY_CTX_get_app_data(ctx: *mut EVP_PKEY_CTX) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_get_keygen_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_get_keygen_info"]
     pub fn EVP_PKEY_CTX_get_keygen_info(
         ctx: *mut EVP_PKEY_CTX,
         idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF"]
     pub fn HKDF(
         out_key: *mut u8,
         out_len: usize,
@@ -16697,7 +16697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_extract"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_extract"]
     pub fn HKDF_extract(
         out_key: *mut u8,
         out_len: *mut usize,
@@ -16709,7 +16709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HKDF_expand"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HKDF_expand"]
     pub fn HKDF_expand(
         out_key: *mut u8,
         out_len: usize,
@@ -16721,11 +16721,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Init"]
     pub fn MD5_Init(md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Update"]
     pub fn MD5_Update(
         md5: *mut MD5_CTX,
         data: *const ::std::os::raw::c_void,
@@ -16733,15 +16733,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Final"]
     pub fn MD5_Final(out: *mut u8, md5: *mut MD5_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5"]
     pub fn MD5(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD5_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD5_Transform"]
     pub fn MD5_Transform(md5: *mut MD5_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -16828,7 +16828,7 @@ impl Default for md5_state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC"]
     pub fn HMAC(
         evp_md: *const EVP_MD,
         key: *const ::std::os::raw::c_void,
@@ -16840,27 +16840,27 @@ extern "C" {
     ) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_init"]
     pub fn HMAC_CTX_init(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_new"]
     pub fn HMAC_CTX_new() -> *mut HMAC_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanup"]
     pub fn HMAC_CTX_cleanup(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_cleanse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_cleanse"]
     pub fn HMAC_CTX_cleanse(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_free"]
     pub fn HMAC_CTX_free(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_ex"]
     pub fn HMAC_Init_ex(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16870,7 +16870,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Update"]
     pub fn HMAC_Update(
         ctx: *mut HMAC_CTX,
         data: *const u8,
@@ -16878,7 +16878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Final"]
     pub fn HMAC_Final(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16886,27 +16886,27 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_size"]
     pub fn HMAC_size(ctx: *const HMAC_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_get_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_get_md"]
     pub fn HMAC_CTX_get_md(ctx: *const HMAC_CTX) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy_ex"]
     pub fn HMAC_CTX_copy_ex(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_reset"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_reset"]
     pub fn HMAC_CTX_reset(ctx: *mut HMAC_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_set_precomputed_key_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_set_precomputed_key_export"]
     pub fn HMAC_set_precomputed_key_export(ctx: *mut HMAC_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_get_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_get_precomputed_key"]
     pub fn HMAC_get_precomputed_key(
         ctx: *mut HMAC_CTX,
         out: *mut u8,
@@ -16914,7 +16914,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init_from_precomputed_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init_from_precomputed_key"]
     pub fn HMAC_Init_from_precomputed_key(
         ctx: *mut HMAC_CTX,
         precomputed_key: *const u8,
@@ -16923,7 +16923,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_Init"]
     pub fn HMAC_Init(
         ctx: *mut HMAC_CTX,
         key: *const ::std::os::raw::c_void,
@@ -16932,7 +16932,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HMAC_CTX_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HMAC_CTX_copy"]
     pub fn HMAC_CTX_copy(dest: *mut HMAC_CTX, src: *const HMAC_CTX) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -17108,86 +17108,86 @@ impl Default for hmac_ctx_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_x25519_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_x25519_hkdf_sha256"]
     pub fn EVP_hpke_x25519_hkdf_sha256() -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_id"]
     pub fn EVP_HPKE_KEM_id(kem: *const EVP_HPKE_KEM) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_public_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_public_key_len"]
     pub fn EVP_HPKE_KEM_public_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_private_key_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_private_key_len"]
     pub fn EVP_HPKE_KEM_private_key_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEM_enc_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEM_enc_len"]
     pub fn EVP_HPKE_KEM_enc_len(kem: *const EVP_HPKE_KEM) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_hkdf_sha256"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_hkdf_sha256"]
     pub fn EVP_hpke_hkdf_sha256() -> *const EVP_HPKE_KDF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_id"]
     pub fn EVP_HPKE_KDF_id(kdf: *const EVP_HPKE_KDF) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KDF_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KDF_hkdf_md"]
     pub fn EVP_HPKE_KDF_hkdf_md(kdf: *const EVP_HPKE_KDF) -> *const EVP_MD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_128_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_128_gcm"]
     pub fn EVP_hpke_aes_128_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_aes_256_gcm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_aes_256_gcm"]
     pub fn EVP_hpke_aes_256_gcm() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_hpke_chacha20_poly1305"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_hpke_chacha20_poly1305"]
     pub fn EVP_hpke_chacha20_poly1305() -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_id"]
     pub fn EVP_HPKE_AEAD_id(aead: *const EVP_HPKE_AEAD) -> u16;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_AEAD_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_AEAD_aead"]
     pub fn EVP_HPKE_AEAD_aead(aead: *const EVP_HPKE_AEAD) -> *const EVP_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_zero"]
     pub fn EVP_HPKE_KEY_zero(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_cleanup"]
     pub fn EVP_HPKE_KEY_cleanup(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_new"]
     pub fn EVP_HPKE_KEY_new() -> *mut EVP_HPKE_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_free"]
     pub fn EVP_HPKE_KEY_free(key: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_copy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_copy"]
     pub fn EVP_HPKE_KEY_copy(
         dst: *mut EVP_HPKE_KEY,
         src: *const EVP_HPKE_KEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_move"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_move"]
     pub fn EVP_HPKE_KEY_move(out: *mut EVP_HPKE_KEY, in_: *mut EVP_HPKE_KEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_init"]
     pub fn EVP_HPKE_KEY_init(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
@@ -17196,18 +17196,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_generate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_generate"]
     pub fn EVP_HPKE_KEY_generate(
         key: *mut EVP_HPKE_KEY,
         kem: *const EVP_HPKE_KEM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_kem"]
     pub fn EVP_HPKE_KEY_kem(key: *const EVP_HPKE_KEY) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_public_key"]
     pub fn EVP_HPKE_KEY_public_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17216,7 +17216,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_KEY_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_KEY_private_key"]
     pub fn EVP_HPKE_KEY_private_key(
         key: *const EVP_HPKE_KEY,
         out: *mut u8,
@@ -17225,23 +17225,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_zero"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_zero"]
     pub fn EVP_HPKE_CTX_zero(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_cleanup"]
     pub fn EVP_HPKE_CTX_cleanup(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_new"]
     pub fn EVP_HPKE_CTX_new() -> *mut EVP_HPKE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_free"]
     pub fn EVP_HPKE_CTX_free(ctx: *mut EVP_HPKE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender"]
     pub fn EVP_HPKE_CTX_setup_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17257,7 +17257,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17275,7 +17275,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_recipient"]
     pub fn EVP_HPKE_CTX_setup_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17288,7 +17288,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender"]
     pub fn EVP_HPKE_CTX_setup_auth_sender(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17304,7 +17304,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing"]
     pub fn EVP_HPKE_CTX_setup_auth_sender_with_seed_for_testing(
         ctx: *mut EVP_HPKE_CTX,
         out_enc: *mut u8,
@@ -17322,7 +17322,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_setup_auth_recipient"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_setup_auth_recipient"]
     pub fn EVP_HPKE_CTX_setup_auth_recipient(
         ctx: *mut EVP_HPKE_CTX,
         key: *const EVP_HPKE_KEY,
@@ -17337,7 +17337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_open"]
     pub fn EVP_HPKE_CTX_open(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17350,7 +17350,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_seal"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_seal"]
     pub fn EVP_HPKE_CTX_seal(
         ctx: *mut EVP_HPKE_CTX,
         out: *mut u8,
@@ -17363,7 +17363,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_export"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_export"]
     pub fn EVP_HPKE_CTX_export(
         ctx: *const EVP_HPKE_CTX,
         out: *mut u8,
@@ -17373,19 +17373,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_max_overhead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_max_overhead"]
     pub fn EVP_HPKE_CTX_max_overhead(ctx: *const EVP_HPKE_CTX) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kem"]
     pub fn EVP_HPKE_CTX_kem(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_aead"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_aead"]
     pub fn EVP_HPKE_CTX_aead(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_AEAD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_HPKE_CTX_kdf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_HPKE_CTX_kdf"]
     pub fn EVP_HPKE_CTX_kdf(ctx: *const EVP_HPKE_CTX) -> *const EVP_HPKE_KDF;
 }
 #[repr(C)]
@@ -17644,7 +17644,7 @@ impl Default for HRSS_public_key {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_generate_key"]
     pub fn HRSS_generate_key(
         out_pub: *mut HRSS_public_key,
         out_priv: *mut HRSS_private_key,
@@ -17652,7 +17652,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_encap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_encap"]
     pub fn HRSS_encap(
         out_ciphertext: *mut u8,
         out_shared_key: *mut u8,
@@ -17661,7 +17661,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_decap"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_decap"]
     pub fn HRSS_decap(
         out_shared_key: *mut u8,
         in_priv: *const HRSS_private_key,
@@ -17670,18 +17670,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_marshal_public_key"]
     pub fn HRSS_marshal_public_key(out: *mut u8, in_pub: *const HRSS_public_key);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_HRSS_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_HRSS_parse_public_key"]
     pub fn HRSS_parse_public_key(
         out: *mut HRSS_public_key,
         in_: *const u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_tls1_prf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_tls1_prf"]
     pub fn CRYPTO_tls1_prf(
         digest: *const EVP_MD,
         out: *mut u8,
@@ -17697,7 +17697,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_digest"]
     pub fn SSKDF_digest(
         out_key: *mut u8,
         out_len: usize,
@@ -17709,7 +17709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SSKDF_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SSKDF_hmac"]
     pub fn SSKDF_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17723,7 +17723,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_KBKDF_ctr_hmac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_KBKDF_ctr_hmac"]
     pub fn KBKDF_ctr_hmac(
         out_key: *mut u8,
         out_len: usize,
@@ -17735,21 +17735,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_hkdf_mode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_hkdf_mode"]
     pub fn EVP_PKEY_CTX_hkdf_mode(
         ctx: *mut EVP_PKEY_CTX,
         mode: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set_hkdf_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set_hkdf_md"]
     pub fn EVP_PKEY_CTX_set_hkdf_md(
         ctx: *mut EVP_PKEY_CTX,
         md: *const EVP_MD,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_key"]
     pub fn EVP_PKEY_CTX_set1_hkdf_key(
         ctx: *mut EVP_PKEY_CTX,
         key: *const u8,
@@ -17757,7 +17757,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_set1_hkdf_salt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_set1_hkdf_salt"]
     pub fn EVP_PKEY_CTX_set1_hkdf_salt(
         ctx: *mut EVP_PKEY_CTX,
         salt: *const u8,
@@ -17765,7 +17765,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_CTX_add1_hkdf_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_CTX_add1_hkdf_info"]
     pub fn EVP_PKEY_CTX_add1_hkdf_info(
         ctx: *mut EVP_PKEY_CTX,
         info: *const u8,
@@ -17773,11 +17773,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Init"]
     pub fn MD4_Init(md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Update"]
     pub fn MD4_Update(
         md4: *mut MD4_CTX,
         data: *const ::std::os::raw::c_void,
@@ -17785,15 +17785,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Final"]
     pub fn MD4_Final(out: *mut u8, md4: *mut MD4_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4"]
     pub fn MD4(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_MD4_Transform"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_MD4_Transform"]
     pub fn MD4_Transform(md4: *mut MD4_CTX, block: *const u8);
 }
 #[repr(C)]
@@ -17895,7 +17895,7 @@ pub struct stack_st_X509_CRL {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_raw_certificates"]
     pub fn PKCS7_get_raw_certificates(
         out_certs: *mut stack_st_CRYPTO_BUFFER,
         cbs: *mut CBS,
@@ -17903,47 +17903,47 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_certificates"]
     pub fn PKCS7_get_certificates(
         out_certs: *mut stack_st_X509,
         cbs: *mut CBS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_raw_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_raw_certificates"]
     pub fn PKCS7_bundle_raw_certificates(
         out: *mut CBB,
         certs: *const stack_st_CRYPTO_BUFFER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_certificates"]
     pub fn PKCS7_bundle_certificates(
         out: *mut CBB,
         certs: *const stack_st_X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_CRLs"]
     pub fn PKCS7_get_CRLs(out_crls: *mut stack_st_X509_CRL, cbs: *mut CBS)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_bundle_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_bundle_CRLs"]
     pub fn PKCS7_bundle_CRLs(
         out: *mut CBB,
         crls: *const stack_st_X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_certificates"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_certificates"]
     pub fn PKCS7_get_PEM_certificates(
         out_certs: *mut stack_st_X509,
         pem_bio: *mut BIO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_PEM_CRLs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_PEM_CRLs"]
     pub fn PKCS7_get_PEM_CRLs(
         out_crls: *mut stack_st_X509_CRL,
         pem_bio: *mut BIO,
@@ -18211,15 +18211,15 @@ impl Default for pkcs7_signed_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_new"]
     pub fn PKCS7_new() -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_free"]
     pub fn PKCS7_free(a: *mut PKCS7);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7"]
     pub fn d2i_PKCS7(
         a: *mut *mut PKCS7,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18227,26 +18227,26 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7"]
     pub fn i2d_PKCS7(
         a: *mut PKCS7,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_it"]
     pub static PKCS7_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_new"]
     pub fn PKCS7_RECIP_INFO_new() -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_free"]
     pub fn PKCS7_RECIP_INFO_free(a: *mut PKCS7_RECIP_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_RECIP_INFO"]
     pub fn d2i_PKCS7_RECIP_INFO(
         a: *mut *mut PKCS7_RECIP_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18254,26 +18254,26 @@ extern "C" {
     ) -> *mut PKCS7_RECIP_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_RECIP_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_RECIP_INFO"]
     pub fn i2d_PKCS7_RECIP_INFO(
         a: *mut PKCS7_RECIP_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_it"]
     pub static PKCS7_RECIP_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_new"]
     pub fn PKCS7_SIGNER_INFO_new() -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_free"]
     pub fn PKCS7_SIGNER_INFO_free(a: *mut PKCS7_SIGNER_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_SIGNER_INFO"]
     pub fn d2i_PKCS7_SIGNER_INFO(
         a: *mut *mut PKCS7_SIGNER_INFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -18281,14 +18281,14 @@ extern "C" {
     ) -> *mut PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_SIGNER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_SIGNER_INFO"]
     pub fn i2d_PKCS7_SIGNER_INFO(
         a: *mut PKCS7_SIGNER_INFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_it"]
     pub static PKCS7_SIGNER_INFO_it: ASN1_ITEM;
 }
 #[repr(C)]
@@ -18336,37 +18336,37 @@ pub type sk_PKCS7_SIGNER_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_dup"]
     pub fn PKCS7_dup(p7: *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS7_bio"]
     pub fn d2i_PKCS7_bio(bio: *mut BIO, out: *mut *mut PKCS7) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS7_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS7_bio"]
     pub fn i2d_PKCS7_bio(bio: *mut BIO, p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signed_attribute"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signed_attribute"]
     pub fn PKCS7_get_signed_attribute(
         si: *const PKCS7_SIGNER_INFO,
         nid: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_get_signer_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_get_signer_info"]
     pub fn PKCS7_get_signer_info(p7: *mut PKCS7) -> *mut stack_st_PKCS7_SIGNER_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_set"]
     pub fn PKCS7_RECIP_INFO_set(
         p7i: *mut PKCS7_RECIP_INFO,
         x509: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_set"]
     pub fn PKCS7_SIGNER_INFO_set(
         p7i: *mut PKCS7_SIGNER_INFO,
         x509: *mut X509,
@@ -18375,46 +18375,46 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_certificate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_certificate"]
     pub fn PKCS7_add_certificate(p7: *mut PKCS7, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_crl"]
     pub fn PKCS7_add_crl(p7: *mut PKCS7, x509: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_recipient_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_recipient_info"]
     pub fn PKCS7_add_recipient_info(
         p7: *mut PKCS7,
         ri: *mut PKCS7_RECIP_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_add_signer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_add_signer"]
     pub fn PKCS7_add_signer(p7: *mut PKCS7, p7i: *mut PKCS7_SIGNER_INFO) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_content_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_content_new"]
     pub fn PKCS7_content_new(p7: *mut PKCS7, nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_cipher"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_cipher"]
     pub fn PKCS7_set_cipher(p7: *mut PKCS7, cipher: *const EVP_CIPHER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_content"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_content"]
     pub fn PKCS7_set_content(p7: *mut PKCS7, p7_data: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_set_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_set_type"]
     pub fn PKCS7_set_type(p7: *mut PKCS7, type_: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_RECIP_INFO_get0_alg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_RECIP_INFO_get0_alg"]
     pub fn PKCS7_RECIP_INFO_get0_alg(ri: *mut PKCS7_RECIP_INFO, penc: *mut *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_SIGNER_INFO_get0_algs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_SIGNER_INFO_get0_algs"]
     pub fn PKCS7_SIGNER_INFO_get0_algs(
         si: *mut PKCS7_SIGNER_INFO,
         pk: *mut *mut EVP_PKEY,
@@ -18423,31 +18423,31 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_data"]
     pub fn PKCS7_type_is_data(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_digest"]
     pub fn PKCS7_type_is_digest(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_encrypted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_encrypted"]
     pub fn PKCS7_type_is_encrypted(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_enveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_enveloped"]
     pub fn PKCS7_type_is_enveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signed"]
     pub fn PKCS7_type_is_signed(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_type_is_signedAndEnveloped"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_type_is_signedAndEnveloped"]
     pub fn PKCS7_type_is_signedAndEnveloped(p7: *const PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS7_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS7_sign"]
     pub fn PKCS7_sign(
         sign_cert: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -18473,15 +18473,15 @@ pub type sk_CRYPTO_BUFFER_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_new"]
     pub fn CRYPTO_BUFFER_POOL_new() -> *mut CRYPTO_BUFFER_POOL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_POOL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_POOL_free"]
     pub fn CRYPTO_BUFFER_POOL_free(pool: *mut CRYPTO_BUFFER_POOL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new"]
     pub fn CRYPTO_BUFFER_new(
         data: *const u8,
         len: usize,
@@ -18489,18 +18489,18 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_alloc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_alloc"]
     pub fn CRYPTO_BUFFER_alloc(out_data: *mut *mut u8, len: usize) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_CBS"]
     pub fn CRYPTO_BUFFER_new_from_CBS(
         cbs: *const CBS,
         pool: *mut CRYPTO_BUFFER_POOL,
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_new_from_static_data_unsafe"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_new_from_static_data_unsafe"]
     pub fn CRYPTO_BUFFER_new_from_static_data_unsafe(
         data: *const u8,
         len: usize,
@@ -18508,31 +18508,31 @@ extern "C" {
     ) -> *mut CRYPTO_BUFFER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_free"]
     pub fn CRYPTO_BUFFER_free(buf: *mut CRYPTO_BUFFER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_up_ref"]
     pub fn CRYPTO_BUFFER_up_ref(buf: *mut CRYPTO_BUFFER) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_data"]
     pub fn CRYPTO_BUFFER_data(buf: *const CRYPTO_BUFFER) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_len"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_len"]
     pub fn CRYPTO_BUFFER_len(buf: *const CRYPTO_BUFFER) -> usize;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_BUFFER_init_CBS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_BUFFER_init_CBS"]
     pub fn CRYPTO_BUFFER_init_CBS(buf: *const CRYPTO_BUFFER, out: *mut CBS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key"]
     pub fn RSA_new_public_key(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key"]
     pub fn RSA_new_private_key(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -18545,59 +18545,59 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new"]
     pub fn RSA_new() -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method"]
     pub fn RSA_new_method(engine: *const ENGINE) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_free"]
     pub fn RSA_free(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_up_ref"]
     pub fn RSA_up_ref(rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_bits"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_bits"]
     pub fn RSA_bits(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_n"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_n"]
     pub fn RSA_get0_n(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_e"]
     pub fn RSA_get0_e(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_d"]
     pub fn RSA_get0_d(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_p"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_p"]
     pub fn RSA_get0_p(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_q"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_q"]
     pub fn RSA_get0_q(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmp1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmp1"]
     pub fn RSA_get0_dmp1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_dmq1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_dmq1"]
     pub fn RSA_get0_dmq1(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_iqmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_iqmp"]
     pub fn RSA_get0_iqmp(rsa: *const RSA) -> *const BIGNUM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_key"]
     pub fn RSA_get0_key(
         rsa: *const RSA,
         out_n: *mut *const BIGNUM,
@@ -18606,11 +18606,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_factors"]
     pub fn RSA_get0_factors(rsa: *const RSA, out_p: *mut *const BIGNUM, out_q: *mut *const BIGNUM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_crt_params"]
     pub fn RSA_get0_crt_params(
         rsa: *const RSA,
         out_dmp1: *mut *const BIGNUM,
@@ -18619,7 +18619,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_key"]
     pub fn RSA_set0_key(
         rsa: *mut RSA,
         n: *mut BIGNUM,
@@ -18628,12 +18628,12 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_factors"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_factors"]
     pub fn RSA_set0_factors(rsa: *mut RSA, p: *mut BIGNUM, q: *mut BIGNUM)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set0_crt_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set0_crt_params"]
     pub fn RSA_set0_crt_params(
         rsa: *mut RSA,
         dmp1: *mut BIGNUM,
@@ -18642,44 +18642,44 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_default_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_default_method"]
     pub fn RSA_get_default_method() -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_new"]
     pub fn RSA_meth_new(
         name: *const ::std::os::raw::c_char,
         flags: ::std::os::raw::c_int,
     ) -> *mut RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_method"]
     pub fn RSA_set_method(rsa: *mut RSA, meth: *const RSA_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_method"]
     pub fn RSA_get_method(rsa: *const RSA) -> *const RSA_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_free"]
     pub fn RSA_meth_free(meth: *mut RSA_METHOD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_init"]
     pub fn RSA_meth_set_init(
         meth: *mut RSA_METHOD,
         init: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_finish"]
     pub fn RSA_meth_set_finish(
         meth: *mut RSA_METHOD,
         finish: ::std::option::Option<unsafe extern "C" fn(rsa: *mut RSA) -> ::std::os::raw::c_int>,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_dec"]
     pub fn RSA_meth_set_priv_dec(
         meth: *mut RSA_METHOD,
         priv_dec: ::std::option::Option<
@@ -18694,7 +18694,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_priv_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_priv_enc"]
     pub fn RSA_meth_set_priv_enc(
         meth: *mut RSA_METHOD,
         priv_enc: ::std::option::Option<
@@ -18709,7 +18709,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_dec"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_dec"]
     pub fn RSA_meth_set_pub_dec(
         meth: *mut RSA_METHOD,
         pub_dec: ::std::option::Option<
@@ -18724,7 +18724,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_pub_enc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_pub_enc"]
     pub fn RSA_meth_set_pub_enc(
         meth: *mut RSA_METHOD,
         pub_enc: ::std::option::Option<
@@ -18739,14 +18739,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set0_app_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set0_app_data"]
     pub fn RSA_meth_set0_app_data(
         meth: *mut RSA_METHOD,
         app_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_meth_set_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_meth_set_sign"]
     pub fn RSA_meth_set_sign(
         meth: *mut RSA_METHOD,
         sign: ::std::option::Option<
@@ -18762,7 +18762,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_ex"]
     pub fn RSA_generate_key_ex(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18771,7 +18771,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key_fips"]
     pub fn RSA_generate_key_fips(
         rsa: *mut RSA,
         bits: ::std::os::raw::c_int,
@@ -18779,7 +18779,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_encrypt"]
     pub fn RSA_encrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18791,7 +18791,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_decrypt"]
     pub fn RSA_decrypt(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18803,7 +18803,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_encrypt"]
     pub fn RSA_public_encrypt(
         flen: usize,
         from: *const u8,
@@ -18813,7 +18813,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_decrypt"]
     pub fn RSA_private_decrypt(
         flen: usize,
         from: *const u8,
@@ -18823,7 +18823,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign"]
     pub fn RSA_sign(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18834,7 +18834,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_pss_mgf1"]
     pub fn RSA_sign_pss_mgf1(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18848,7 +18848,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_sign_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_sign_raw"]
     pub fn RSA_sign_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18860,7 +18860,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify"]
     pub fn RSA_verify(
         hash_nid: ::std::os::raw::c_int,
         digest: *const u8,
@@ -18871,7 +18871,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_pss_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_pss_mgf1"]
     pub fn RSA_verify_pss_mgf1(
         rsa: *mut RSA,
         digest: *const u8,
@@ -18884,7 +18884,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_raw"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_raw"]
     pub fn RSA_verify_raw(
         rsa: *mut RSA,
         out_len: *mut usize,
@@ -18896,7 +18896,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_encrypt"]
     pub fn RSA_private_encrypt(
         flen: usize,
         from: *const u8,
@@ -18906,7 +18906,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_decrypt"]
     pub fn RSA_public_decrypt(
         flen: usize,
         from: *const u8,
@@ -18916,31 +18916,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_size"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_size"]
     pub fn RSA_size(rsa: *const RSA) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_is_opaque"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_is_opaque"]
     pub fn RSA_is_opaque(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPublicKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPublicKey_dup"]
     pub fn RSAPublicKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSAPrivateKey_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSAPrivateKey_dup"]
     pub fn RSAPrivateKey_dup(rsa: *const RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_key"]
     pub fn RSA_check_key(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_check_fips"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_check_fips"]
     pub fn RSA_check_fips(key: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS_mgf1"]
     pub fn RSA_verify_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         mHash: *const u8,
@@ -18951,7 +18951,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS_mgf1"]
     pub fn RSA_padding_add_PKCS1_PSS_mgf1(
         rsa: *const RSA,
         EM: *mut u8,
@@ -18962,7 +18962,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP_mgf1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP_mgf1"]
     pub fn RSA_padding_add_PKCS1_OAEP_mgf1(
         to: *mut u8,
         to_len: usize,
@@ -18975,7 +18975,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS1_MGF1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS1_MGF1"]
     pub fn PKCS1_MGF1(
         out: *mut u8,
         len: usize,
@@ -18985,7 +18985,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_add_pkcs1_prefix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_add_pkcs1_prefix"]
     pub fn RSA_add_pkcs1_prefix(
         out_msg: *mut *mut u8,
         out_msg_len: *mut usize,
@@ -18996,19 +18996,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_public_key"]
     pub fn RSA_parse_public_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_from_bytes"]
     pub fn RSA_public_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_public_key"]
     pub fn RSA_marshal_public_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_public_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_public_key_to_bytes"]
     pub fn RSA_public_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19016,19 +19016,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_parse_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_parse_private_key"]
     pub fn RSA_parse_private_key(cbs: *mut CBS) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_from_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_from_bytes"]
     pub fn RSA_private_key_from_bytes(in_: *const u8, in_len: usize) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_marshal_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_marshal_private_key"]
     pub fn RSA_marshal_private_key(cbb: *mut CBB, rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_private_key_to_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_private_key_to_bytes"]
     pub fn RSA_private_key_to_bytes(
         out_bytes: *mut *mut u8,
         out_len: *mut usize,
@@ -19036,7 +19036,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_crt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_crt"]
     pub fn RSA_new_private_key_no_crt(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19044,15 +19044,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_no_e"]
     pub fn RSA_new_private_key_no_e(n: *const BIGNUM, d: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_public_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_public_key_large_e"]
     pub fn RSA_new_public_key_large_e(n: *const BIGNUM, e: *const BIGNUM) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_private_key_large_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_private_key_large_e"]
     pub fn RSA_new_private_key_large_e(
         n: *const BIGNUM,
         e: *const BIGNUM,
@@ -19065,7 +19065,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_new_index"]
     pub fn RSA_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -19075,7 +19075,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_ex_data"]
     pub fn RSA_set_ex_data(
         rsa: *mut RSA,
         idx: ::std::os::raw::c_int,
@@ -19083,34 +19083,34 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get_ex_data"]
     pub fn RSA_get_ex_data(
         rsa: *const RSA,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_flags"]
     pub fn RSA_flags(rsa: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_set_flags"]
     pub fn RSA_set_flags(rsa: *mut RSA, flags: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_test_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_test_flags"]
     pub fn RSA_test_flags(rsa: *const RSA, flags: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_on"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_on"]
     pub fn RSA_blinding_on(rsa: *mut RSA, ctx: *mut BN_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_blinding_off_temp_for_accp_compatibility"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_blinding_off_temp_for_accp_compatibility"]
     pub fn RSA_blinding_off_temp_for_accp_compatibility(rsa: *mut RSA);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_pkey_ctx_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_pkey_ctx_ctrl"]
     pub fn RSA_pkey_ctx_ctrl(
         ctx: *mut EVP_PKEY_CTX,
         optype: ::std::os::raw::c_int,
@@ -19120,7 +19120,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_generate_key"]
     pub fn RSA_generate_key(
         bits: ::std::os::raw::c_int,
         e: u64,
@@ -19129,7 +19129,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey"]
     pub fn d2i_RSAPublicKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19137,11 +19137,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey"]
     pub fn i2d_RSAPublicKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey"]
     pub fn d2i_RSAPrivateKey(
         out: *mut *mut RSA,
         inp: *mut *const u8,
@@ -19149,11 +19149,11 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey"]
     pub fn i2d_RSAPrivateKey(in_: *const RSA, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_PSS"]
     pub fn RSA_padding_add_PKCS1_PSS(
         rsa: *const RSA,
         EM: *mut u8,
@@ -19163,7 +19163,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_verify_PKCS1_PSS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_verify_PKCS1_PSS"]
     pub fn RSA_verify_PKCS1_PSS(
         rsa: *const RSA,
         mHash: *const u8,
@@ -19173,7 +19173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_padding_add_PKCS1_OAEP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_padding_add_PKCS1_OAEP"]
     pub fn RSA_padding_add_PKCS1_OAEP(
         to: *mut u8,
         to_len: usize,
@@ -19184,7 +19184,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print"]
     pub fn RSA_print(
         bio: *mut BIO,
         rsa: *const RSA,
@@ -19192,7 +19192,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_print_fp"]
     pub fn RSA_print_fp(
         fp: *mut FILE,
         rsa: *const RSA,
@@ -19200,11 +19200,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_get0_pss_params"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_get0_pss_params"]
     pub fn RSA_get0_pss_params(rsa: *const RSA) -> *const RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_new_method_no_e"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_new_method_no_e"]
     pub fn RSA_new_method_no_e(engine: *const ENGINE, n: *const BIGNUM) -> *mut RSA;
 }
 pub type sk_X509_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509)>;
@@ -19223,27 +19223,27 @@ pub type sk_X509_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_it"]
     pub static X509_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_up_ref"]
     pub fn X509_up_ref(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_chain_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_chain_up_ref"]
     pub fn X509_chain_up_ref(chain: *mut stack_st_X509) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_dup"]
     pub fn X509_dup(x509: *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_free"]
     pub fn X509_free(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509"]
     pub fn d2i_X509(
         out: *mut *mut X509,
         inp: *mut *const u8,
@@ -19251,62 +19251,62 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_parse_from_buffer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_parse_from_buffer"]
     pub fn X509_parse_from_buffer(buf: *mut CRYPTO_BUFFER) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509"]
     pub fn i2d_X509(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_version"]
     pub fn X509_get_version(x509: *const X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_serialNumber"]
     pub fn X509_get0_serialNumber(x509: *const X509) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notBefore"]
     pub fn X509_get0_notBefore(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_notAfter"]
     pub fn X509_get0_notAfter(x509: *const X509) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_issuer_name"]
     pub fn X509_get_issuer_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_subject_name"]
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_X509_PUBKEY"]
     pub fn X509_get_X509_PUBKEY(x509: *const X509) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey"]
     pub fn X509_get0_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pubkey"]
     pub fn X509_get_pubkey(x509: *const X509) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_pubkey_bitstr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_pubkey_bitstr"]
     pub fn X509_get0_pubkey_bitstr(x509: *const X509) -> *mut ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_private_key"]
     pub fn X509_check_private_key(
         x509: *const X509,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_uids"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_uids"]
     pub fn X509_get0_uids(
         x509: *const X509,
         out_issuer_uid: *mut *const ASN1_BIT_STRING,
@@ -19314,27 +19314,27 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extension_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extension_flags"]
     pub fn X509_get_extension_flags(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_pathlen"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_pathlen"]
     pub fn X509_get_pathlen(x509: *mut X509) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_key_usage"]
     pub fn X509_get_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_extended_key_usage"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_extended_key_usage"]
     pub fn X509_get_extended_key_usage(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_subject_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_subject_key_id"]
     pub fn X509_get0_subject_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_key_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_key_id"]
     pub fn X509_get0_authority_key_id(x509: *mut X509) -> *const ASN1_OCTET_STRING;
 }
 #[repr(C)]
@@ -19360,11 +19360,11 @@ pub type sk_GENERAL_NAME_delete_if_func = ::std::option::Option<
 >;
 pub type GENERAL_NAMES = stack_st_GENERAL_NAME;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_issuer"]
     pub fn X509_get0_authority_issuer(x509: *mut X509) -> *const GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_authority_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_authority_serial"]
     pub fn X509_get0_authority_serial(x509: *mut X509) -> *const ASN1_INTEGER;
 }
 #[repr(C)]
@@ -19373,15 +19373,15 @@ pub struct stack_st_X509_EXTENSION {
     _unused: [u8; 0],
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_extensions"]
     pub fn X509_get0_extensions(x509: *const X509) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_count"]
     pub fn X509_get_ext_count(x: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_NID"]
     pub fn X509_get_ext_by_NID(
         x: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19389,7 +19389,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_OBJ"]
     pub fn X509_get_ext_by_OBJ(
         x: *const X509,
         obj: *const ASN1_OBJECT,
@@ -19397,7 +19397,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_by_critical"]
     pub fn X509_get_ext_by_critical(
         x: *const X509,
         crit: ::std::os::raw::c_int,
@@ -19405,11 +19405,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext"]
     pub fn X509_get_ext(x: *const X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ext_d2i"]
     pub fn X509_get_ext_d2i(
         x509: *const X509,
         nid: ::std::os::raw::c_int,
@@ -19418,11 +19418,11 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_tbs_sigalg"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_tbs_sigalg"]
     pub fn X509_get0_tbs_sigalg(x509: *const X509) -> *const X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_info"]
     pub fn X509_get_signature_info(
         x509: *mut X509,
         digest_nid: *mut ::std::os::raw::c_int,
@@ -19432,7 +19432,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get0_signature"]
     pub fn X509_get0_signature(
         out_sig: *mut *const ASN1_BIT_STRING,
         out_alg: *mut *const X509_ALGOR,
@@ -19440,84 +19440,84 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_signature_nid"]
     pub fn X509_get_signature_nid(x509: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_tbs"]
     pub fn i2d_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify"]
     pub fn X509_verify(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_email"]
     pub fn X509_get1_email(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get1_ocsp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get1_ocsp"]
     pub fn X509_get1_ocsp(x509: *const X509) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_email_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_email_free"]
     pub fn X509_email_free(sk: *mut stack_st_OPENSSL_STRING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_new"]
     pub fn X509_new() -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_version"]
     pub fn X509_set_version(
         x509: *mut X509,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_serialNumber"]
     pub fn X509_set_serialNumber(
         x509: *mut X509,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notBefore"]
     pub fn X509_set1_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_notAfter"]
     pub fn X509_set1_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notBefore"]
     pub fn X509_getm_notBefore(x509: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_getm_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_getm_notAfter"]
     pub fn X509_getm_notAfter(x: *mut X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_issuer_name"]
     pub fn X509_set_issuer_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_subject_name"]
     pub fn X509_set_subject_name(x509: *mut X509, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_pubkey"]
     pub fn X509_set_pubkey(x509: *mut X509, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_delete_ext"]
     pub fn X509_delete_ext(x: *mut X509, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add_ext"]
     pub fn X509_add_ext(
         x: *mut X509,
         ex: *const X509_EXTENSION,
@@ -19525,7 +19525,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_ext_i2d"]
     pub fn X509_add1_ext_i2d(
         x: *mut X509,
         nid: ::std::os::raw::c_int,
@@ -19535,7 +19535,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign"]
     pub fn X509_sign(
         x509: *mut X509,
         pkey: *mut EVP_PKEY,
@@ -19543,25 +19543,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_sign_ctx"]
     pub fn X509_sign_ctx(x509: *mut X509, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_tbs"]
     pub fn i2d_re_X509_tbs(
         x509: *mut X509,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_algo"]
     pub fn X509_set1_signature_algo(
         x509: *mut X509,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set1_signature_value"]
     pub fn X509_set1_signature_value(
         x509: *mut X509,
         sig: *const u8,
@@ -19569,11 +19569,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_AUX"]
     pub fn i2d_X509_AUX(x509: *mut X509, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_AUX"]
     pub fn d2i_X509_AUX(
         x509: *mut *mut X509,
         inp: *mut *const u8,
@@ -19581,7 +19581,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_set1"]
     pub fn X509_alias_set1(
         x509: *mut X509,
         name: *const u8,
@@ -19589,7 +19589,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_set1"]
     pub fn X509_keyid_set1(
         x509: *mut X509,
         id: *const u8,
@@ -19597,33 +19597,33 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_alias_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_alias_get0"]
     pub fn X509_alias_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_keyid_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_keyid_get0"]
     pub fn X509_keyid_get0(x509: *const X509, out_len: *mut ::std::os::raw::c_int) -> *const u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_trust_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_trust_object"]
     pub fn X509_add1_trust_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_add1_reject_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_add1_reject_object"]
     pub fn X509_add1_reject_object(
         x509: *mut X509,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_trust_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_trust_clear"]
     pub fn X509_trust_clear(x509: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_reject_clear"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_reject_clear"]
     pub fn X509_reject_clear(x509: *mut X509);
 }
 pub type sk_X509_CRL_free_func = ::std::option::Option<unsafe extern "C" fn(arg1: *mut X509_CRL)>;
@@ -19663,23 +19663,23 @@ pub type sk_X509_REVOKED_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_it"]
     pub static X509_CRL_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_up_ref"]
     pub fn X509_CRL_up_ref(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_dup"]
     pub fn X509_CRL_dup(crl: *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_free"]
     pub fn X509_CRL_free(crl: *mut X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL"]
     pub fn d2i_X509_CRL(
         out: *mut *mut X509_CRL,
         inp: *mut *const u8,
@@ -19687,27 +19687,27 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL"]
     pub fn i2d_X509_CRL(crl: *mut X509_CRL, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_version"]
     pub fn X509_CRL_get_version(crl: *const X509_CRL) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_lastUpdate"]
     pub fn X509_CRL_get0_lastUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_nextUpdate"]
     pub fn X509_CRL_get0_nextUpdate(crl: *const X509_CRL) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_issuer"]
     pub fn X509_CRL_get_issuer(crl: *const X509_CRL) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_serial"]
     pub fn X509_CRL_get0_by_serial(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19715,7 +19715,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_by_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_by_cert"]
     pub fn X509_CRL_get0_by_cert(
         crl: *mut X509_CRL,
         out: *mut *mut X509_REVOKED,
@@ -19723,19 +19723,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_REVOKED"]
     pub fn X509_CRL_get_REVOKED(crl: *mut X509_CRL) -> *mut stack_st_X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_extensions"]
     pub fn X509_CRL_get0_extensions(crl: *const X509_CRL) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_count"]
     pub fn X509_CRL_get_ext_count(x: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_NID"]
     pub fn X509_CRL_get_ext_by_NID(
         x: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19743,7 +19743,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_OBJ"]
     pub fn X509_CRL_get_ext_by_OBJ(
         x: *const X509_CRL,
         obj: *const ASN1_OBJECT,
@@ -19751,7 +19751,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_by_critical"]
     pub fn X509_CRL_get_ext_by_critical(
         x: *const X509_CRL,
         crit: ::std::os::raw::c_int,
@@ -19759,11 +19759,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext"]
     pub fn X509_CRL_get_ext(x: *const X509_CRL, loc: ::std::os::raw::c_int) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_ext_d2i"]
     pub fn X509_CRL_get_ext_d2i(
         crl: *const X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19772,7 +19772,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get0_signature"]
     pub fn X509_CRL_get0_signature(
         crl: *const X509_CRL,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -19780,70 +19780,70 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_signature_nid"]
     pub fn X509_CRL_get_signature_nid(crl: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_tbs"]
     pub fn i2d_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_verify"]
     pub fn X509_CRL_verify(crl: *mut X509_CRL, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_new"]
     pub fn X509_CRL_new() -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_version"]
     pub fn X509_CRL_set_version(
         crl: *mut X509_CRL,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set_issuer_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set_issuer_name"]
     pub fn X509_CRL_set_issuer_name(
         crl: *mut X509_CRL,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_lastUpdate"]
     pub fn X509_CRL_set1_lastUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_nextUpdate"]
     pub fn X509_CRL_set1_nextUpdate(
         crl: *mut X509_CRL,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add0_revoked"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add0_revoked"]
     pub fn X509_CRL_add0_revoked(
         crl: *mut X509_CRL,
         rev: *mut X509_REVOKED,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sort"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sort"]
     pub fn X509_CRL_sort(crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_delete_ext"]
     pub fn X509_CRL_delete_ext(x: *mut X509_CRL, loc: ::std::os::raw::c_int)
         -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add_ext"]
     pub fn X509_CRL_add_ext(
         x: *mut X509_CRL,
         ex: *const X509_EXTENSION,
@@ -19851,7 +19851,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_add1_ext_i2d"]
     pub fn X509_CRL_add1_ext_i2d(
         x: *mut X509_CRL,
         nid: ::std::os::raw::c_int,
@@ -19861,7 +19861,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign"]
     pub fn X509_CRL_sign(
         crl: *mut X509_CRL,
         pkey: *mut EVP_PKEY,
@@ -19869,25 +19869,25 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_sign_ctx"]
     pub fn X509_CRL_sign_ctx(crl: *mut X509_CRL, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_CRL_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_CRL_tbs"]
     pub fn i2d_re_X509_CRL_tbs(
         crl: *mut X509_CRL,
         outp: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_algo"]
     pub fn X509_CRL_set1_signature_algo(
         crl: *mut X509_CRL,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_set1_signature_value"]
     pub fn X509_CRL_set1_signature_value(
         crl: *mut X509_CRL,
         sig: *const u8,
@@ -19895,26 +19895,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_http_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_http_nbio"]
     pub fn X509_CRL_http_nbio(
         rctx: *mut OCSP_REQ_CTX,
         pcrl: *mut *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_it"]
     pub static X509_REVOKED_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_new"]
     pub fn X509_REVOKED_new() -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_free"]
     pub fn X509_REVOKED_free(rev: *mut X509_REVOKED);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REVOKED"]
     pub fn d2i_X509_REVOKED(
         out: *mut *mut X509_REVOKED,
         inp: *mut *const u8,
@@ -19922,45 +19922,45 @@ extern "C" {
     ) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REVOKED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REVOKED"]
     pub fn i2d_X509_REVOKED(alg: *const X509_REVOKED, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_dup"]
     pub fn X509_REVOKED_dup(rev: *const X509_REVOKED) -> *mut X509_REVOKED;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_serialNumber"]
     pub fn X509_REVOKED_get0_serialNumber(revoked: *const X509_REVOKED) -> *const ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_serialNumber"]
     pub fn X509_REVOKED_set_serialNumber(
         revoked: *mut X509_REVOKED,
         serial: *const ASN1_INTEGER,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_revocationDate"]
     pub fn X509_REVOKED_get0_revocationDate(revoked: *const X509_REVOKED) -> *const ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_set_revocationDate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_set_revocationDate"]
     pub fn X509_REVOKED_set_revocationDate(
         revoked: *mut X509_REVOKED,
         tm: *const ASN1_TIME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get0_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get0_extensions"]
     pub fn X509_REVOKED_get0_extensions(r: *const X509_REVOKED) -> *const stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_count"]
     pub fn X509_REVOKED_get_ext_count(x: *const X509_REVOKED) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_NID"]
     pub fn X509_REVOKED_get_ext_by_NID(
         x: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -19968,7 +19968,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_OBJ"]
     pub fn X509_REVOKED_get_ext_by_OBJ(
         x: *const X509_REVOKED,
         obj: *const ASN1_OBJECT,
@@ -19976,7 +19976,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_by_critical"]
     pub fn X509_REVOKED_get_ext_by_critical(
         x: *const X509_REVOKED,
         crit: ::std::os::raw::c_int,
@@ -19984,21 +19984,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext"]
     pub fn X509_REVOKED_get_ext(
         x: *const X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_delete_ext"]
     pub fn X509_REVOKED_delete_ext(
         x: *mut X509_REVOKED,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add_ext"]
     pub fn X509_REVOKED_add_ext(
         x: *mut X509_REVOKED,
         ex: *const X509_EXTENSION,
@@ -20006,7 +20006,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_get_ext_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_get_ext_d2i"]
     pub fn X509_REVOKED_get_ext_d2i(
         revoked: *const X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20015,7 +20015,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REVOKED_add1_ext_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REVOKED_add1_ext_i2d"]
     pub fn X509_REVOKED_add1_ext_i2d(
         x: *mut X509_REVOKED,
         nid: ::std::os::raw::c_int,
@@ -20025,19 +20025,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_it"]
     pub static X509_REQ_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_dup"]
     pub fn X509_REQ_dup(req: *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_free"]
     pub fn X509_REQ_free(req: *mut X509_REQ);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ"]
     pub fn d2i_X509_REQ(
         out: *mut *mut X509_REQ,
         inp: *mut *const u8,
@@ -20045,45 +20045,45 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ"]
     pub fn i2d_X509_REQ(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_version"]
     pub fn X509_REQ_get_version(req: *const X509_REQ) -> ::std::os::raw::c_long;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_subject_name"]
     pub fn X509_REQ_get_subject_name(req: *const X509_REQ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_pubkey"]
     pub fn X509_REQ_get0_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_pubkey"]
     pub fn X509_REQ_get_pubkey(req: *const X509_REQ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_check_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_check_private_key"]
     pub fn X509_REQ_check_private_key(
         req: *const X509_REQ,
         pkey: *const EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_count"]
     pub fn X509_REQ_get_attr_count(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr"]
     pub fn X509_REQ_get_attr(
         req: *const X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_NID"]
     pub fn X509_REQ_get_attr_by_NID(
         req: *const X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20091,7 +20091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_attr_by_OBJ"]
     pub fn X509_REQ_get_attr_by_OBJ(
         req: *const X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20099,15 +20099,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_extension_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_extension_nid"]
     pub fn X509_REQ_extension_nid(nid: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_extensions"]
     pub fn X509_REQ_get_extensions(req: *const X509_REQ) -> *mut stack_st_X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get0_signature"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get0_signature"]
     pub fn X509_REQ_get0_signature(
         req: *const X509_REQ,
         out_sig: *mut *const ASN1_BIT_STRING,
@@ -20115,55 +20115,55 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get_signature_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get_signature_nid"]
     pub fn X509_REQ_get_signature_nid(req: *const X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_verify"]
     pub fn X509_REQ_verify(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_get1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_get1_email"]
     pub fn X509_REQ_get1_email(req: *const X509_REQ) -> *mut stack_st_OPENSSL_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_new"]
     pub fn X509_REQ_new() -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_version"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_version"]
     pub fn X509_REQ_set_version(
         req: *mut X509_REQ,
         version: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_subject_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_subject_name"]
     pub fn X509_REQ_set_subject_name(
         req: *mut X509_REQ,
         name: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set_pubkey"]
     pub fn X509_REQ_set_pubkey(req: *mut X509_REQ, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_delete_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_delete_attr"]
     pub fn X509_REQ_delete_attr(
         req: *mut X509_REQ,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr"]
     pub fn X509_REQ_add1_attr(
         req: *mut X509_REQ,
         attr: *const X509_ATTRIBUTE,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_OBJ"]
     pub fn X509_REQ_add1_attr_by_OBJ(
         req: *mut X509_REQ,
         obj: *const ASN1_OBJECT,
@@ -20173,7 +20173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_NID"]
     pub fn X509_REQ_add1_attr_by_NID(
         req: *mut X509_REQ,
         nid: ::std::os::raw::c_int,
@@ -20183,7 +20183,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add1_attr_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add1_attr_by_txt"]
     pub fn X509_REQ_add1_attr_by_txt(
         req: *mut X509_REQ,
         attrname: *const ::std::os::raw::c_char,
@@ -20193,7 +20193,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions_nid"]
     pub fn X509_REQ_add_extensions_nid(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
@@ -20201,14 +20201,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_add_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_add_extensions"]
     pub fn X509_REQ_add_extensions(
         req: *mut X509_REQ,
         exts: *const stack_st_X509_EXTENSION,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign"]
     pub fn X509_REQ_sign(
         req: *mut X509_REQ,
         pkey: *mut EVP_PKEY,
@@ -20216,22 +20216,22 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_sign_ctx"]
     pub fn X509_REQ_sign_ctx(req: *mut X509_REQ, ctx: *mut EVP_MD_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_re_X509_REQ_tbs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_re_X509_REQ_tbs"]
     pub fn i2d_re_X509_REQ_tbs(req: *mut X509_REQ, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_algo"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_algo"]
     pub fn X509_REQ_set1_signature_algo(
         req: *mut X509_REQ,
         algo: *const X509_ALGOR,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_set1_signature_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_set1_signature_value"]
     pub fn X509_REQ_set1_signature_value(
         req: *mut X509_REQ,
         sig: *const u8,
@@ -20281,19 +20281,19 @@ pub type sk_X509_NAME_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_it"]
     pub static X509_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_new"]
     pub fn X509_NAME_new() -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_free"]
     pub fn X509_NAME_free(name: *mut X509_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME"]
     pub fn d2i_X509_NAME(
         out: *mut *mut X509_NAME,
         inp: *mut *const u8,
@@ -20301,19 +20301,19 @@ extern "C" {
     ) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME"]
     pub fn i2d_X509_NAME(in_: *mut X509_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_dup"]
     pub fn X509_NAME_dup(name: *mut X509_NAME) -> *mut X509_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_cmp"]
     pub fn X509_NAME_cmp(a: *const X509_NAME, b: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get0_der"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get0_der"]
     pub fn X509_NAME_get0_der(
         name: *mut X509_NAME,
         out_der: *mut *const u8,
@@ -20321,15 +20321,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_set"]
     pub fn X509_NAME_set(xn: *mut *mut X509_NAME, name: *mut X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_entry_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_entry_count"]
     pub fn X509_NAME_entry_count(name: *const X509_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_NID"]
     pub fn X509_NAME_get_index_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20337,7 +20337,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_index_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_index_by_OBJ"]
     pub fn X509_NAME_get_index_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20345,21 +20345,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_entry"]
     pub fn X509_NAME_get_entry(
         name: *const X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_delete_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_delete_entry"]
     pub fn X509_NAME_delete_entry(
         name: *mut X509_NAME,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry"]
     pub fn X509_NAME_add_entry(
         name: *mut X509_NAME,
         entry: *const X509_NAME_ENTRY,
@@ -20368,7 +20368,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_OBJ"]
     pub fn X509_NAME_add_entry_by_OBJ(
         name: *mut X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -20380,7 +20380,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_NID"]
     pub fn X509_NAME_add_entry_by_NID(
         name: *mut X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -20392,7 +20392,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_add_entry_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_add_entry_by_txt"]
     pub fn X509_NAME_add_entry_by_txt(
         name: *mut X509_NAME,
         field: *const ::std::os::raw::c_char,
@@ -20404,19 +20404,19 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_it"]
     pub static X509_NAME_ENTRY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_new"]
     pub fn X509_NAME_ENTRY_new() -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_free"]
     pub fn X509_NAME_ENTRY_free(entry: *mut X509_NAME_ENTRY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_NAME_ENTRY"]
     pub fn d2i_X509_NAME_ENTRY(
         out: *mut *mut X509_NAME_ENTRY,
         inp: *mut *const u8,
@@ -20424,33 +20424,33 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_NAME_ENTRY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_NAME_ENTRY"]
     pub fn i2d_X509_NAME_ENTRY(
         in_: *const X509_NAME_ENTRY,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_dup"]
     pub fn X509_NAME_ENTRY_dup(entry: *const X509_NAME_ENTRY) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_object"]
     pub fn X509_NAME_ENTRY_get_object(entry: *const X509_NAME_ENTRY) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_object"]
     pub fn X509_NAME_ENTRY_set_object(
         entry: *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_get_data"]
     pub fn X509_NAME_ENTRY_get_data(entry: *const X509_NAME_ENTRY) -> *mut ASN1_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set_data"]
     pub fn X509_NAME_ENTRY_set_data(
         entry: *mut X509_NAME_ENTRY,
         type_: ::std::os::raw::c_int,
@@ -20459,11 +20459,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_set"]
     pub fn X509_NAME_ENTRY_set(entry: *const X509_NAME_ENTRY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_OBJ"]
     pub fn X509_NAME_ENTRY_create_by_OBJ(
         out: *mut *mut X509_NAME_ENTRY,
         obj: *const ASN1_OBJECT,
@@ -20473,7 +20473,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_NID"]
     pub fn X509_NAME_ENTRY_create_by_NID(
         out: *mut *mut X509_NAME_ENTRY,
         nid: ::std::os::raw::c_int,
@@ -20483,7 +20483,7 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_ENTRY_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_ENTRY_create_by_txt"]
     pub fn X509_NAME_ENTRY_create_by_txt(
         out: *mut *mut X509_NAME_ENTRY,
         field: *const ::std::os::raw::c_char,
@@ -20493,19 +20493,19 @@ extern "C" {
     ) -> *mut X509_NAME_ENTRY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_it"]
     pub static X509_PUBKEY_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_new"]
     pub fn X509_PUBKEY_new() -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_free"]
     pub fn X509_PUBKEY_free(key: *mut X509_PUBKEY);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_PUBKEY"]
     pub fn d2i_X509_PUBKEY(
         out: *mut *mut X509_PUBKEY,
         inp: *mut *const u8,
@@ -20513,23 +20513,23 @@ extern "C" {
     ) -> *mut X509_PUBKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_PUBKEY"]
     pub fn i2d_X509_PUBKEY(key: *const X509_PUBKEY, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set"]
     pub fn X509_PUBKEY_set(x: *mut *mut X509_PUBKEY, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0"]
     pub fn X509_PUBKEY_get0(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get"]
     pub fn X509_PUBKEY_get(key: *const X509_PUBKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_set0_param"]
     pub fn X509_PUBKEY_set0_param(
         pub_: *mut X509_PUBKEY,
         obj: *mut ASN1_OBJECT,
@@ -20540,7 +20540,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_param"]
     pub fn X509_PUBKEY_get0_param(
         out_obj: *mut *mut ASN1_OBJECT,
         out_key: *mut *const u8,
@@ -20550,23 +20550,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PUBKEY_get0_public_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PUBKEY_get0_public_key"]
     pub fn X509_PUBKEY_get0_public_key(pub_: *const X509_PUBKEY) -> *const ASN1_BIT_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_it"]
     pub static X509_EXTENSION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_new"]
     pub fn X509_EXTENSION_new() -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_free"]
     pub fn X509_EXTENSION_free(ex: *mut X509_EXTENSION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSION"]
     pub fn d2i_X509_EXTENSION(
         out: *mut *mut X509_EXTENSION,
         inp: *mut *const u8,
@@ -20574,18 +20574,18 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSION"]
     pub fn i2d_X509_EXTENSION(
         ex: *const X509_EXTENSION,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_dup"]
     pub fn X509_EXTENSION_dup(ex: *const X509_EXTENSION) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_NID"]
     pub fn X509_EXTENSION_create_by_NID(
         ex: *mut *mut X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20594,7 +20594,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_create_by_OBJ"]
     pub fn X509_EXTENSION_create_by_OBJ(
         ex: *mut *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20603,33 +20603,33 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_object"]
     pub fn X509_EXTENSION_get_object(ex: *const X509_EXTENSION) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_data"]
     pub fn X509_EXTENSION_get_data(ne: *const X509_EXTENSION) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_get_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_get_critical"]
     pub fn X509_EXTENSION_get_critical(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_object"]
     pub fn X509_EXTENSION_set_object(
         ex: *mut X509_EXTENSION,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_critical"]
     pub fn X509_EXTENSION_set_critical(
         ex: *mut X509_EXTENSION,
         crit: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSION_set_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSION_set_data"]
     pub fn X509_EXTENSION_set_data(
         ex: *mut X509_EXTENSION,
         data: *const ASN1_OCTET_STRING,
@@ -20653,11 +20653,11 @@ pub type sk_X509_EXTENSION_delete_if_func = ::std::option::Option<
 >;
 pub type X509_EXTENSIONS = stack_st_X509_EXTENSION;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_EXTENSIONS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_EXTENSIONS_it"]
     pub static X509_EXTENSIONS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_EXTENSIONS"]
     pub fn d2i_X509_EXTENSIONS(
         out: *mut *mut X509_EXTENSIONS,
         inp: *mut *const u8,
@@ -20665,18 +20665,18 @@ extern "C" {
     ) -> *mut X509_EXTENSIONS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_EXTENSIONS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_EXTENSIONS"]
     pub fn i2d_X509_EXTENSIONS(
         alg: *const X509_EXTENSIONS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_count"]
     pub fn X509v3_get_ext_count(x: *const stack_st_X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_NID"]
     pub fn X509v3_get_ext_by_NID(
         x: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -20684,7 +20684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_OBJ"]
     pub fn X509v3_get_ext_by_OBJ(
         x: *const stack_st_X509_EXTENSION,
         obj: *const ASN1_OBJECT,
@@ -20692,7 +20692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext_by_critical"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext_by_critical"]
     pub fn X509v3_get_ext_by_critical(
         x: *const stack_st_X509_EXTENSION,
         crit: ::std::os::raw::c_int,
@@ -20700,21 +20700,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_get_ext"]
     pub fn X509v3_get_ext(
         x: *const stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_delete_ext"]
     pub fn X509v3_delete_ext(
         x: *mut stack_st_X509_EXTENSION,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509v3_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509v3_add_ext"]
     pub fn X509v3_add_ext(
         x: *mut *mut stack_st_X509_EXTENSION,
         ex: *const X509_EXTENSION,
@@ -21057,15 +21057,15 @@ impl Default for GENERAL_NAME_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_new"]
     pub fn GENERAL_NAME_new() -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_free"]
     pub fn GENERAL_NAME_free(gen: *mut GENERAL_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAME"]
     pub fn d2i_GENERAL_NAME(
         out: *mut *mut GENERAL_NAME,
         inp: *mut *const u8,
@@ -21073,23 +21073,23 @@ extern "C" {
     ) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAME"]
     pub fn i2d_GENERAL_NAME(in_: *mut GENERAL_NAME, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_dup"]
     pub fn GENERAL_NAME_dup(gen: *mut GENERAL_NAME) -> *mut GENERAL_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_new"]
     pub fn GENERAL_NAMES_new() -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAMES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAMES_free"]
     pub fn GENERAL_NAMES_free(gens: *mut GENERAL_NAMES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_GENERAL_NAMES"]
     pub fn d2i_GENERAL_NAMES(
         out: *mut *mut GENERAL_NAMES,
         inp: *mut *const u8,
@@ -21097,27 +21097,27 @@ extern "C" {
     ) -> *mut GENERAL_NAMES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_GENERAL_NAMES"]
     pub fn i2d_GENERAL_NAMES(in_: *mut GENERAL_NAMES, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_new"]
     pub fn OTHERNAME_new() -> *mut OTHERNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OTHERNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OTHERNAME_free"]
     pub fn OTHERNAME_free(name: *mut OTHERNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_new"]
     pub fn EDIPARTYNAME_new() -> *mut EDIPARTYNAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EDIPARTYNAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EDIPARTYNAME_free"]
     pub fn EDIPARTYNAME_free(name: *mut EDIPARTYNAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_value"]
     pub fn GENERAL_NAME_set0_value(
         gen: *mut GENERAL_NAME,
         type_: ::std::os::raw::c_int,
@@ -21125,14 +21125,14 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_value"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_value"]
     pub fn GENERAL_NAME_get0_value(
         gen: *const GENERAL_NAME,
         out_type: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_set0_othername"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_set0_othername"]
     pub fn GENERAL_NAME_set0_othername(
         gen: *mut GENERAL_NAME,
         oid: *mut ASN1_OBJECT,
@@ -21140,7 +21140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_get0_otherName"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_get0_otherName"]
     pub fn GENERAL_NAME_get0_otherName(
         gen: *const GENERAL_NAME,
         out_oid: *mut *mut ASN1_OBJECT,
@@ -21169,23 +21169,23 @@ pub type sk_X509_ALGOR_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_it"]
     pub static X509_ALGOR_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_new"]
     pub fn X509_ALGOR_new() -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_dup"]
     pub fn X509_ALGOR_dup(alg: *const X509_ALGOR) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_free"]
     pub fn X509_ALGOR_free(alg: *mut X509_ALGOR);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ALGOR"]
     pub fn d2i_X509_ALGOR(
         out: *mut *mut X509_ALGOR,
         inp: *mut *const u8,
@@ -21193,11 +21193,11 @@ extern "C" {
     ) -> *mut X509_ALGOR;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ALGOR"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ALGOR"]
     pub fn i2d_X509_ALGOR(alg: *const X509_ALGOR, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set0"]
     pub fn X509_ALGOR_set0(
         alg: *mut X509_ALGOR,
         obj: *mut ASN1_OBJECT,
@@ -21206,7 +21206,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_get0"]
     pub fn X509_ALGOR_get0(
         out_obj: *mut *const ASN1_OBJECT,
         out_param_type: *mut ::std::os::raw::c_int,
@@ -21215,11 +21215,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_set_md"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_set_md"]
     pub fn X509_ALGOR_set_md(alg: *mut X509_ALGOR, md: *const EVP_MD);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ALGOR_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ALGOR_cmp"]
     pub fn X509_ALGOR_cmp(a: *const X509_ALGOR, b: *const X509_ALGOR) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21244,23 +21244,23 @@ pub type sk_X509_ATTRIBUTE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_it"]
     pub static X509_ATTRIBUTE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_new"]
     pub fn X509_ATTRIBUTE_new() -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_dup"]
     pub fn X509_ATTRIBUTE_dup(attr: *const X509_ATTRIBUTE) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_free"]
     pub fn X509_ATTRIBUTE_free(attr: *mut X509_ATTRIBUTE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_ATTRIBUTE"]
     pub fn d2i_X509_ATTRIBUTE(
         out: *mut *mut X509_ATTRIBUTE,
         inp: *mut *const u8,
@@ -21268,14 +21268,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_ATTRIBUTE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_ATTRIBUTE"]
     pub fn i2d_X509_ATTRIBUTE(
         alg: *const X509_ATTRIBUTE,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create"]
     pub fn X509_ATTRIBUTE_create(
         nid: ::std::os::raw::c_int,
         attrtype: ::std::os::raw::c_int,
@@ -21283,7 +21283,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_NID"]
     pub fn X509_ATTRIBUTE_create_by_NID(
         attr: *mut *mut X509_ATTRIBUTE,
         nid: ::std::os::raw::c_int,
@@ -21293,7 +21293,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_OBJ"]
     pub fn X509_ATTRIBUTE_create_by_OBJ(
         attr: *mut *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
@@ -21303,7 +21303,7 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_create_by_txt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_create_by_txt"]
     pub fn X509_ATTRIBUTE_create_by_txt(
         attr: *mut *mut X509_ATTRIBUTE,
         attrname: *const ::std::os::raw::c_char,
@@ -21313,14 +21313,14 @@ extern "C" {
     ) -> *mut X509_ATTRIBUTE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_object"]
     pub fn X509_ATTRIBUTE_set1_object(
         attr: *mut X509_ATTRIBUTE,
         obj: *const ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_set1_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_set1_data"]
     pub fn X509_ATTRIBUTE_set1_data(
         attr: *mut X509_ATTRIBUTE,
         attrtype: ::std::os::raw::c_int,
@@ -21329,7 +21329,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_data"]
     pub fn X509_ATTRIBUTE_get0_data(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
@@ -21338,89 +21338,89 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_count"]
     pub fn X509_ATTRIBUTE_count(attr: *const X509_ATTRIBUTE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_object"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_object"]
     pub fn X509_ATTRIBUTE_get0_object(attr: *mut X509_ATTRIBUTE) -> *mut ASN1_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_ATTRIBUTE_get0_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_ATTRIBUTE_get0_type"]
     pub fn X509_ATTRIBUTE_get0_type(
         attr: *mut X509_ATTRIBUTE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ASN1_TYPE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_new"]
     pub fn X509_STORE_new() -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_up_ref"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_up_ref"]
     pub fn X509_STORE_up_ref(store: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_free"]
     pub fn X509_STORE_free(store: *mut X509_STORE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_cert"]
     pub fn X509_STORE_add_cert(store: *mut X509_STORE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_crl"]
     pub fn X509_STORE_add_crl(store: *mut X509_STORE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_param"]
     pub fn X509_STORE_get0_param(store: *mut X509_STORE) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set1_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set1_param"]
     pub fn X509_STORE_set1_param(
         store: *mut X509_STORE,
         param: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_flags"]
     pub fn X509_STORE_set_flags(
         store: *mut X509_STORE,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_depth"]
     pub fn X509_STORE_set_depth(
         store: *mut X509_STORE,
         depth: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_purpose"]
     pub fn X509_STORE_set_purpose(
         store: *mut X509_STORE,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_trust"]
     pub fn X509_STORE_set_trust(
         store: *mut X509_STORE,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_new"]
     pub fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_free"]
     pub fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_init"]
     pub fn X509_STORE_CTX_init(
         ctx: *mut X509_STORE_CTX,
         store: *mut X509_STORE,
@@ -21429,92 +21429,92 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert"]
     pub fn X509_verify_cert(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_chain"]
     pub fn X509_STORE_CTX_get0_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_chain"]
     pub fn X509_STORE_CTX_get1_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_cert"]
     pub fn X509_STORE_CTX_set_cert(c: *mut X509_STORE_CTX, x: *mut X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error"]
     pub fn X509_STORE_CTX_get_error(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_error"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_error"]
     pub fn X509_STORE_CTX_set_error(ctx: *mut X509_STORE_CTX, err: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_verify_cert_error_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_verify_cert_error_string"]
     pub fn X509_verify_cert_error_string(
         err: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_error_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_error_depth"]
     pub fn X509_STORE_CTX_get_error_depth(ctx: *mut X509_STORE_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_current_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_current_cert"]
     pub fn X509_STORE_CTX_get_current_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_issuer"]
     pub fn X509_STORE_CTX_get0_current_issuer(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_current_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_current_crl"]
     pub fn X509_STORE_CTX_get0_current_crl(ctx: *mut X509_STORE_CTX) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_store"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_store"]
     pub fn X509_STORE_CTX_get0_store(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_cert"]
     pub fn X509_STORE_CTX_get0_cert(ctx: *mut X509_STORE_CTX) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_untrusted"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_untrusted"]
     pub fn X509_STORE_CTX_get0_untrusted(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_trusted_stack"]
     pub fn X509_STORE_CTX_set0_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_crls"]
     pub fn X509_STORE_CTX_set0_crls(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509_CRL);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_default"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_default"]
     pub fn X509_STORE_CTX_set_default(
         ctx: *mut X509_STORE_CTX,
         name: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_param"]
     pub fn X509_STORE_CTX_get0_param(ctx: *mut X509_STORE_CTX) -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set0_param"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set0_param"]
     pub fn X509_STORE_CTX_set0_param(ctx: *mut X509_STORE_CTX, param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_flags"]
     pub fn X509_STORE_CTX_set_flags(ctx: *mut X509_STORE_CTX, flags: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time"]
     pub fn X509_STORE_CTX_set_time(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21522,7 +21522,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_time_posix"]
     pub fn X509_STORE_CTX_set_time_posix(
         ctx: *mut X509_STORE_CTX,
         flags: ::std::os::raw::c_ulong,
@@ -21530,95 +21530,95 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_depth"]
     pub fn X509_STORE_CTX_set_depth(ctx: *mut X509_STORE_CTX, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_purpose"]
     pub fn X509_STORE_CTX_set_purpose(
         ctx: *mut X509_STORE_CTX,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_trust"]
     pub fn X509_STORE_CTX_set_trust(
         ctx: *mut X509_STORE_CTX,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_new"]
     pub fn X509_VERIFY_PARAM_new() -> *mut X509_VERIFY_PARAM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_free"]
     pub fn X509_VERIFY_PARAM_free(param: *mut X509_VERIFY_PARAM);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_inherit"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_inherit"]
     pub fn X509_VERIFY_PARAM_inherit(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1"]
     pub fn X509_VERIFY_PARAM_set1(
         to: *mut X509_VERIFY_PARAM,
         from: *const X509_VERIFY_PARAM,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_flags"]
     pub fn X509_VERIFY_PARAM_set_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_clear_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_clear_flags"]
     pub fn X509_VERIFY_PARAM_clear_flags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_flags"]
     pub fn X509_VERIFY_PARAM_get_flags(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_depth"]
     pub fn X509_VERIFY_PARAM_set_depth(param: *mut X509_VERIFY_PARAM, depth: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_get_depth"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_get_depth"]
     pub fn X509_VERIFY_PARAM_get_depth(param: *const X509_VERIFY_PARAM) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time"]
     pub fn X509_VERIFY_PARAM_set_time(param: *mut X509_VERIFY_PARAM, t: time_t);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_time_posix"]
     pub fn X509_VERIFY_PARAM_set_time_posix(param: *mut X509_VERIFY_PARAM, t: i64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add0_policy"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add0_policy"]
     pub fn X509_VERIFY_PARAM_add0_policy(
         param: *mut X509_VERIFY_PARAM,
         policy: *mut ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_policies"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_policies"]
     pub fn X509_VERIFY_PARAM_set1_policies(
         param: *mut X509_VERIFY_PARAM,
         policies: *const stack_st_ASN1_OBJECT,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_host"]
     pub fn X509_VERIFY_PARAM_set1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21626,7 +21626,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_add1_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_add1_host"]
     pub fn X509_VERIFY_PARAM_add1_host(
         param: *mut X509_VERIFY_PARAM,
         name: *const ::std::os::raw::c_char,
@@ -21634,14 +21634,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_hostflags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_hostflags"]
     pub fn X509_VERIFY_PARAM_set_hostflags(
         param: *mut X509_VERIFY_PARAM,
         flags: ::std::os::raw::c_uint,
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_email"]
     pub fn X509_VERIFY_PARAM_set1_email(
         param: *mut X509_VERIFY_PARAM,
         email: *const ::std::os::raw::c_char,
@@ -21649,7 +21649,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip"]
     pub fn X509_VERIFY_PARAM_set1_ip(
         param: *mut X509_VERIFY_PARAM,
         ip: *const u8,
@@ -21657,21 +21657,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set1_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set1_ip_asc"]
     pub fn X509_VERIFY_PARAM_set1_ip_asc(
         param: *mut X509_VERIFY_PARAM,
         ipasc: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_purpose"]
     pub fn X509_VERIFY_PARAM_set_purpose(
         param: *mut X509_VERIFY_PARAM,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_VERIFY_PARAM_set_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_VERIFY_PARAM_set_trust"]
     pub fn X509_VERIFY_PARAM_set_trust(
         param: *mut X509_VERIFY_PARAM,
         trust: ::std::os::raw::c_int,
@@ -21739,19 +21739,19 @@ impl Default for Netscape_spki_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_it"]
     pub static NETSCAPE_SPKI_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_new"]
     pub fn NETSCAPE_SPKI_new() -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_free"]
     pub fn NETSCAPE_SPKI_free(spki: *mut NETSCAPE_SPKI);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKI"]
     pub fn d2i_NETSCAPE_SPKI(
         out: *mut *mut NETSCAPE_SPKI,
         inp: *mut *const u8,
@@ -21759,43 +21759,43 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKI"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKI"]
     pub fn i2d_NETSCAPE_SPKI(
         spki: *const NETSCAPE_SPKI,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_verify"]
     pub fn NETSCAPE_SPKI_verify(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_decode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_decode"]
     pub fn NETSCAPE_SPKI_b64_decode(
         str_: *const ::std::os::raw::c_char,
         len: ossl_ssize_t,
     ) -> *mut NETSCAPE_SPKI;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_b64_encode"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_b64_encode"]
     pub fn NETSCAPE_SPKI_b64_encode(spki: *mut NETSCAPE_SPKI) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_get_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_get_pubkey"]
     pub fn NETSCAPE_SPKI_get_pubkey(spki: *const NETSCAPE_SPKI) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_set_pubkey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_set_pubkey"]
     pub fn NETSCAPE_SPKI_set_pubkey(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_sign"]
     pub fn NETSCAPE_SPKI_sign(
         spki: *mut NETSCAPE_SPKI,
         pkey: *mut EVP_PKEY,
@@ -21853,19 +21853,19 @@ impl Default for Netscape_spkac_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_it"]
     pub static NETSCAPE_SPKAC_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_new"]
     pub fn NETSCAPE_SPKAC_new() -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKAC_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKAC_free"]
     pub fn NETSCAPE_SPKAC_free(spkac: *mut NETSCAPE_SPKAC);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NETSCAPE_SPKAC"]
     pub fn d2i_NETSCAPE_SPKAC(
         out: *mut *mut NETSCAPE_SPKAC,
         inp: *mut *const u8,
@@ -21873,14 +21873,14 @@ extern "C" {
     ) -> *mut NETSCAPE_SPKAC;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NETSCAPE_SPKAC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NETSCAPE_SPKAC"]
     pub fn i2d_NETSCAPE_SPKAC(
         spkac: *const NETSCAPE_SPKAC,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NETSCAPE_SPKI_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NETSCAPE_SPKI_print"]
     pub fn NETSCAPE_SPKI_print(out: *mut BIO, spki: *mut NETSCAPE_SPKI) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -21967,19 +21967,19 @@ impl Default for rsa_pss_params_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_it"]
     pub static RSA_PSS_PARAMS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_new"]
     pub fn RSA_PSS_PARAMS_new() -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RSA_PSS_PARAMS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RSA_PSS_PARAMS_free"]
     pub fn RSA_PSS_PARAMS_free(params: *mut RSA_PSS_PARAMS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PSS_PARAMS"]
     pub fn d2i_RSA_PSS_PARAMS(
         out: *mut *mut RSA_PSS_PARAMS,
         inp: *mut *const u8,
@@ -21987,26 +21987,26 @@ extern "C" {
     ) -> *mut RSA_PSS_PARAMS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PSS_PARAMS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PSS_PARAMS"]
     pub fn i2d_RSA_PSS_PARAMS(
         in_: *const RSA_PSS_PARAMS,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_it"]
     pub static PKCS8_PRIV_KEY_INFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_new"]
     pub fn PKCS8_PRIV_KEY_INFO_new() -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_PRIV_KEY_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_PRIV_KEY_INFO_free"]
     pub fn PKCS8_PRIV_KEY_INFO_free(key: *mut PKCS8_PRIV_KEY_INFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO(
         out: *mut *mut PKCS8_PRIV_KEY_INFO,
         inp: *mut *const u8,
@@ -22014,34 +22014,34 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO(
         key: *const PKCS8_PRIV_KEY_INFO,
         outp: *mut *mut u8,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKCS82PKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKCS82PKEY"]
     pub fn EVP_PKCS82PKEY(p8: *const PKCS8_PRIV_KEY_INFO) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY2PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY2PKCS8"]
     pub fn EVP_PKEY2PKCS8(pkey: *const EVP_PKEY) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_it"]
     pub static X509_SIG_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_new"]
     pub fn X509_SIG_new() -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_free"]
     pub fn X509_SIG_free(key: *mut X509_SIG);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_SIG"]
     pub fn d2i_X509_SIG(
         out: *mut *mut X509_SIG,
         inp: *mut *const u8,
@@ -22049,11 +22049,11 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_SIG"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_SIG"]
     pub fn i2d_X509_SIG(sig: *const X509_SIG, outp: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_get0"]
     pub fn X509_SIG_get0(
         sig: *const X509_SIG,
         out_alg: *mut *const X509_ALGOR,
@@ -22061,7 +22061,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_SIG_getm"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_SIG_getm"]
     pub fn X509_SIG_getm(
         sig: *mut X509_SIG,
         out_alg: *mut *mut X509_ALGOR,
@@ -22069,7 +22069,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex"]
     pub fn X509_print_ex(
         bp: *mut BIO,
         x: *mut X509,
@@ -22078,7 +22078,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_ex_fp"]
     pub fn X509_print_ex_fp(
         fp: *mut FILE,
         x: *mut X509,
@@ -22087,23 +22087,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print"]
     pub fn X509_print(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_print_fp"]
     pub fn X509_print_fp(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print"]
     pub fn X509_CRL_print(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_print_fp"]
     pub fn X509_CRL_print_fp(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_ex"]
     pub fn X509_REQ_print_ex(
         bp: *mut BIO,
         x: *mut X509_REQ,
@@ -22112,15 +22112,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print"]
     pub fn X509_REQ_print(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_print_fp"]
     pub fn X509_REQ_print_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex"]
     pub fn X509_NAME_print_ex(
         out: *mut BIO,
         nm: *const X509_NAME,
@@ -22129,7 +22129,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print"]
     pub fn X509_NAME_print(
         bp: *mut BIO,
         name: *const X509_NAME,
@@ -22137,7 +22137,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_oneline"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_oneline"]
     pub fn X509_NAME_oneline(
         name: *const X509_NAME,
         buf: *mut ::std::os::raw::c_char,
@@ -22145,7 +22145,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_print_ex_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_print_ex_fp"]
     pub fn X509_NAME_print_ex_fp(
         fp: *mut FILE,
         nm: *const X509_NAME,
@@ -22154,7 +22154,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_dump"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_dump"]
     pub fn X509_signature_dump(
         bio: *mut BIO,
         sig: *const ASN1_STRING,
@@ -22162,7 +22162,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_signature_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_signature_print"]
     pub fn X509_signature_print(
         bio: *mut BIO,
         alg: *const X509_ALGOR,
@@ -22170,7 +22170,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print"]
     pub fn X509V3_EXT_print(
         out: *mut BIO,
         ext: *const X509_EXTENSION,
@@ -22179,7 +22179,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_print_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_print_fp"]
     pub fn X509V3_EXT_print_fp(
         out: *mut FILE,
         ext: *const X509_EXTENSION,
@@ -22188,7 +22188,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_extensions_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_extensions_print"]
     pub fn X509V3_extensions_print(
         out: *mut BIO,
         title: *const ::std::os::raw::c_char,
@@ -22198,11 +22198,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_NAME_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_NAME_print"]
     pub fn GENERAL_NAME_print(out: *mut BIO, gen: *const GENERAL_NAME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_pubkey_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_pubkey_digest"]
     pub fn X509_pubkey_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22211,7 +22211,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_digest"]
     pub fn X509_digest(
         x509: *const X509,
         md: *const EVP_MD,
@@ -22220,7 +22220,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_digest"]
     pub fn X509_CRL_digest(
         crl: *const X509_CRL,
         md: *const EVP_MD,
@@ -22229,7 +22229,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_REQ_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_REQ_digest"]
     pub fn X509_REQ_digest(
         req: *const X509_REQ,
         md: *const EVP_MD,
@@ -22238,7 +22238,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_digest"]
     pub fn X509_NAME_digest(
         name: *const X509_NAME,
         md: *const EVP_MD,
@@ -22247,259 +22247,259 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_bio"]
     pub fn d2i_X509_bio(bp: *mut BIO, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_bio"]
     pub fn d2i_X509_CRL_bio(bp: *mut BIO, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_bio"]
     pub fn d2i_X509_REQ_bio(bp: *mut BIO, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_bio"]
     pub fn d2i_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_bio"]
     pub fn d2i_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_bio"]
     pub fn d2i_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_bio"]
     pub fn d2i_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_bio"]
     pub fn d2i_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_bio"]
     pub fn d2i_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_bio"]
     pub fn d2i_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_bio"]
     pub fn d2i_PKCS8_bio(bp: *mut BIO, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_bio"]
     pub fn d2i_PUBKEY_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DHparams_bio"]
     pub fn d2i_DHparams_bio(bp: *mut BIO, dh: *mut *mut DH) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_bio"]
     pub fn d2i_PrivateKey_bio(bp: *mut BIO, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_bio"]
     pub fn i2d_X509_bio(bp: *mut BIO, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_bio"]
     pub fn i2d_X509_CRL_bio(bp: *mut BIO, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_bio"]
     pub fn i2d_X509_REQ_bio(bp: *mut BIO, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_bio"]
     pub fn i2d_RSAPrivateKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_bio"]
     pub fn i2d_RSAPublicKey_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_bio"]
     pub fn i2d_RSA_PUBKEY_bio(bp: *mut BIO, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_bio"]
     pub fn i2d_DSA_PUBKEY_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_bio"]
     pub fn i2d_DSAPrivateKey_bio(bp: *mut BIO, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_bio"]
     pub fn i2d_EC_PUBKEY_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_bio"]
     pub fn i2d_ECPrivateKey_bio(bp: *mut BIO, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_bio"]
     pub fn i2d_PKCS8_bio(bp: *mut BIO, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_bio"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_bio(
         bp: *mut BIO,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_bio"]
     pub fn i2d_PrivateKey_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_bio"]
     pub fn i2d_PUBKEY_bio(bp: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DHparams_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DHparams_bio"]
     pub fn i2d_DHparams_bio(bp: *mut BIO, dh: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_bio"]
     pub fn i2d_PKCS8PrivateKeyInfo_bio(bp: *mut BIO, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_fp"]
     pub fn d2i_X509_fp(fp: *mut FILE, x509: *mut *mut X509) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_CRL_fp"]
     pub fn d2i_X509_CRL_fp(fp: *mut FILE, crl: *mut *mut X509_CRL) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_X509_REQ_fp"]
     pub fn d2i_X509_REQ_fp(fp: *mut FILE, req: *mut *mut X509_REQ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPrivateKey_fp"]
     pub fn d2i_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSAPublicKey_fp"]
     pub fn d2i_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_RSA_PUBKEY_fp"]
     pub fn d2i_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut *mut RSA) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSA_PUBKEY_fp"]
     pub fn d2i_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DSAPrivateKey_fp"]
     pub fn d2i_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut *mut DSA) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EC_PUBKEY_fp"]
     pub fn d2i_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ECPrivateKey_fp"]
     pub fn d2i_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut *mut EC_KEY) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_fp"]
     pub fn d2i_PKCS8_fp(fp: *mut FILE, p8: *mut *mut X509_SIG) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn d2i_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut *mut PKCS8_PRIV_KEY_INFO,
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PrivateKey_fp"]
     pub fn d2i_PrivateKey_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PUBKEY_fp"]
     pub fn d2i_PUBKEY_fp(fp: *mut FILE, a: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_fp"]
     pub fn i2d_X509_fp(fp: *mut FILE, x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_CRL_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_CRL_fp"]
     pub fn i2d_X509_CRL_fp(fp: *mut FILE, crl: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_X509_REQ_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_X509_REQ_fp"]
     pub fn i2d_X509_REQ_fp(fp: *mut FILE, req: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPrivateKey_fp"]
     pub fn i2d_RSAPrivateKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSAPublicKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSAPublicKey_fp"]
     pub fn i2d_RSAPublicKey_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_RSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_RSA_PUBKEY_fp"]
     pub fn i2d_RSA_PUBKEY_fp(fp: *mut FILE, rsa: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSA_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSA_PUBKEY_fp"]
     pub fn i2d_DSA_PUBKEY_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DSAPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DSAPrivateKey_fp"]
     pub fn i2d_DSAPrivateKey_fp(fp: *mut FILE, dsa: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EC_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EC_PUBKEY_fp"]
     pub fn i2d_EC_PUBKEY_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ECPrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ECPrivateKey_fp"]
     pub fn i2d_ECPrivateKey_fp(fp: *mut FILE, eckey: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_fp"]
     pub fn i2d_PKCS8_fp(fp: *mut FILE, p8: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8_PRIV_KEY_INFO_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8_PRIV_KEY_INFO_fp"]
     pub fn i2d_PKCS8_PRIV_KEY_INFO_fp(
         fp: *mut FILE,
         p8inf: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKeyInfo_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKeyInfo_fp"]
     pub fn i2d_PKCS8PrivateKeyInfo_fp(fp: *mut FILE, key: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PrivateKey_fp"]
     pub fn i2d_PrivateKey_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PUBKEY_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PUBKEY_fp"]
     pub fn i2d_PUBKEY_fp(fp: *mut FILE, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_issuer_and_serial"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_issuer_and_serial"]
     pub fn X509_find_by_issuer_and_serial(
         sk: *const stack_st_X509,
         name: *mut X509_NAME,
@@ -22507,23 +22507,23 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_find_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_find_by_subject"]
     pub fn X509_find_by_subject(sk: *const stack_st_X509, name: *mut X509_NAME) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time"]
     pub fn X509_cmp_time(s: *const ASN1_TIME, t: *const time_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_time_posix"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_time_posix"]
     pub fn X509_cmp_time_posix(s: *const ASN1_TIME, t: i64) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp_current_time"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp_current_time"]
     pub fn X509_cmp_current_time(s: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj"]
     pub fn X509_time_adj(
         s: *mut ASN1_TIME,
         offset_sec: ::std::os::raw::c_long,
@@ -22531,7 +22531,7 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_time_adj_ex"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_time_adj_ex"]
     pub fn X509_time_adj_ex(
         s: *mut ASN1_TIME,
         offset_day: ::std::os::raw::c_int,
@@ -22540,40 +22540,40 @@ extern "C" {
     ) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_gmtime_adj"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_gmtime_adj"]
     pub fn X509_gmtime_adj(s: *mut ASN1_TIME, offset_sec: ::std::os::raw::c_long)
         -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_cmp"]
     pub fn X509_issuer_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_cmp"]
     pub fn X509_subject_name_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_cmp"]
     pub fn X509_CRL_cmp(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash"]
     pub fn X509_issuer_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash"]
     pub fn X509_subject_name_hash(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_issuer_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_issuer_name_hash_old"]
     pub fn X509_issuer_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_subject_name_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_subject_name_hash_old"]
     pub fn X509_subject_name_hash_old(x509: *mut X509) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_new_index"]
     pub fn X509_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22583,7 +22583,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_ex_data"]
     pub fn X509_set_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
@@ -22591,14 +22591,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_ex_data"]
     pub fn X509_get_ex_data(
         r: *mut X509,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_new_index"]
     pub fn X509_STORE_CTX_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22608,7 +22608,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_ex_data"]
     pub fn X509_STORE_CTX_set_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
@@ -22616,14 +22616,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_ex_data"]
     pub fn X509_STORE_CTX_get_ex_data(
         ctx: *mut X509_STORE_CTX,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_new_index"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_new_index"]
     pub fn X509_STORE_get_ex_new_index(
         argl: ::std::os::raw::c_long,
         argp: *mut ::std::os::raw::c_void,
@@ -22633,7 +22633,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_ex_data"]
     pub fn X509_STORE_set_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
@@ -22641,14 +22641,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get_ex_data"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get_ex_data"]
     pub fn X509_STORE_get_ex_data(
         ctx: *mut X509_STORE,
         idx: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_digest"]
     pub fn ASN1_digest(
         i2d: i2d_of_void,
         type_: *const EVP_MD,
@@ -22658,7 +22658,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_digest"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_digest"]
     pub fn ASN1_item_digest(
         it: *const ASN1_ITEM,
         type_: *const EVP_MD,
@@ -22668,7 +22668,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_verify"]
     pub fn ASN1_item_verify(
         it: *const ASN1_ITEM,
         algor1: *const X509_ALGOR,
@@ -22678,7 +22678,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign"]
     pub fn ASN1_item_sign(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22690,7 +22690,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ASN1_item_sign_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ASN1_item_sign_ctx"]
     pub fn ASN1_item_sign_ctx(
         it: *const ASN1_ITEM,
         algor1: *mut X509_ALGOR,
@@ -22701,26 +22701,26 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_supported_extension"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_supported_extension"]
     pub fn X509_supported_extension(ex: *const X509_EXTENSION) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ca"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ca"]
     pub fn X509_check_ca(x509: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_issued"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_issued"]
     pub fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_check"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_check"]
     pub fn NAME_CONSTRAINTS_check(
         x509: *mut X509,
         nc: *mut NAME_CONSTRAINTS,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_host"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_host"]
     pub fn X509_check_host(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22730,7 +22730,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_email"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_email"]
     pub fn X509_check_email(
         x509: *const X509,
         chk: *const ::std::os::raw::c_char,
@@ -22739,7 +22739,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip"]
     pub fn X509_check_ip(
         x509: *const X509,
         chk: *const u8,
@@ -22748,7 +22748,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_ip_asc"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_ip_asc"]
     pub fn X509_check_ip_asc(
         x509: *const X509,
         ipasc: *const ::std::os::raw::c_char,
@@ -22756,7 +22756,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_issuer"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_issuer"]
     pub fn X509_STORE_CTX_get1_issuer(
         out_issuer: *mut *mut X509,
         ctx: *mut X509_STORE_CTX,
@@ -22764,7 +22764,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_purpose"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_purpose"]
     pub fn X509_check_purpose(
         x509: *mut X509,
         purpose: ::std::os::raw::c_int,
@@ -22772,7 +22772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_check_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_check_trust"]
     pub fn X509_check_trust(
         x509: *mut X509,
         id: ::std::os::raw::c_int,
@@ -22933,7 +22933,7 @@ pub type sk_X509_INFO_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_INFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_INFO_free"]
     pub fn X509_INFO_free(info: *mut X509_INFO);
 }
 #[repr(C)]
@@ -23031,7 +23031,7 @@ impl Default for v3_ext_ctx {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_ctx"]
     pub fn X509V3_set_ctx(
         ctx: *mut X509V3_CTX,
         issuer: *const X509,
@@ -23042,11 +23042,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_set_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_set_nconf"]
     pub fn X509V3_set_nconf(ctx: *mut X509V3_CTX, conf: *const CONF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf"]
     pub fn X509V3_EXT_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23055,7 +23055,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_nconf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_nconf_nid"]
     pub fn X509V3_EXT_nconf_nid(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23064,7 +23064,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf_nid"]
     pub fn X509V3_EXT_conf_nid(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *const X509V3_CTX,
@@ -23073,7 +23073,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf_sk"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf_sk"]
     pub fn X509V3_EXT_add_nconf_sk(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23082,7 +23082,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_nconf"]
     pub fn X509V3_EXT_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23091,7 +23091,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_REQ_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_REQ_add_nconf"]
     pub fn X509V3_EXT_REQ_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23100,7 +23100,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_CRL_add_nconf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_CRL_add_nconf"]
     pub fn X509V3_EXT_CRL_add_nconf(
         conf: *const CONF,
         ctx: *const X509V3_CTX,
@@ -23109,7 +23109,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_conf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_conf"]
     pub fn X509V3_EXT_conf(
         conf: *mut lhash_st_CONF_VALUE,
         ctx: *mut X509V3_CTX,
@@ -23118,14 +23118,14 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_OCTET_STRING"]
     pub fn i2s_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         oct: *const ASN1_OCTET_STRING,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_OCTET_STRING"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_OCTET_STRING"]
     pub fn s2i_ASN1_OCTET_STRING(
         method: *const X509V3_EXT_METHOD,
         ctx: *const X509V3_CTX,
@@ -23133,32 +23133,32 @@ extern "C" {
     ) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_INTEGER"]
     pub fn i2s_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_INTEGER,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_s2i_ASN1_INTEGER"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_s2i_ASN1_INTEGER"]
     pub fn s2i_ASN1_INTEGER(
         method: *const X509V3_EXT_METHOD,
         value: *const ::std::os::raw::c_char,
     ) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2s_ASN1_ENUMERATED"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2s_ASN1_ENUMERATED"]
     pub fn i2s_ASN1_ENUMERATED(
         method: *const X509V3_EXT_METHOD,
         aint: *const ASN1_ENUMERATED,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_conf_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_conf_free"]
     pub fn X509V3_conf_free(val: *mut CONF_VALUE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAME"]
     pub fn i2v_GENERAL_NAME(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAME,
@@ -23166,7 +23166,7 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2v_GENERAL_NAMES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2v_GENERAL_NAMES"]
     pub fn i2v_GENERAL_NAMES(
         method: *const X509V3_EXT_METHOD,
         gen: *const GENERAL_NAMES,
@@ -23174,43 +23174,43 @@ extern "C" {
     ) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS"]
     pub fn a2i_IPADDRESS(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_a2i_IPADDRESS_NC"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_a2i_IPADDRESS_NC"]
     pub fn a2i_IPADDRESS_NC(ipasc: *const ::std::os::raw::c_char) -> *mut ASN1_OCTET_STRING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notBefore"]
     pub fn X509_get_notBefore(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_notAfter"]
     pub fn X509_get_notAfter(x509: *const X509) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notBefore"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notBefore"]
     pub fn X509_set_notBefore(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_set_notAfter"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_set_notAfter"]
     pub fn X509_set_notAfter(x509: *mut X509, tm: *const ASN1_TIME) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_lastUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_lastUpdate"]
     pub fn X509_CRL_get_lastUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_get_nextUpdate"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_get_nextUpdate"]
     pub fn X509_CRL_get_nextUpdate(crl: *mut X509_CRL) -> *mut ASN1_TIME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_serialNumber"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_serialNumber"]
     pub fn X509_get_serialNumber(x509: *mut X509) -> *mut ASN1_INTEGER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_OBJ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_OBJ"]
     pub fn X509_NAME_get_text_by_OBJ(
         name: *const X509_NAME,
         obj: *const ASN1_OBJECT,
@@ -23219,7 +23219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_get_text_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_get_text_by_NID"]
     pub fn X509_NAME_get_text_by_NID(
         name: *const X509_NAME,
         nid: ::std::os::raw::c_int,
@@ -23228,31 +23228,31 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get0_parent_ctx"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get0_parent_ctx"]
     pub fn X509_STORE_CTX_get0_parent_ctx(ctx: *mut X509_STORE_CTX) -> *mut X509_STORE_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_free"]
     pub fn X509_LOOKUP_free(ctx: *mut X509_LOOKUP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_cleanup"]
     pub fn X509_STORE_CTX_cleanup(ctx: *mut X509_STORE_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add_standard_extensions"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add_standard_extensions"]
     pub fn X509V3_add_standard_extensions() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_parse_list"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_parse_list"]
     pub fn X509V3_parse_list(line: *const ::std::os::raw::c_char) -> *mut stack_st_CONF_VALUE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_chain"]
     pub fn X509_STORE_CTX_get_chain(ctx: *mut X509_STORE_CTX) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_trusted_stack"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_trusted_stack"]
     pub fn X509_STORE_CTX_trusted_stack(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
@@ -23262,7 +23262,7 @@ pub type X509_STORE_CTX_verify_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_verify_cb"]
     pub fn X509_STORE_CTX_set_verify_cb(
         ctx: *mut X509_STORE_CTX,
         verify_cb: ::std::option::Option<
@@ -23274,7 +23274,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_verify_cb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_verify_cb"]
     pub fn X509_STORE_set_verify_cb(store: *mut X509_STORE, verify_cb: X509_STORE_CTX_verify_cb);
 }
 pub type X509_STORE_CTX_get_crl_fn = ::std::option::Option<
@@ -23288,15 +23288,15 @@ pub type X509_STORE_CTX_check_crl_fn = ::std::option::Option<
     unsafe extern "C" fn(ctx: *mut X509_STORE_CTX, crl: *mut X509_CRL) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_get_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_get_crl"]
     pub fn X509_STORE_set_get_crl(store: *mut X509_STORE, get_crl: X509_STORE_CTX_get_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_check_crl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_check_crl"]
     pub fn X509_STORE_set_check_crl(store: *mut X509_STORE, check_crl: X509_STORE_CTX_check_crl_fn);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_set_chain"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_set_chain"]
     pub fn X509_STORE_CTX_set_chain(ctx: *mut X509_STORE_CTX, sk: *mut stack_st_X509);
 }
 #[repr(C)]
@@ -23476,74 +23476,74 @@ pub type sk_X509_TRUST_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_area"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_area"]
     pub fn X509_get_default_cert_area() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir"]
     pub fn X509_get_default_cert_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file"]
     pub fn X509_get_default_cert_file() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_dir_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_dir_env"]
     pub fn X509_get_default_cert_dir_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_cert_file_env"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_cert_file_env"]
     pub fn X509_get_default_cert_file_env() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_get_default_private_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_get_default_private_dir"]
     pub fn X509_get_default_private_dir() -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_set"]
     pub fn X509_TRUST_set(
         t: *mut ::std::os::raw::c_int,
         trust: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_cmp"]
     pub fn X509_cmp(a: *const X509, b: *const X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash"]
     pub fn X509_NAME_hash(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_NAME_hash_old"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_NAME_hash_old"]
     pub fn X509_NAME_hash_old(name: *mut X509_NAME) -> u32;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_CRL_match"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_CRL_match"]
     pub fn X509_CRL_match(a: *const X509_CRL, b: *const X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_count"]
     pub fn X509_TRUST_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0"]
     pub fn X509_TRUST_get0(idx: ::std::os::raw::c_int) -> *const X509_TRUST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_by_id"]
     pub fn X509_TRUST_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_flags"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_flags"]
     pub fn X509_TRUST_get_flags(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get0_name"]
     pub fn X509_TRUST_get0_name(xp: *const X509_TRUST) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_TRUST_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_TRUST_get_trust"]
     pub fn X509_TRUST_get_trust(xp: *const X509_TRUST) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -23568,7 +23568,7 @@ pub type sk_X509_OBJECT_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_load_file"]
     pub fn X509_LOOKUP_load_file(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23576,7 +23576,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_add_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_add_dir"]
     pub fn X509_LOOKUP_add_dir(
         lookup: *mut X509_LOOKUP,
         path: *const ::std::os::raw::c_char,
@@ -23584,79 +23584,79 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_new"]
     pub fn X509_OBJECT_new() -> *mut X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_free"]
     pub fn X509_OBJECT_free(obj: *mut X509_OBJECT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get_type"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get_type"]
     pub fn X509_OBJECT_get_type(obj: *const X509_OBJECT) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509"]
     pub fn X509_OBJECT_get0_X509(obj: *const X509_OBJECT) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_get0_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_get0_X509_CRL"]
     pub fn X509_OBJECT_get0_X509_CRL(a: *const X509_OBJECT) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509"]
     pub fn X509_OBJECT_set1_X509(a: *mut X509_OBJECT, obj: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_OBJECT_set1_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_OBJECT_set1_X509_CRL"]
     pub fn X509_OBJECT_set1_X509_CRL(
         a: *mut X509_OBJECT,
         obj: *mut X509_CRL,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_lock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_lock"]
     pub fn X509_STORE_lock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_unlock"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_unlock"]
     pub fn X509_STORE_unlock(v: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_get0_objects"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_get0_objects"]
     pub fn X509_STORE_get0_objects(st: *mut X509_STORE) -> *mut stack_st_X509_OBJECT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_certs"]
     pub fn X509_STORE_CTX_get1_certs(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get1_crls"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get1_crls"]
     pub fn X509_STORE_CTX_get1_crls(
         st: *mut X509_STORE_CTX,
         nm: *mut X509_NAME,
     ) -> *mut stack_st_X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_add_lookup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_add_lookup"]
     pub fn X509_STORE_add_lookup(
         v: *mut X509_STORE,
         m: *const X509_LOOKUP_METHOD,
     ) -> *mut X509_LOOKUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_hash_dir"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_hash_dir"]
     pub fn X509_LOOKUP_hash_dir() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_file"]
     pub fn X509_LOOKUP_file() -> *const X509_LOOKUP_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_CTX_get_by_subject"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_CTX_get_by_subject"]
     pub fn X509_STORE_CTX_get_by_subject(
         vs: *mut X509_STORE_CTX,
         type_: ::std::os::raw::c_int,
@@ -23665,7 +23665,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_LOOKUP_ctrl"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_LOOKUP_ctrl"]
     pub fn X509_LOOKUP_ctrl(
         ctx: *mut X509_LOOKUP,
         cmd: ::std::os::raw::c_int,
@@ -23675,7 +23675,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_file"]
     pub fn X509_load_cert_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23683,7 +23683,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_crl_file"]
     pub fn X509_load_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23691,7 +23691,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_load_cert_crl_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_load_cert_crl_file"]
     pub fn X509_load_cert_crl_file(
         ctx: *mut X509_LOOKUP,
         file: *const ::std::os::raw::c_char,
@@ -23699,7 +23699,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_load_locations"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_load_locations"]
     pub fn X509_STORE_load_locations(
         ctx: *mut X509_STORE,
         file: *const ::std::os::raw::c_char,
@@ -23707,7 +23707,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_STORE_set_default_paths"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_STORE_set_default_paths"]
     pub fn X509_STORE_set_default_paths(ctx: *mut X509_STORE) -> ::std::os::raw::c_int;
 }
 pub type X509V3_EXT_NEW =
@@ -25151,15 +25151,15 @@ pub type sk_X509_PURPOSE_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_new"]
     pub fn BASIC_CONSTRAINTS_new() -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_free"]
     pub fn BASIC_CONSTRAINTS_free(a: *mut BASIC_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_BASIC_CONSTRAINTS"]
     pub fn d2i_BASIC_CONSTRAINTS(
         a: *mut *mut BASIC_CONSTRAINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25167,26 +25167,26 @@ extern "C" {
     ) -> *mut BASIC_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_BASIC_CONSTRAINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_BASIC_CONSTRAINTS"]
     pub fn i2d_BASIC_CONSTRAINTS(
         a: *const BASIC_CONSTRAINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_BASIC_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_BASIC_CONSTRAINTS_it"]
     pub static BASIC_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_new"]
     pub fn AUTHORITY_KEYID_new() -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_free"]
     pub fn AUTHORITY_KEYID_free(a: *mut AUTHORITY_KEYID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_KEYID"]
     pub fn d2i_AUTHORITY_KEYID(
         a: *mut *mut AUTHORITY_KEYID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25194,26 +25194,26 @@ extern "C" {
     ) -> *mut AUTHORITY_KEYID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_KEYID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_KEYID"]
     pub fn i2d_AUTHORITY_KEYID(
         a: *mut AUTHORITY_KEYID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_KEYID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_KEYID_it"]
     pub static AUTHORITY_KEYID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_new"]
     pub fn EXTENDED_KEY_USAGE_new() -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_free"]
     pub fn EXTENDED_KEY_USAGE_free(a: *mut EXTENDED_KEY_USAGE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_EXTENDED_KEY_USAGE"]
     pub fn d2i_EXTENDED_KEY_USAGE(
         a: *mut *mut EXTENDED_KEY_USAGE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25221,26 +25221,26 @@ extern "C" {
     ) -> *mut EXTENDED_KEY_USAGE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_EXTENDED_KEY_USAGE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_EXTENDED_KEY_USAGE"]
     pub fn i2d_EXTENDED_KEY_USAGE(
         a: *const EXTENDED_KEY_USAGE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EXTENDED_KEY_USAGE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EXTENDED_KEY_USAGE_it"]
     pub static EXTENDED_KEY_USAGE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_new"]
     pub fn CERTIFICATEPOLICIES_new() -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_free"]
     pub fn CERTIFICATEPOLICIES_free(a: *mut CERTIFICATEPOLICIES);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CERTIFICATEPOLICIES"]
     pub fn d2i_CERTIFICATEPOLICIES(
         a: *mut *mut CERTIFICATEPOLICIES,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25248,26 +25248,26 @@ extern "C" {
     ) -> *mut CERTIFICATEPOLICIES;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CERTIFICATEPOLICIES"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CERTIFICATEPOLICIES"]
     pub fn i2d_CERTIFICATEPOLICIES(
         a: *const CERTIFICATEPOLICIES,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CERTIFICATEPOLICIES_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CERTIFICATEPOLICIES_it"]
     pub static CERTIFICATEPOLICIES_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_new"]
     pub fn POLICYINFO_new() -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_free"]
     pub fn POLICYINFO_free(a: *mut POLICYINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYINFO"]
     pub fn d2i_POLICYINFO(
         a: *mut *mut POLICYINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25275,26 +25275,26 @@ extern "C" {
     ) -> *mut POLICYINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYINFO"]
     pub fn i2d_POLICYINFO(
         a: *const POLICYINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYINFO_it"]
     pub static POLICYINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_new"]
     pub fn POLICYQUALINFO_new() -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_free"]
     pub fn POLICYQUALINFO_free(a: *mut POLICYQUALINFO);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_POLICYQUALINFO"]
     pub fn d2i_POLICYQUALINFO(
         a: *mut *mut POLICYQUALINFO,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25302,26 +25302,26 @@ extern "C" {
     ) -> *mut POLICYQUALINFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_POLICYQUALINFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_POLICYQUALINFO"]
     pub fn i2d_POLICYQUALINFO(
         a: *const POLICYQUALINFO,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICYQUALINFO_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICYQUALINFO_it"]
     pub static POLICYQUALINFO_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_new"]
     pub fn USERNOTICE_new() -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_free"]
     pub fn USERNOTICE_free(a: *mut USERNOTICE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_USERNOTICE"]
     pub fn d2i_USERNOTICE(
         a: *mut *mut USERNOTICE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25329,26 +25329,26 @@ extern "C" {
     ) -> *mut USERNOTICE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_USERNOTICE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_USERNOTICE"]
     pub fn i2d_USERNOTICE(
         a: *const USERNOTICE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_USERNOTICE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_USERNOTICE_it"]
     pub static USERNOTICE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_new"]
     pub fn NOTICEREF_new() -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_free"]
     pub fn NOTICEREF_free(a: *mut NOTICEREF);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_NOTICEREF"]
     pub fn d2i_NOTICEREF(
         a: *mut *mut NOTICEREF,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25356,26 +25356,26 @@ extern "C" {
     ) -> *mut NOTICEREF;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_NOTICEREF"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_NOTICEREF"]
     pub fn i2d_NOTICEREF(
         a: *const NOTICEREF,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NOTICEREF_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NOTICEREF_it"]
     pub static NOTICEREF_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_new"]
     pub fn CRL_DIST_POINTS_new() -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_free"]
     pub fn CRL_DIST_POINTS_free(a: *mut CRL_DIST_POINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_CRL_DIST_POINTS"]
     pub fn d2i_CRL_DIST_POINTS(
         a: *mut *mut CRL_DIST_POINTS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25383,26 +25383,26 @@ extern "C" {
     ) -> *mut CRL_DIST_POINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_CRL_DIST_POINTS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_CRL_DIST_POINTS"]
     pub fn i2d_CRL_DIST_POINTS(
         a: *mut CRL_DIST_POINTS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRL_DIST_POINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRL_DIST_POINTS_it"]
     pub static CRL_DIST_POINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_new"]
     pub fn DIST_POINT_new() -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_free"]
     pub fn DIST_POINT_free(a: *mut DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT"]
     pub fn d2i_DIST_POINT(
         a: *mut *mut DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25410,26 +25410,26 @@ extern "C" {
     ) -> *mut DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT"]
     pub fn i2d_DIST_POINT(
         a: *mut DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_it"]
     pub static DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_new"]
     pub fn DIST_POINT_NAME_new() -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_free"]
     pub fn DIST_POINT_NAME_free(a: *mut DIST_POINT_NAME);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_DIST_POINT_NAME"]
     pub fn d2i_DIST_POINT_NAME(
         a: *mut *mut DIST_POINT_NAME,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25437,26 +25437,26 @@ extern "C" {
     ) -> *mut DIST_POINT_NAME;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_DIST_POINT_NAME"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_DIST_POINT_NAME"]
     pub fn i2d_DIST_POINT_NAME(
         a: *mut DIST_POINT_NAME,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_NAME_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_NAME_it"]
     pub static DIST_POINT_NAME_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_new"]
     pub fn ISSUING_DIST_POINT_new() -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_free"]
     pub fn ISSUING_DIST_POINT_free(a: *mut ISSUING_DIST_POINT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ISSUING_DIST_POINT"]
     pub fn d2i_ISSUING_DIST_POINT(
         a: *mut *mut ISSUING_DIST_POINT,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25464,33 +25464,33 @@ extern "C" {
     ) -> *mut ISSUING_DIST_POINT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ISSUING_DIST_POINT"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ISSUING_DIST_POINT"]
     pub fn i2d_ISSUING_DIST_POINT(
         a: *mut ISSUING_DIST_POINT,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ISSUING_DIST_POINT_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ISSUING_DIST_POINT_it"]
     pub static ISSUING_DIST_POINT_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_DIST_POINT_set_dpname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_DIST_POINT_set_dpname"]
     pub fn DIST_POINT_set_dpname(
         dpn: *mut DIST_POINT_NAME,
         iname: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_new"]
     pub fn ACCESS_DESCRIPTION_new() -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_free"]
     pub fn ACCESS_DESCRIPTION_free(a: *mut ACCESS_DESCRIPTION);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_ACCESS_DESCRIPTION"]
     pub fn d2i_ACCESS_DESCRIPTION(
         a: *mut *mut ACCESS_DESCRIPTION,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25498,26 +25498,26 @@ extern "C" {
     ) -> *mut ACCESS_DESCRIPTION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_ACCESS_DESCRIPTION"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_ACCESS_DESCRIPTION"]
     pub fn i2d_ACCESS_DESCRIPTION(
         a: *mut ACCESS_DESCRIPTION,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ACCESS_DESCRIPTION_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ACCESS_DESCRIPTION_it"]
     pub static ACCESS_DESCRIPTION_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_new"]
     pub fn AUTHORITY_INFO_ACCESS_new() -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_free"]
     pub fn AUTHORITY_INFO_ACCESS_free(a: *mut AUTHORITY_INFO_ACCESS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_AUTHORITY_INFO_ACCESS"]
     pub fn d2i_AUTHORITY_INFO_ACCESS(
         a: *mut *mut AUTHORITY_INFO_ACCESS,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25525,77 +25525,77 @@ extern "C" {
     ) -> *mut AUTHORITY_INFO_ACCESS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_AUTHORITY_INFO_ACCESS"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_AUTHORITY_INFO_ACCESS"]
     pub fn i2d_AUTHORITY_INFO_ACCESS(
         a: *mut AUTHORITY_INFO_ACCESS,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_AUTHORITY_INFO_ACCESS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_AUTHORITY_INFO_ACCESS_it"]
     pub static AUTHORITY_INFO_ACCESS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_it"]
     pub static POLICY_MAPPING_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_new"]
     pub fn POLICY_MAPPING_new() -> *mut POLICY_MAPPING;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPING_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPING_free"]
     pub fn POLICY_MAPPING_free(a: *mut POLICY_MAPPING);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_MAPPINGS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_MAPPINGS_it"]
     pub static POLICY_MAPPINGS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_it"]
     pub static GENERAL_SUBTREE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_new"]
     pub fn GENERAL_SUBTREE_new() -> *mut GENERAL_SUBTREE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_GENERAL_SUBTREE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_GENERAL_SUBTREE_free"]
     pub fn GENERAL_SUBTREE_free(a: *mut GENERAL_SUBTREE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_it"]
     pub static NAME_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_new"]
     pub fn NAME_CONSTRAINTS_new() -> *mut NAME_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_NAME_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_NAME_CONSTRAINTS_free"]
     pub fn NAME_CONSTRAINTS_free(a: *mut NAME_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_new"]
     pub fn POLICY_CONSTRAINTS_new() -> *mut POLICY_CONSTRAINTS;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_free"]
     pub fn POLICY_CONSTRAINTS_free(a: *mut POLICY_CONSTRAINTS);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_POLICY_CONSTRAINTS_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_POLICY_CONSTRAINTS_it"]
     pub static POLICY_CONSTRAINTS_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add"]
     pub fn X509V3_EXT_add(ext: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn X509V3_EXT_add_list(extlist: *mut X509V3_EXT_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_add_alias"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_add_alias"]
     pub fn X509V3_EXT_add_alias(
         nid_to: ::std::os::raw::c_int,
         nid_from: ::std::os::raw::c_int,
@@ -25605,19 +25605,19 @@ extern "C" {
     pub fn X509V3_EXT_cleanup();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get"]
     pub fn X509V3_EXT_get(ext: *const X509_EXTENSION) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_get_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_get_nid"]
     pub fn X509V3_EXT_get_nid(nid: ::std::os::raw::c_int) -> *const X509V3_EXT_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_d2i"]
     pub fn X509V3_EXT_d2i(ext: *const X509_EXTENSION) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_get_d2i"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_get_d2i"]
     pub fn X509V3_get_d2i(
         extensions: *const stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25626,14 +25626,14 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_free"]
     pub fn X509V3_EXT_free(
         nid: ::std::os::raw::c_int,
         ext_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_EXT_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_EXT_i2d"]
     pub fn X509V3_EXT_i2d(
         ext_nid: ::std::os::raw::c_int,
         crit: ::std::os::raw::c_int,
@@ -25641,7 +25641,7 @@ extern "C" {
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509V3_add1_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509V3_add1_i2d"]
     pub fn X509V3_add1_i2d(
         x: *mut *mut stack_st_X509_EXTENSION,
         nid: ::std::os::raw::c_int,
@@ -25651,43 +25651,43 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_set"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_set"]
     pub fn X509_PURPOSE_set(
         p: *mut ::std::os::raw::c_int,
         purpose: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_count"]
     pub fn X509_PURPOSE_get_count() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0"]
     pub fn X509_PURPOSE_get0(idx: ::std::os::raw::c_int) -> *const X509_PURPOSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_sname"]
     pub fn X509_PURPOSE_get_by_sname(sname: *const ::std::os::raw::c_char)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_by_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_by_id"]
     pub fn X509_PURPOSE_get_by_id(id: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_name"]
     pub fn X509_PURPOSE_get0_name(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get0_sname"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get0_sname"]
     pub fn X509_PURPOSE_get0_sname(xp: *const X509_PURPOSE) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_trust"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_trust"]
     pub fn X509_PURPOSE_get_trust(xp: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_X509_PURPOSE_get_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_X509_PURPOSE_get_id"]
     pub fn X509_PURPOSE_get_id(arg1: *const X509_PURPOSE) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
@@ -25854,15 +25854,15 @@ pub type sk_OCSP_SINGLERESP_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_new"]
     pub fn OCSP_BASICRESP_new() -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_free"]
     pub fn OCSP_BASICRESP_free(a: *mut OCSP_BASICRESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_BASICRESP"]
     pub fn d2i_OCSP_BASICRESP(
         a: *mut *mut OCSP_BASICRESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25870,26 +25870,26 @@ extern "C" {
     ) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_BASICRESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_BASICRESP"]
     pub fn i2d_OCSP_BASICRESP(
         a: *mut OCSP_BASICRESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_it"]
     pub static OCSP_BASICRESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_new"]
     pub fn OCSP_RESPONSE_new() -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_free"]
     pub fn OCSP_RESPONSE_free(a: *mut OCSP_RESPONSE);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE"]
     pub fn d2i_OCSP_RESPONSE(
         a: *mut *mut OCSP_RESPONSE,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25897,26 +25897,26 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE"]
     pub fn i2d_OCSP_RESPONSE(
         a: *mut OCSP_RESPONSE,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_it"]
     pub static OCSP_RESPONSE_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_new"]
     pub fn OCSP_CERTID_new() -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_free"]
     pub fn OCSP_CERTID_free(a: *mut OCSP_CERTID);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_CERTID"]
     pub fn d2i_OCSP_CERTID(
         a: *mut *mut OCSP_CERTID,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25924,26 +25924,26 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_CERTID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_CERTID"]
     pub fn i2d_OCSP_CERTID(
         a: *mut OCSP_CERTID,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_it"]
     pub static OCSP_CERTID_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_new"]
     pub fn OCSP_REQUEST_new() -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_free"]
     pub fn OCSP_REQUEST_free(a: *mut OCSP_REQUEST);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST"]
     pub fn d2i_OCSP_REQUEST(
         a: *mut *mut OCSP_REQUEST,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25951,26 +25951,26 @@ extern "C" {
     ) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST"]
     pub fn i2d_OCSP_REQUEST(
         a: *mut OCSP_REQUEST,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_it"]
     pub static OCSP_REQUEST_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_new"]
     pub fn OCSP_SINGLERESP_new() -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_free"]
     pub fn OCSP_SINGLERESP_free(a: *mut OCSP_SINGLERESP);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_SINGLERESP"]
     pub fn d2i_OCSP_SINGLERESP(
         a: *mut *mut OCSP_SINGLERESP,
         in_: *mut *const ::std::os::raw::c_uchar,
@@ -25978,41 +25978,41 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_SINGLERESP"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_SINGLERESP"]
     pub fn i2d_OCSP_SINGLERESP(
         a: *mut OCSP_SINGLERESP,
         out: *mut *mut ::std::os::raw::c_uchar,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_it"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_it"]
     pub static OCSP_SINGLERESP_it: ASN1_ITEM;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_REQUEST_bio"]
     pub fn d2i_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut *mut OCSP_REQUEST) -> *mut OCSP_REQUEST;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_OCSP_RESPONSE_bio"]
     pub fn d2i_OCSP_RESPONSE_bio(
         bp: *mut BIO,
         presp: *mut *mut OCSP_RESPONSE,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_RESPONSE_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_RESPONSE_bio"]
     pub fn i2d_OCSP_RESPONSE_bio(bp: *mut BIO, presp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_OCSP_REQUEST_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_OCSP_REQUEST_bio"]
     pub fn i2d_OCSP_REQUEST_bio(bp: *mut BIO, preq: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_CERTID_dup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_CERTID_dup"]
     pub fn OCSP_CERTID_dup(id: *mut OCSP_CERTID) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_bio"]
     pub fn OCSP_sendreq_bio(
         b: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26020,7 +26020,7 @@ extern "C" {
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_new"]
     pub fn OCSP_sendreq_new(
         io: *mut BIO,
         path: *const ::std::os::raw::c_char,
@@ -26029,26 +26029,26 @@ extern "C" {
     ) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_sendreq_nbio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_sendreq_nbio"]
     pub fn OCSP_sendreq_nbio(
         presp: *mut *mut OCSP_RESPONSE,
         rctx: *mut OCSP_REQ_CTX,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_new"]
     pub fn OCSP_REQ_CTX_new(io: *mut BIO, maxline: ::std::os::raw::c_int) -> *mut OCSP_REQ_CTX;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_free"]
     pub fn OCSP_REQ_CTX_free(rctx: *mut OCSP_REQ_CTX);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_set_max_response_length"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_set_max_response_length"]
     pub fn OCSP_set_max_response_length(rctx: *mut OCSP_REQ_CTX, len: ::std::os::raw::c_ulong);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_http"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_http"]
     pub fn OCSP_REQ_CTX_http(
         rctx: *mut OCSP_REQ_CTX,
         op: *const ::std::os::raw::c_char,
@@ -26056,14 +26056,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_set1_req"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_set1_req"]
     pub fn OCSP_REQ_CTX_set1_req(
         rctx: *mut OCSP_REQ_CTX,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_add1_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_add1_header"]
     pub fn OCSP_REQ_CTX_add1_header(
         rctx: *mut OCSP_REQ_CTX,
         name: *const ::std::os::raw::c_char,
@@ -26071,7 +26071,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQ_CTX_i2d"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQ_CTX_i2d"]
     pub fn OCSP_REQ_CTX_i2d(
         rctx: *mut OCSP_REQ_CTX,
         it: *const ASN1_ITEM,
@@ -26079,15 +26079,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add0_id"]
     pub fn OCSP_request_add0_id(req: *mut OCSP_REQUEST, cid: *mut OCSP_CERTID) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_onereq_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_onereq_get0_id"]
     pub fn OCSP_onereq_get0_id(one: *mut OCSP_ONEREQ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_nonce"]
     pub fn OCSP_request_add1_nonce(
         req: *mut OCSP_REQUEST,
         val: *mut ::std::os::raw::c_uchar,
@@ -26095,7 +26095,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_nonce"]
     pub fn OCSP_basic_add1_nonce(
         resp: *mut OCSP_BASICRESP,
         val: *mut ::std::os::raw::c_uchar,
@@ -26103,48 +26103,48 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_nonce"]
     pub fn OCSP_check_nonce(
         req: *mut OCSP_REQUEST,
         bs: *mut OCSP_BASICRESP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_copy_nonce"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_copy_nonce"]
     pub fn OCSP_copy_nonce(
         resp: *mut OCSP_BASICRESP,
         req: *mut OCSP_REQUEST,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_set1_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_set1_name"]
     pub fn OCSP_request_set1_name(
         req: *mut OCSP_REQUEST,
         nm: *mut X509_NAME,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_add1_cert"]
     pub fn OCSP_request_add1_cert(req: *mut OCSP_REQUEST, cert: *mut X509)
         -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_is_signed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_is_signed"]
     pub fn OCSP_request_is_signed(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_count"]
     pub fn OCSP_request_onereq_count(req: *mut OCSP_REQUEST) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_onereq_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_onereq_get0"]
     pub fn OCSP_request_onereq_get0(
         req: *mut OCSP_REQUEST,
         i: ::std::os::raw::c_int,
     ) -> *mut OCSP_ONEREQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_sign"]
     pub fn OCSP_request_sign(
         req: *mut OCSP_REQUEST,
         signer: *mut X509,
@@ -26155,23 +26155,23 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status"]
     pub fn OCSP_response_status(resp: *mut OCSP_RESPONSE) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_get1_basic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_get1_basic"]
     pub fn OCSP_response_get1_basic(resp: *mut OCSP_RESPONSE) -> *mut OCSP_BASICRESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_count"]
     pub fn OCSP_resp_count(bs: *mut OCSP_BASICRESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_get0"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_get0"]
     pub fn OCSP_resp_get0(bs: *mut OCSP_BASICRESP, idx: usize) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_single_get0_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_single_get0_status"]
     pub fn OCSP_single_get0_status(
         single: *mut OCSP_SINGLERESP,
         reason: *mut ::std::os::raw::c_int,
@@ -26181,7 +26181,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find"]
     pub fn OCSP_resp_find(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26189,7 +26189,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_resp_find_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_resp_find_status"]
     pub fn OCSP_resp_find_status(
         bs: *mut OCSP_BASICRESP,
         id: *mut OCSP_CERTID,
@@ -26201,7 +26201,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_check_validity"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_check_validity"]
     pub fn OCSP_check_validity(
         thisUpdate: *mut ASN1_GENERALIZEDTIME,
         nextUpdate: *mut ASN1_GENERALIZEDTIME,
@@ -26210,7 +26210,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_verify"]
     pub fn OCSP_basic_verify(
         bs: *mut OCSP_BASICRESP,
         certs: *mut stack_st_X509,
@@ -26219,7 +26219,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_request_verify"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_request_verify"]
     pub fn OCSP_request_verify(
         req: *mut OCSP_REQUEST,
         certs: *mut stack_st_X509,
@@ -26228,7 +26228,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_id_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_id_new"]
     pub fn OCSP_cert_id_new(
         dgst: *const EVP_MD,
         issuerName: *const X509_NAME,
@@ -26237,7 +26237,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_to_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_to_id"]
     pub fn OCSP_cert_to_id(
         dgst: *const EVP_MD,
         subject: *const X509,
@@ -26245,7 +26245,7 @@ extern "C" {
     ) -> *mut OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_parse_url"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_parse_url"]
     pub fn OCSP_parse_url(
         url: *const ::std::os::raw::c_char,
         phost: *mut *mut ::std::os::raw::c_char,
@@ -26255,18 +26255,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_issuer_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_issuer_cmp"]
     pub fn OCSP_id_issuer_cmp(
         a: *const OCSP_CERTID,
         b: *const OCSP_CERTID,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_cmp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_cmp"]
     pub fn OCSP_id_cmp(a: *const OCSP_CERTID, b: *const OCSP_CERTID) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_id_get0_info"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_id_get0_info"]
     pub fn OCSP_id_get0_info(
         nameHash: *mut *mut ASN1_OCTET_STRING,
         algor: *mut *mut ASN1_OBJECT,
@@ -26276,14 +26276,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_cert"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_cert"]
     pub fn OCSP_basic_add1_cert(
         resp: *mut OCSP_BASICRESP,
         cert: *mut X509,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_add1_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_add1_status"]
     pub fn OCSP_basic_add1_status(
         resp: *mut OCSP_BASICRESP,
         cid: *mut OCSP_CERTID,
@@ -26295,7 +26295,7 @@ extern "C" {
     ) -> *mut OCSP_SINGLERESP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_basic_sign"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_basic_sign"]
     pub fn OCSP_basic_sign(
         resp: *mut OCSP_BASICRESP,
         signer: *mut X509,
@@ -26306,36 +26306,36 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_create"]
     pub fn OCSP_response_create(
         status: ::std::os::raw::c_int,
         bs: *mut OCSP_BASICRESP,
     ) -> *mut OCSP_RESPONSE;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get0_id"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get0_id"]
     pub fn OCSP_SINGLERESP_get0_id(x: *const OCSP_SINGLERESP) -> *const OCSP_CERTID;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_response_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_response_status_str"]
     pub fn OCSP_response_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_cert_status_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_cert_status_str"]
     pub fn OCSP_cert_status_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_crl_reason_str"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_crl_reason_str"]
     pub fn OCSP_crl_reason_str(
         status_code: ::std::os::raw::c_long,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_REQUEST_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_REQUEST_print"]
     pub fn OCSP_REQUEST_print(
         bp: *mut BIO,
         req: *mut OCSP_REQUEST,
@@ -26343,7 +26343,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_RESPONSE_print"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_RESPONSE_print"]
     pub fn OCSP_RESPONSE_print(
         bp: *mut BIO,
         resp: *mut OCSP_RESPONSE,
@@ -26351,7 +26351,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext_by_NID"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext_by_NID"]
     pub fn OCSP_BASICRESP_get_ext_by_NID(
         bs: *mut OCSP_BASICRESP,
         nid: ::std::os::raw::c_int,
@@ -26359,21 +26359,21 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_get_ext"]
     pub fn OCSP_BASICRESP_get_ext(
         bs: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_BASICRESP_delete_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_BASICRESP_delete_ext"]
     pub fn OCSP_BASICRESP_delete_ext(
         x: *mut OCSP_BASICRESP,
         loc: ::std::os::raw::c_int,
     ) -> *mut X509_EXTENSION;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_add_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_add_ext"]
     pub fn OCSP_SINGLERESP_add_ext(
         sresp: *mut OCSP_SINGLERESP,
         ex: *mut X509_EXTENSION,
@@ -26381,11 +26381,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext_count"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext_count"]
     pub fn OCSP_SINGLERESP_get_ext_count(sresp: *mut OCSP_SINGLERESP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_OCSP_SINGLERESP_get_ext"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_OCSP_SINGLERESP_get_ext"]
     pub fn OCSP_SINGLERESP_get_ext(
         sresp: *mut OCSP_SINGLERESP,
         loc: ::std::os::raw::c_int,
@@ -26400,14 +26400,14 @@ pub type pem_password_cb = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_get_EVP_CIPHER_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_get_EVP_CIPHER_INFO"]
     pub fn PEM_get_EVP_CIPHER_INFO(
         header: *mut ::std::os::raw::c_char,
         cipher: *mut EVP_CIPHER_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_do_header"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_do_header"]
     pub fn PEM_do_header(
         cipher: *mut EVP_CIPHER_INFO,
         data: *mut ::std::os::raw::c_uchar,
@@ -26417,7 +26417,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio"]
     pub fn PEM_read_bio(
         bp: *mut BIO,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26427,7 +26427,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio"]
     pub fn PEM_write_bio(
         bp: *mut BIO,
         name: *const ::std::os::raw::c_char,
@@ -26437,7 +26437,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_bytes_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_bytes_read_bio"]
     pub fn PEM_bytes_read_bio(
         pdata: *mut *mut ::std::os::raw::c_uchar,
         plen: *mut ::std::os::raw::c_long,
@@ -26449,7 +26449,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read_bio"]
     pub fn PEM_ASN1_read_bio(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26460,7 +26460,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write_bio"]
     pub fn PEM_ASN1_write_bio(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26474,7 +26474,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read_bio"]
     pub fn PEM_X509_INFO_read_bio(
         bp: *mut BIO,
         sk: *mut stack_st_X509_INFO,
@@ -26483,7 +26483,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_X509_INFO_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_X509_INFO_read"]
     pub fn PEM_X509_INFO_read(
         fp: *mut FILE,
         sk: *mut stack_st_X509_INFO,
@@ -26492,7 +26492,7 @@ extern "C" {
     ) -> *mut stack_st_X509_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read"]
     pub fn PEM_read(
         fp: *mut FILE,
         name: *mut *mut ::std::os::raw::c_char,
@@ -26502,7 +26502,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write"]
     pub fn PEM_write(
         fp: *mut FILE,
         name: *const ::std::os::raw::c_char,
@@ -26512,7 +26512,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_read"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_read"]
     pub fn PEM_ASN1_read(
         d2i: d2i_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26523,7 +26523,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_ASN1_write"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_ASN1_write"]
     pub fn PEM_ASN1_write(
         i2d: i2d_of_void,
         name: *const ::std::os::raw::c_char,
@@ -26537,7 +26537,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_def_callback"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_def_callback"]
     pub fn PEM_def_callback(
         buf: *mut ::std::os::raw::c_char,
         size: ::std::os::raw::c_int,
@@ -26546,7 +26546,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509"]
     pub fn PEM_read_bio_X509(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26555,7 +26555,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509"]
     pub fn PEM_read_X509(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26564,15 +26564,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509"]
     pub fn PEM_write_bio_X509(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509"]
     pub fn PEM_write_X509(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_AUX"]
     pub fn PEM_read_bio_X509_AUX(
         bp: *mut BIO,
         x: *mut *mut X509,
@@ -26581,7 +26581,7 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_AUX"]
     pub fn PEM_read_X509_AUX(
         fp: *mut FILE,
         x: *mut *mut X509,
@@ -26590,15 +26590,15 @@ extern "C" {
     ) -> *mut X509;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_AUX"]
     pub fn PEM_write_bio_X509_AUX(bp: *mut BIO, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_AUX"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_AUX"]
     pub fn PEM_write_X509_AUX(fp: *mut FILE, x: *mut X509) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_REQ"]
     pub fn PEM_read_bio_X509_REQ(
         bp: *mut BIO,
         x: *mut *mut X509_REQ,
@@ -26607,7 +26607,7 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_REQ"]
     pub fn PEM_read_X509_REQ(
         fp: *mut FILE,
         x: *mut *mut X509_REQ,
@@ -26616,23 +26616,23 @@ extern "C" {
     ) -> *mut X509_REQ;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ"]
     pub fn PEM_write_bio_X509_REQ(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ"]
     pub fn PEM_write_X509_REQ(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_REQ_NEW"]
     pub fn PEM_write_bio_X509_REQ_NEW(bp: *mut BIO, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_REQ_NEW"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_REQ_NEW"]
     pub fn PEM_write_X509_REQ_NEW(fp: *mut FILE, x: *mut X509_REQ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_X509_CRL"]
     pub fn PEM_read_bio_X509_CRL(
         bp: *mut BIO,
         x: *mut *mut X509_CRL,
@@ -26641,7 +26641,7 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_X509_CRL"]
     pub fn PEM_read_X509_CRL(
         fp: *mut FILE,
         x: *mut *mut X509_CRL,
@@ -26650,15 +26650,15 @@ extern "C" {
     ) -> *mut X509_CRL;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_X509_CRL"]
     pub fn PEM_write_bio_X509_CRL(bp: *mut BIO, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_X509_CRL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_X509_CRL"]
     pub fn PEM_write_X509_CRL(fp: *mut FILE, x: *mut X509_CRL) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS7"]
     pub fn PEM_read_bio_PKCS7(
         bp: *mut BIO,
         x: *mut *mut PKCS7,
@@ -26667,7 +26667,7 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS7"]
     pub fn PEM_read_PKCS7(
         fp: *mut FILE,
         x: *mut *mut PKCS7,
@@ -26676,15 +26676,15 @@ extern "C" {
     ) -> *mut PKCS7;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS7"]
     pub fn PEM_write_bio_PKCS7(bp: *mut BIO, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS7"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS7"]
     pub fn PEM_write_PKCS7(fp: *mut FILE, x: *mut PKCS7) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8"]
     pub fn PEM_read_bio_PKCS8(
         bp: *mut BIO,
         x: *mut *mut X509_SIG,
@@ -26693,7 +26693,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8"]
     pub fn PEM_read_PKCS8(
         fp: *mut FILE,
         x: *mut *mut X509_SIG,
@@ -26702,15 +26702,15 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8"]
     pub fn PEM_write_bio_PKCS8(bp: *mut BIO, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8"]
     pub fn PEM_write_PKCS8(fp: *mut FILE, x: *mut X509_SIG) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26719,7 +26719,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_read_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut *mut PKCS8_PRIV_KEY_INFO,
@@ -26728,21 +26728,21 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_bio_PKCS8_PRIV_KEY_INFO(
         bp: *mut BIO,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8_PRIV_KEY_INFO"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8_PRIV_KEY_INFO"]
     pub fn PEM_write_PKCS8_PRIV_KEY_INFO(
         fp: *mut FILE,
         x: *mut PKCS8_PRIV_KEY_INFO,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPrivateKey"]
     pub fn PEM_read_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26751,7 +26751,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPrivateKey"]
     pub fn PEM_read_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26760,7 +26760,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPrivateKey"]
     pub fn PEM_write_bio_RSAPrivateKey(
         bp: *mut BIO,
         x: *mut RSA,
@@ -26772,7 +26772,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPrivateKey"]
     pub fn PEM_write_RSAPrivateKey(
         fp: *mut FILE,
         x: *mut RSA,
@@ -26784,7 +26784,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSAPublicKey"]
     pub fn PEM_read_bio_RSAPublicKey(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26793,7 +26793,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSAPublicKey"]
     pub fn PEM_read_RSAPublicKey(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26802,15 +26802,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSAPublicKey"]
     pub fn PEM_write_bio_RSAPublicKey(bp: *mut BIO, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSAPublicKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSAPublicKey"]
     pub fn PEM_write_RSAPublicKey(fp: *mut FILE, x: *const RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_RSA_PUBKEY"]
     pub fn PEM_read_bio_RSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut RSA,
@@ -26819,7 +26819,7 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_RSA_PUBKEY"]
     pub fn PEM_read_RSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut RSA,
@@ -26828,15 +26828,15 @@ extern "C" {
     ) -> *mut RSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_RSA_PUBKEY"]
     pub fn PEM_write_bio_RSA_PUBKEY(bp: *mut BIO, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_RSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_RSA_PUBKEY"]
     pub fn PEM_write_RSA_PUBKEY(fp: *mut FILE, x: *mut RSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAPrivateKey"]
     pub fn PEM_read_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26845,7 +26845,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAPrivateKey"]
     pub fn PEM_read_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26854,7 +26854,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAPrivateKey"]
     pub fn PEM_write_bio_DSAPrivateKey(
         bp: *mut BIO,
         x: *mut DSA,
@@ -26866,7 +26866,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAPrivateKey"]
     pub fn PEM_write_DSAPrivateKey(
         fp: *mut FILE,
         x: *mut DSA,
@@ -26878,7 +26878,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSA_PUBKEY"]
     pub fn PEM_read_bio_DSA_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26887,7 +26887,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSA_PUBKEY"]
     pub fn PEM_read_DSA_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26896,15 +26896,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSA_PUBKEY"]
     pub fn PEM_write_bio_DSA_PUBKEY(bp: *mut BIO, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSA_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSA_PUBKEY"]
     pub fn PEM_write_DSA_PUBKEY(fp: *mut FILE, x: *mut DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DSAparams"]
     pub fn PEM_read_bio_DSAparams(
         bp: *mut BIO,
         x: *mut *mut DSA,
@@ -26913,7 +26913,7 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DSAparams"]
     pub fn PEM_read_DSAparams(
         fp: *mut FILE,
         x: *mut *mut DSA,
@@ -26922,15 +26922,15 @@ extern "C" {
     ) -> *mut DSA;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DSAparams"]
     pub fn PEM_write_bio_DSAparams(bp: *mut BIO, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DSAparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DSAparams"]
     pub fn PEM_write_DSAparams(fp: *mut FILE, x: *const DSA) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPrivateKey"]
     pub fn PEM_read_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26939,7 +26939,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_ECPrivateKey"]
     pub fn PEM_read_ECPrivateKey(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26948,7 +26948,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPrivateKey"]
     pub fn PEM_write_bio_ECPrivateKey(
         bp: *mut BIO,
         x: *mut EC_KEY,
@@ -26960,7 +26960,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_ECPrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_ECPrivateKey"]
     pub fn PEM_write_ECPrivateKey(
         fp: *mut FILE,
         x: *mut EC_KEY,
@@ -26972,7 +26972,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_EC_PUBKEY"]
     pub fn PEM_read_bio_EC_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EC_KEY,
@@ -26981,7 +26981,7 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_EC_PUBKEY"]
     pub fn PEM_read_EC_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EC_KEY,
@@ -26990,15 +26990,15 @@ extern "C" {
     ) -> *mut EC_KEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_EC_PUBKEY"]
     pub fn PEM_write_bio_EC_PUBKEY(bp: *mut BIO, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_EC_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_EC_PUBKEY"]
     pub fn PEM_write_EC_PUBKEY(fp: *mut FILE, x: *mut EC_KEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_DHparams"]
     pub fn PEM_read_bio_DHparams(
         bp: *mut BIO,
         x: *mut *mut DH,
@@ -27007,7 +27007,7 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_DHparams"]
     pub fn PEM_read_DHparams(
         fp: *mut FILE,
         x: *mut *mut DH,
@@ -27016,15 +27016,15 @@ extern "C" {
     ) -> *mut DH;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_DHparams"]
     pub fn PEM_write_bio_DHparams(bp: *mut BIO, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_DHparams"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_DHparams"]
     pub fn PEM_write_DHparams(fp: *mut FILE, x: *const DH) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PrivateKey"]
     pub fn PEM_read_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27033,7 +27033,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PrivateKey"]
     pub fn PEM_read_PrivateKey(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27042,7 +27042,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey"]
     pub fn PEM_write_bio_PrivateKey(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27054,7 +27054,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PrivateKey"]
     pub fn PEM_write_PrivateKey(
         fp: *mut FILE,
         x: *mut EVP_PKEY,
@@ -27066,7 +27066,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_PUBKEY"]
     pub fn PEM_read_bio_PUBKEY(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27075,7 +27075,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_PUBKEY"]
     pub fn PEM_read_PUBKEY(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27084,15 +27084,15 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PUBKEY"]
     pub fn PEM_write_bio_PUBKEY(bp: *mut BIO, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PUBKEY"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PUBKEY"]
     pub fn PEM_write_PUBKEY(fp: *mut FILE, x: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey_nid"]
     pub fn PEM_write_bio_PKCS8PrivateKey_nid(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27104,7 +27104,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PKCS8PrivateKey"]
     pub fn PEM_write_bio_PKCS8PrivateKey(
         arg1: *mut BIO,
         arg2: *const EVP_PKEY,
@@ -27116,7 +27116,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_bio"]
     pub fn i2d_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27128,7 +27128,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_bio"]
     pub fn i2d_PKCS8PrivateKey_nid_bio(
         bp: *mut BIO,
         x: *const EVP_PKEY,
@@ -27140,7 +27140,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_bio"]
     pub fn d2i_PKCS8PrivateKey_bio(
         bp: *mut BIO,
         x: *mut *mut EVP_PKEY,
@@ -27149,7 +27149,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_fp"]
     pub fn i2d_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27161,7 +27161,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS8PrivateKey_nid_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS8PrivateKey_nid_fp"]
     pub fn i2d_PKCS8PrivateKey_nid_fp(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27173,7 +27173,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey_nid"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey_nid"]
     pub fn PEM_write_PKCS8PrivateKey_nid(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27185,7 +27185,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS8PrivateKey_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS8PrivateKey_fp"]
     pub fn d2i_PKCS8PrivateKey_fp(
         fp: *mut FILE,
         x: *mut *mut EVP_PKEY,
@@ -27194,7 +27194,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_PKCS8PrivateKey"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_PKCS8PrivateKey"]
     pub fn PEM_write_PKCS8PrivateKey(
         fp: *mut FILE,
         x: *const EVP_PKEY,
@@ -27206,15 +27206,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_Parameters"]
     pub fn PEM_read_bio_Parameters(bio: *mut BIO, pkey: *mut *mut EVP_PKEY) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_Parameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_Parameters"]
     pub fn PEM_write_bio_Parameters(bio: *mut BIO, pkey: *mut EVP_PKEY) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_read_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_read_bio_ECPKParameters"]
     pub fn PEM_read_bio_ECPKParameters(
         bio: *mut BIO,
         out_group: *mut *mut EC_GROUP,
@@ -27223,14 +27223,14 @@ extern "C" {
     ) -> *mut EC_GROUP;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_ECPKParameters"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_ECPKParameters"]
     pub fn PEM_write_bio_ECPKParameters(
         out: *mut BIO,
         group: *const EC_GROUP,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PEM_write_bio_PrivateKey_traditional"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PEM_write_bio_PrivateKey_traditional"]
     pub fn PEM_write_bio_PrivateKey_traditional(
         bp: *mut BIO,
         x: *mut EVP_PKEY,
@@ -27242,7 +27242,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_encrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_encrypt"]
     pub fn PKCS8_encrypt(
         pbe_nid: ::std::os::raw::c_int,
         cipher: *const EVP_CIPHER,
@@ -27255,7 +27255,7 @@ extern "C" {
     ) -> *mut X509_SIG;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_marshal_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_marshal_encrypted_private_key"]
     pub fn PKCS8_marshal_encrypted_private_key(
         out: *mut CBB,
         pbe_nid: ::std::os::raw::c_int,
@@ -27269,7 +27269,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_decrypt"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_decrypt"]
     pub fn PKCS8_decrypt(
         pkcs8: *mut X509_SIG,
         pass: *const ::std::os::raw::c_char,
@@ -27277,7 +27277,7 @@ extern "C" {
     ) -> *mut PKCS8_PRIV_KEY_INFO;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS8_parse_encrypted_private_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS8_parse_encrypted_private_key"]
     pub fn PKCS8_parse_encrypted_private_key(
         cbs: *mut CBS,
         pass: *const ::std::os::raw::c_char,
@@ -27285,7 +27285,7 @@ extern "C" {
     ) -> *mut EVP_PKEY;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_get_key_and_certs"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_get_key_and_certs"]
     pub fn PKCS12_get_key_and_certs(
         out_key: *mut *mut EVP_PKEY,
         out_certs: *mut stack_st_X509,
@@ -27294,11 +27294,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_PBE_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_PBE_add"]
     pub fn PKCS12_PBE_add();
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12"]
     pub fn d2i_PKCS12(
         out_p12: *mut *mut PKCS12,
         ber_bytes: *mut *const u8,
@@ -27306,27 +27306,27 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_bio"]
     pub fn d2i_PKCS12_bio(bio: *mut BIO, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_d2i_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_d2i_PKCS12_fp"]
     pub fn d2i_PKCS12_fp(fp: *mut FILE, out_p12: *mut *mut PKCS12) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12"]
     pub fn i2d_PKCS12(p12: *const PKCS12, out: *mut *mut u8) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_bio"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_bio"]
     pub fn i2d_PKCS12_bio(bio: *mut BIO, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_i2d_PKCS12_fp"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_i2d_PKCS12_fp"]
     pub fn i2d_PKCS12_fp(fp: *mut FILE, p12: *const PKCS12) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_parse"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_parse"]
     pub fn PKCS12_parse(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27336,7 +27336,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_verify_mac"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_verify_mac"]
     pub fn PKCS12_verify_mac(
         p12: *const PKCS12,
         password: *const ::std::os::raw::c_char,
@@ -27344,7 +27344,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_create"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_create"]
     pub fn PKCS12_create(
         password: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -27359,93 +27359,93 @@ extern "C" {
     ) -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_new"]
     pub fn PKCS12_new() -> *mut PKCS12;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_PKCS12_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_PKCS12_free"]
     pub fn PKCS12_free(p12: *mut PKCS12);
 }
 pub type poly1305_state = [u8; 512usize];
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_init"]
     pub fn CRYPTO_poly1305_init(state: *mut poly1305_state, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_update"]
     pub fn CRYPTO_poly1305_update(state: *mut poly1305_state, in_: *const u8, in_len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_CRYPTO_poly1305_finish"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_CRYPTO_poly1305_finish"]
     pub fn CRYPTO_poly1305_finish(state: *mut poly1305_state, mac: *mut u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_bytes"]
     pub fn RAND_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_priv_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_priv_bytes"]
     pub fn RAND_priv_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_enable_fork_unsafe_buffering"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_enable_fork_unsafe_buffering"]
     pub fn RAND_enable_fork_unsafe_buffering(fd: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_system_entropy_for_custom_prng"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_system_entropy_for_custom_prng"]
     pub fn RAND_get_system_entropy_for_custom_prng(buf: *mut u8, len: usize);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_pseudo_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_pseudo_bytes"]
     pub fn RAND_pseudo_bytes(buf: *mut u8, len: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_seed"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_seed"]
     pub fn RAND_seed(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_load_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_load_file"]
     pub fn RAND_load_file(
         path: *const ::std::os::raw::c_char,
         num: ::std::os::raw::c_long,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_write_file"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_write_file"]
     pub fn RAND_write_file(file: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_file_name"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_file_name"]
     pub fn RAND_file_name(
         buf: *mut ::std::os::raw::c_char,
         num: usize,
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_add"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_add"]
     pub fn RAND_add(buf: *const ::std::os::raw::c_void, num: ::std::os::raw::c_int, entropy: f64);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd"]
     pub fn RAND_egd(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_egd_bytes"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_egd_bytes"]
     pub fn RAND_egd_bytes(
         arg1: *const ::std::os::raw::c_char,
         bytes: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_poll"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_poll"]
     pub fn RAND_poll() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_status"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_status"]
     pub fn RAND_status() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_cleanup"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_cleanup"]
     pub fn RAND_cleanup();
 }
 #[repr(C)]
@@ -27546,23 +27546,23 @@ fn bindgen_test_layout_rand_meth_st() {
     );
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_SSLeay"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_SSLeay"]
     pub fn RAND_SSLeay() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_OpenSSL"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_OpenSSL"]
     pub fn RAND_OpenSSL() -> *mut RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_get_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_get_rand_method"]
     pub fn RAND_get_rand_method() -> *const RAND_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_set_rand_method"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_set_rand_method"]
     pub fn RAND_set_rand_method(arg1: *const RAND_METHOD) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RAND_keep_random_devices_open"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RAND_keep_random_devices_open"]
     pub fn RAND_keep_random_devices_open(a: ::std::os::raw::c_int);
 }
 #[repr(C)]
@@ -27627,11 +27627,11 @@ impl Default for rc4_key_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4_set_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4_set_key"]
     pub fn RC4_set_key(rc4key: *mut RC4_KEY, len: ::std::os::raw::c_uint, key: *const u8);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RC4"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RC4"]
     pub fn RC4(key: *mut RC4_KEY, len: usize, in_: *const u8, out: *mut u8);
 }
 #[repr(C)]
@@ -27718,11 +27718,11 @@ impl Default for RIPEMD160state_st {
     }
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Init"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Init"]
     pub fn RIPEMD160_Init(ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Update"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Update"]
     pub fn RIPEMD160_Update(
         ctx: *mut RIPEMD160_CTX,
         data: *const ::std::os::raw::c_void,
@@ -27730,50 +27730,50 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160_Final"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160_Final"]
     pub fn RIPEMD160_Final(out: *mut u8, ctx: *mut RIPEMD160_CTX) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_RIPEMD160"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_RIPEMD160"]
     pub fn RIPEMD160(data: *const u8, len: usize, out: *mut u8) -> *mut u8;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_before_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_before_call"]
     pub fn FIPS_service_indicator_before_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_FIPS_service_indicator_after_call"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_FIPS_service_indicator_after_call"]
     pub fn FIPS_service_indicator_after_call() -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_awslc_version_string"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_awslc_version_string"]
     pub fn awslc_version_string() -> *const ::std::os::raw::c_char;
 }
 pub const FIPSStatus_AWSLC_NOT_APPROVED: FIPSStatus = 0;
 pub const FIPSStatus_AWSLC_APPROVED: FIPSStatus = 1;
 pub type FIPSStatus = ::std::os::raw::c_uint;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_SIPHASH_24"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_SIPHASH_24"]
     pub fn SIPHASH_24(key: *const u64, input: *const u8, input_len: usize) -> u64;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v1"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v1"]
     pub fn TRUST_TOKEN_experiment_v1() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_voprf"]
     pub fn TRUST_TOKEN_experiment_v2_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_experiment_v2_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_experiment_v2_pmb"]
     pub fn TRUST_TOKEN_experiment_v2_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_voprf"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_voprf"]
     pub fn TRUST_TOKEN_pst_v1_voprf() -> *const TRUST_TOKEN_METHOD;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_pst_v1_pmb"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_pst_v1_pmb"]
     pub fn TRUST_TOKEN_pst_v1_pmb() -> *const TRUST_TOKEN_METHOD;
 }
 #[repr(C)]
@@ -27848,15 +27848,15 @@ pub type sk_TRUST_TOKEN_delete_if_func = ::std::option::Option<
     ) -> ::std::os::raw::c_int,
 >;
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_new"]
     pub fn TRUST_TOKEN_new(data: *const u8, len: usize) -> *mut TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_free"]
     pub fn TRUST_TOKEN_free(token: *mut TRUST_TOKEN);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_generate_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_generate_key"]
     pub fn TRUST_TOKEN_generate_key(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27869,7 +27869,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_derive_key_from_secret"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_derive_key_from_secret"]
     pub fn TRUST_TOKEN_derive_key_from_secret(
         method: *const TRUST_TOKEN_METHOD,
         out_priv_key: *mut u8,
@@ -27884,18 +27884,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_new"]
     pub fn TRUST_TOKEN_CLIENT_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_CLIENT;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_free"]
     pub fn TRUST_TOKEN_CLIENT_free(ctx: *mut TRUST_TOKEN_CLIENT);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_add_key"]
     pub fn TRUST_TOKEN_CLIENT_add_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27904,14 +27904,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_set_srr_key"]
     pub fn TRUST_TOKEN_CLIENT_set_srr_key(
         ctx: *mut TRUST_TOKEN_CLIENT,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27920,7 +27920,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_issuance_over_message"]
     pub fn TRUST_TOKEN_CLIENT_begin_issuance_over_message(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27931,7 +27931,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_issuance"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_issuance"]
     pub fn TRUST_TOKEN_CLIENT_finish_issuance(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_key_index: *mut usize,
@@ -27940,7 +27940,7 @@ extern "C" {
     ) -> *mut stack_st_TRUST_TOKEN;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_begin_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_begin_redemption"]
     pub fn TRUST_TOKEN_CLIENT_begin_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out: *mut *mut u8,
@@ -27952,7 +27952,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_CLIENT_finish_redemption"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_CLIENT_finish_redemption"]
     pub fn TRUST_TOKEN_CLIENT_finish_redemption(
         ctx: *mut TRUST_TOKEN_CLIENT,
         out_rr: *mut *mut u8,
@@ -27964,18 +27964,18 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_new"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_new"]
     pub fn TRUST_TOKEN_ISSUER_new(
         method: *const TRUST_TOKEN_METHOD,
         max_batchsize: usize,
     ) -> *mut TRUST_TOKEN_ISSUER;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_free"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_free"]
     pub fn TRUST_TOKEN_ISSUER_free(ctx: *mut TRUST_TOKEN_ISSUER);
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_add_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_add_key"]
     pub fn TRUST_TOKEN_ISSUER_add_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -27983,14 +27983,14 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_srr_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_srr_key"]
     pub fn TRUST_TOKEN_ISSUER_set_srr_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *mut EVP_PKEY,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_set_metadata_key"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_set_metadata_key"]
     pub fn TRUST_TOKEN_ISSUER_set_metadata_key(
         ctx: *mut TRUST_TOKEN_ISSUER,
         key: *const u8,
@@ -27998,7 +27998,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_issue"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_issue"]
     pub fn TRUST_TOKEN_ISSUER_issue(
         ctx: *const TRUST_TOKEN_ISSUER,
         out: *mut *mut u8,
@@ -28012,7 +28012,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem"]
     pub fn TRUST_TOKEN_ISSUER_redeem(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28025,7 +28025,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_ISSUER_redeem_over_message"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_ISSUER_redeem_over_message"]
     pub fn TRUST_TOKEN_ISSUER_redeem_over_message(
         ctx: *const TRUST_TOKEN_ISSUER,
         out_public: *mut u32,
@@ -28040,7 +28040,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_TRUST_TOKEN_decode_private_metadata"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_TRUST_TOKEN_decode_private_metadata"]
     pub fn TRUST_TOKEN_decode_private_metadata(
         method: *const TRUST_TOKEN_METHOD,
         out_value: *mut u8,
@@ -28052,7 +28052,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_keygen_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_keygen_deterministic"]
     pub fn EVP_PKEY_keygen_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         out_pkey: *mut *mut EVP_PKEY,
@@ -28061,7 +28061,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_EVP_PKEY_encapsulate_deterministic"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_EVP_PKEY_encapsulate_deterministic"]
     pub fn EVP_PKEY_encapsulate_deterministic(
         ctx: *mut EVP_PKEY_CTX,
         ciphertext: *mut u8,
@@ -28073,15 +28073,15 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_LIB_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_LIB_RUST"]
     pub fn ERR_GET_LIB_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_REASON_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_REASON_RUST"]
     pub fn ERR_GET_REASON_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[link_name = "\u{1}aws_lc_fips_0_13_3_ERR_GET_FUNC_RUST"]
+    #[link_name = "\u{1}aws_lc_fips_0_13_4_ERR_GET_FUNC_RUST"]
     pub fn ERR_GET_FUNC_RUST(packed_error: u32) -> ::std::os::raw::c_int;
 }
 pub type __builtin_va_list = [__va_list_tag; 1usize];


### PR DESCRIPTION

### Description of changes: 
* Bump `aws-lc-fips-sys` to v0.13.4
* This is needed to publish a version that does not depend on "paste".

### Call-outs:
* The dependency on "paste" was removed in a previous PR: https://github.com/aws/aws-lc-rs/pull/724
* Manual changes in this commit: https://github.com/aws/aws-lc-rs/commit/0b0ced7b384f25ac0dc4183e00d8e0162bbf495b
* Automated Workflow: https://github.com/aws/aws-lc-rs/actions/runs/13820709450

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
