### PR TITLE
aws-lc-sys: output only one library

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -377,16 +377,15 @@ impl CcBuilder {
             cc_build.flag(flag);
         }
         self.run_compiler_checks(&mut cc_build);
-        let mut archiver = cc_build.clone();
 
-        let mut object_files = self.add_all_files(lib, &mut cc_build);
-        object_files.extend(cc_build.compile_intermediates());
-
-        archiver.objects(object_files);
+        let object_files = self.add_all_files(lib, &mut cc_build);
+        for object in object_files {
+            cc_build.object(object);
+        }
         if let Some(prefix) = &self.build_prefix {
-            archiver.compile(format!("{}_crypto", prefix.as_str()).as_str());
+            cc_build.compile(format!("{}_crypto", prefix.as_str()).as_str());
         } else {
-            archiver.compile(lib.name);
+            cc_build.compile(lib.name);
         }
     }
 


### PR DESCRIPTION
### Description of changes: 
Change build script to only produce a single library for linking.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
