### PR TITLE
Update to bindgen 0.71.1

### DIFF
--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -70,10 +70,10 @@ cc = "1.0.100"
 regex = "1"
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")))'.build-dependencies]
-bindgen = { version = "0.69.5", optional = true }
+bindgen = { version = "0.71.1", optional = true }
 
 [target.'cfg(not(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = ""))))'.build-dependencies]
-bindgen = { version = "0.69.5" }
+bindgen = { version = "0.71.1" }
 
 [dev-dependencies]
 # Pinned dependency to preserve MSRV: 1.60.0  <= rust-version < 1.65.0

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -57,10 +57,6 @@ lazy_static = "1.4.0"
 clap = { version = "4.1.8", features = ["derive"] }
 hex = "0.4.3"
 
-# Pinned dependency to preserve MSRV: 1.63.0 <= rust-version < 1.70.0
-which = "5.0.0"
-# Pinned dependency to preserve MSRV: ??? <= rust-version < 1.70.0
-home = "=0.5.5"
 # Pinned dependency to preserve MSRV: 1.60.0  <= rust-version < 1.65.0
 regex = "<1.10.0"
 # Pinned dependency to preserve MSRV: ??? <= rust-version < 1.65.0
@@ -73,4 +69,4 @@ proc-macro2 = "1.0.60"
 once_cell = "~1.20.3"
 
 [package.metadata.cargo-udeps.ignore]
-development = ["which", "home", "regex", "regex-automata", "regex-syntax", "proc-macro2", "jobserver", "cc", "once_cell"]
+development = ["regex", "regex-automata", "regex-syntax", "proc-macro2", "jobserver", "cc", "once_cell"]

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -62,10 +62,10 @@ fs_extra = "1.3"
 cc = { version = "1.0.100", features = ["parallel"] }
 
 [target.'cfg(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu")))'.build-dependencies]
-bindgen = { version = "0.69.5", optional = true }
+bindgen = { version = "0.71.1", optional = true }
 
 [target.'cfg(not(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu"))))'.build-dependencies]
-bindgen = { version = "0.69.5" }
+bindgen = { version = "0.71.1" }
 
 [package.metadata.aws-lc-sys]
 commit-hash = "8a9ebcfdcf8bb4a685ca83646265ea0aab85c3c8"

--- a/aws-lc-sys/builder/sys_bindgen.rs
+++ b/aws-lc-sys/builder/sys_bindgen.rs
@@ -65,7 +65,11 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: &BindingOptions) -> bi
         .allowlist_file(r".*(/|\\)openssl((/|\\)[^/\\]+)+\.h")
         .allowlist_file(r".*(/|\\)rust_wrapper\.h")
         .rustified_enum(r"point_conversion_form_t")
-        .rust_target(bindgen::RustTarget::Stable_1_59)
+        .rust_target(
+            bindgen::RustTarget::stable(59, 0)
+                .map_err(|x| x.to_string())
+                .unwrap(),
+        )
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
         .generate_comments(true)
         .fit_macro_constants(false)


### PR DESCRIPTION
### Issues:
No issue, this seems straightforward, if its not straightforward I can raise an issue.

### Description of changes: 

Bindgen 0.70 removes the dependency on `which` and `home`.
So upgrading from 0.69 to 0.71 will reduce the number of dependencies users need to pull in and improve build times.

I think that on most platforms, in standard configurations, aws-lc-rs doesnt actually depend on bindgen.
However due to cargo's design, `bindgen`, `which` and `home` are all included in the Cargo.lock but not actually built.
This requires users to drill down into their dependencies and manually inspect feature combinations and platforms to realize that bindgens `which` and `home` deps are not actually being built.

So to ease this pain lets upgrade to bindgen 0.71.

### Call-outs:
None

### Testing:
I built it locally on mac os with `--features bindgen`, I expect CI to thoroughly test different platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
