### PR TITLE
Support RsaSubjectPublicKey to/from X509; Bump version

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.12.6"
+version = "1.12.7"
 # this crate re-exports whatever sys crate that was selected
-links = "aws_lc_rs_1_12_6_sys"
+links = "aws_lc_rs_1_12_7_sys"
 edition = "2021"
 rust-version = "1.63.0"
 keywords = ["crypto", "cryptography", "security"]

--- a/aws-lc-rs/Makefile
+++ b/aws-lc-rs/Makefile
@@ -4,6 +4,8 @@ UNAME_S := $(shell uname -s)
 
 AWS_LC_RS_COV_EXTRA_FEATURES := unstable
 
+export AWS_LC_RS_DISABLE_SLOW_TESTS := 1
+
 asan:
 # TODO: This build target produces linker error on Mac.
 # Run specific tests:

--- a/aws-lc-rs/src/rsa/encoding.rs
+++ b/aws-lc-rs/src/rsa/encoding.rs
@@ -76,7 +76,7 @@ pub(in crate::rsa) mod rfc8017 {
 ///
 /// Encodings that use the `SubjectPublicKeyInfo` structure.
 pub(in crate::rsa) mod rfc5280 {
-    use crate::aws_lc::{EVP_PKEY, EVP_PKEY_RSA};
+    use crate::aws_lc::{EVP_PKEY, EVP_PKEY_RSA, EVP_PKEY_RSA_PSS};
     use crate::buffer::Buffer;
     use crate::encoding::PublicKeyX509Der;
     use crate::error::{KeyRejected, Unspecified};
@@ -92,6 +92,9 @@ pub(in crate::rsa) mod rfc5280 {
     pub(in crate::rsa) fn decode_public_key_der(
         value: &[u8],
     ) -> Result<LcPtr<EVP_PKEY>, KeyRejected> {
-        LcPtr::<EVP_PKEY>::parse_rfc5280_public_key(value, EVP_PKEY_RSA)
+        LcPtr::<EVP_PKEY>::parse_rfc5280_public_key(value, EVP_PKEY_RSA).or(
+            // Does anyone encode with this OID?
+            LcPtr::<EVP_PKEY>::parse_rfc5280_public_key(value, EVP_PKEY_RSA_PSS),
+        )
     }
 }

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -315,13 +315,9 @@ impl PublicKey {
     pub fn from_der(input: &[u8]) -> Result<Self, KeyRejected> {
         // These both invoke `RSA_check_key`:
         // https://github.com/aws/aws-lc/blob/4368aaa6975ba41bd76d3bb12fac54c4680247fb/crypto/rsa_extra/rsa_asn1.c#L105-L109
-        let evp_pkey =
-            rfc8017::decode_public_key_der(input).or(rfc5280::decode_public_key_der(input))?;
-        if is_rsa_key(&evp_pkey) {
-            PublicKey::new(&evp_pkey)
-        } else {
-            Err(KeyRejected::wrong_algorithm())
-        }
+        PublicKey::new(
+            &rfc8017::decode_public_key_der(input).or(rfc5280::decode_public_key_der(input))?,
+        )
     }
 }
 

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -819,16 +819,33 @@ fn min_encrypt_key() {
     const PUBLIC_KEY: &[u8] = include_bytes!("data/rsa_test_public_key_2048.x509");
 
     let parsed_private_key = PrivateDecryptingKey::from_pkcs8(PRIVATE_KEY).expect("key supported");
+    let signing_priv_key = RsaKeyPair::from_pkcs8(PRIVATE_KEY).expect("key supported");
     let parsed_public_key = PublicEncryptingKey::from_der(PUBLIC_KEY).expect("key supported");
+    let parsed_signing_public_key =
+        RsaSubjectPublicKey::from_der(PUBLIC_KEY).expect("key supported");
 
-    let public_key = parsed_private_key.public_key();
+    let derived_public_key = parsed_private_key.public_key();
+    let derived_signing_public_key = signing_priv_key.public_key();
 
     let private_key_bytes =
         AsDer::<Pkcs8V1Der>::as_der(&parsed_private_key).expect("serializeable");
-    let public_key_bytes = AsDer::<PublicKeyX509Der>::as_der(&public_key).expect("serializeable");
+    let signing_private_key_bytes =
+        AsDer::<Pkcs8V1Der>::as_der(&signing_priv_key).expect("serializeable");
+    let parsed_public_key_bytes =
+        AsDer::<PublicKeyX509Der>::as_der(&parsed_public_key).expect("serializeable");
+    let parsed_signing_public_key_bytes =
+        AsDer::<PublicKeyX509Der>::as_der(&parsed_signing_public_key).expect("serializeable");
+    let derived_public_key_bytes =
+        AsDer::<PublicKeyX509Der>::as_der(&derived_public_key).expect("serializeable");
+    let derived_signing_public_key_bytes =
+        AsDer::<PublicKeyX509Der>::as_der(derived_signing_public_key).expect("serializeable");
 
     assert_eq!(PRIVATE_KEY, private_key_bytes.as_ref());
-    assert_eq!(PUBLIC_KEY, public_key_bytes.as_ref());
+    assert_eq!(PRIVATE_KEY, signing_private_key_bytes.as_ref());
+    assert_eq!(PUBLIC_KEY, parsed_public_key_bytes.as_ref());
+    assert_eq!(PUBLIC_KEY, parsed_signing_public_key_bytes.as_ref());
+    assert_eq!(PUBLIC_KEY, derived_public_key_bytes.as_ref());
+    assert_eq!(PUBLIC_KEY, derived_signing_public_key_bytes.as_ref());
 
     let oaep_parsed_private =
         OaepPrivateDecryptingKey::new(parsed_private_key.clone()).expect("supported key");


### PR DESCRIPTION
### Issues:
Addresses #741

### Description of changes: 
* Support `RsaSubjectPublicKey` serialization to/from X509
* Bump the patch version to 1.12.7.

### Testing:
Added test coverage for new functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
