### PR TITLE
Include Go source in `aws-lc-sys` crate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -553,19 +553,25 @@ jobs:
   cmake-source-path-has-spaces:
     if: github.repository_owner == 'aws'
     name:
-      "Spaces in path (CMake) - ${{ matrix.os }}"
+      "Spaces in path (CMake) - ${{ matrix.os }} - pregen-src: ${{ matrix.pregen_src }}"
     runs-on: ${{ matrix.os }}
     env:
       AWS_LC_SYS_CMAKE_BUILDER: 1
+      AWS_LC_SYS_NO_PREGENERATED_SRC: ${{ matrix.pregen_src }}
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        pregen_src: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
           path: "path has spaces/aws-lc-rs"
+      - if: ${{ matrix.pregen_src == 1 }}
+        shell: bash
+        run: |
+          rm -rf ./aws-lc-sys/aws-lc/generated-src/*
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/setup-nasm@v1
       - uses: dtolnay/rust-toolchain@stable

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -19,6 +19,7 @@ include = [
     "/aws-lc/**/CMakeLists.txt",
     "/aws-lc/**/*.cmake",
     "/aws-lc/**/*.errordata",
+    "/aws-lc/**/*.go",
     "/aws-lc/**/*.lds",
     "!/aws-lc/bindings/**",
     "!/aws-lc/docs/**",

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -40,6 +40,7 @@ include = [
     "/CMakeLists.txt",
     "/builder/**/*.rs",
     "/builder/**/*.bat",
+    "/builder/**/*.sh",
     "/builder/**/*.obj",
     "/Cargo.toml",
     "/generated-include/**",

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -19,7 +19,7 @@ include = [
     "/aws-lc/**/CMakeLists.txt",
     "/aws-lc/**/*.cmake",
     "/aws-lc/**/*.errordata",
-    "/aws-lc/**/*.go",
+    "/aws-lc/**/err_data_generate.go",
     "/aws-lc/**/*.lds",
     "!/aws-lc/bindings/**",
     "!/aws-lc/docs/**",

--- a/aws-lc-sys/builder/main.rs
+++ b/aws-lc-sys/builder/main.rs
@@ -360,7 +360,7 @@ fn get_builder(prefix: &Option<String>, manifest_dir: &Path, out_dir: &Path) -> 
         ))
     };
 
-    if let Some(val) = env_var_to_bool("AWS_LC_SYS_CMAKE_BUILDER") {
+    if let Some(val) = is_cmake_builder() {
         let builder: Box<dyn Builder> = if val {
             cmake_builder_builder()
         } else {
@@ -420,6 +420,8 @@ static mut AWS_LC_SYS_EXTERNAL_BINDGEN: bool = false;
 static mut AWS_LC_SYS_NO_ASM: bool = false;
 static mut AWS_LC_SYS_CFLAGS: String = String::new();
 static mut AWS_LC_SYS_PREBUILT_NASM: Option<bool> = None;
+static mut AWS_LC_SYS_CMAKE_BUILDER: Option<bool> = None;
+static mut AWS_LC_SYS_NO_PREGENERATED_SRC: bool = false;
 
 static mut AWS_LC_SYS_C_STD: CStdRequested = CStdRequested::None;
 
@@ -434,6 +436,9 @@ fn initialize() {
         AWS_LC_SYS_CFLAGS = option_env("AWS_LC_SYS_CFLAGS").unwrap_or_default();
         AWS_LC_SYS_PREBUILT_NASM = env_var_to_bool("AWS_LC_SYS_PREBUILT_NASM");
         AWS_LC_SYS_C_STD = CStdRequested::from_env();
+        AWS_LC_SYS_CMAKE_BUILDER = env_var_to_bool("AWS_LC_SYS_CMAKE_BUILDER");
+        AWS_LC_SYS_NO_PREGENERATED_SRC =
+            env_var_to_bool("AWS_LC_SYS_NO_PREGENERATED_SRC").unwrap_or(false);
     }
 
     if !is_external_bindgen() && (is_pregenerating_bindings() || !has_bindgen_feature()) {
@@ -493,6 +498,18 @@ fn is_external_bindgen() -> bool {
 
 fn is_no_asm() -> bool {
     unsafe { AWS_LC_SYS_NO_ASM }
+}
+
+fn is_cmake_builder() -> Option<bool> {
+    if is_no_pregenerated_src() {
+        Some(true)
+    } else {
+        unsafe { AWS_LC_SYS_CMAKE_BUILDER }
+    }
+}
+
+fn is_no_pregenerated_src() -> bool {
+    unsafe { AWS_LC_SYS_NO_PREGENERATED_SRC }
 }
 
 #[allow(unknown_lints)]


### PR DESCRIPTION
### Issues
* #752
* #753

### Description of changes: 
* Include `err_data_generate.go` and `prebuilt-nasm.sh` in the `aws-lc-sys` crate
* Add support for `AWS_LC_SYS_NO_PREGENERATED_SRC` environment variable that will prevent any pregenerated code from being used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
