### PR TITLE
Cleanup environment variable usage

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -150,6 +150,8 @@ jobs:
     if: github.repository_owner == 'aws'
     name: C-std ${{ matrix.os }} - ${{ matrix.c_std }} - Force CMake ${{ matrix.cmake }}
     runs-on: ${{ matrix.os }}
+    env:
+      AWS_LC_SYS_CMAKE_BUILDER: ${{ matrix.cmake }}
     strategy:
       fail-fast: false
       matrix:
@@ -165,9 +167,8 @@ jobs:
         id: toolchain
         with:
           toolchain: stable
-      - run: |
-          echo 'export AWS_LC_SYS_CMAKE_BUILDER=${{ matrix.cmake }}' >> "$GITHUB_ENV"
-      - name: Run cargo test
+      - if: ${{ !startsWith(matrix.os, 'windows-') || matrix.cmake == '1' }} # Windows requires CMake build
+        name: Run cargo test
         working-directory: ./aws-lc-rs
         env:
           AWS_LC_SYS_PREBUILT_NASM: 1

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -42,7 +42,7 @@ jobs:
           - [ powerpc64le-unknown-linux-gnu, 1, 0 ]
           - [ riscv64gc-unknown-linux-gnu, 0, 1 ]
           - [ s390x-unknown-linux-gnu, 0, 1 ]
-          - [ x86_64-pc-windows-gnu, 0, 1 ]
+          - [ x86_64-pc-windows-gnu, 0, 1 ] # Requires release build. See: https://github.com/rust-lang/rust/issues/139380
           - [ x86_64-unknown-linux-musl, 0, 1 ]
           - [ x86_64-unknown-illumos, 0, 0 ]
     steps:
@@ -92,7 +92,7 @@ jobs:
         if: ${{ matrix.target[0] != 'arm-linux-androideabi' }}
         run: |
           unset AWS_LC_SYS_EXTERNAL_BINDGEN
-          cross test -p aws-lc-sys "${CROSS_TEST_EXTRA_FLAG}" --features ssl --target ${{ matrix.target[0] }}
+          cross test -p aws-lc-sys --release "${CROSS_TEST_EXTRA_FLAG}" --features ssl --target ${{ matrix.target[0] }}
 
   aws-lc-rs-cross-0_2_5-test:
     if: github.repository_owner == 'aws'

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -136,8 +136,6 @@ jobs:
           submodules: "recursive"
       - run: |
           brew install llvm
-          echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"'
-          echo 'export LIBCLANG_PATH=/opt/homebrew/opt/llvm' >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
@@ -158,8 +156,6 @@ jobs:
           submodules: "recursive"
       - run: |
           brew install llvm
-          echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"'
-          echo 'export LIBCLANG_PATH=/opt/homebrew/opt/llvm' >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -51,6 +51,14 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.18'
+      - if: ${{ startsWith( matrix.os, 'macos-') }}
+        name: Update Cmake
+        # Use latest CMake
+        run: |
+          brew update
+          brew upgrade cmake
+          cmake --version
+          echo 'CMAKE=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/bin/cmake' >> $GITHUB_ENV
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -213,8 +213,8 @@ jobs:
       - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
-          echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"'
-          echo 'export LIBCLANG_PATH=/opt/homebrew/opt/llvm' >> "$GITHUB_ENV"
+          echo 'LIBCLANG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/lib' >> $GITHUB_ENV
+          echo 'LLVM_CONFIG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
       - name: Install NASM on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -495,6 +495,9 @@ jobs:
     if: github.repository_owner == 'aws'
     name: Clang 19.1 + bindgen tests
     runs-on: macos-14-xlarge
+    env:
+      LIBCLANG_PATH: '/opt/homebrew/opt/llvm@19/lib'
+      LLVM_CONFIG_PATH: '/opt/homebrew/opt/llvm@19/bin/llvm-config'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -510,8 +513,6 @@ jobs:
           brew update
           brew uninstall --force llvm
           brew install llvm@19
-          echo 'LIBCLANG_PATH=/opt/homebrew/opt/llvm@19/lib' >> $GITHUB_ENV
-          echo 'LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm@19/bin/llvm-config' >> $GITHUB_ENV
       - name: aws-lc-sys bindgen build
         working-directory: ./aws-lc-sys
         run: cargo test --features bindgen

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -578,6 +578,14 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.18'
+      - if: ${{ startsWith( matrix.os, 'macos-') }}
+        name: Update Cmake
+        # Use latest CMake
+        run: |
+          brew update
+          brew upgrade cmake
+          cmake --version
+          echo 'CMAKE=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/bin/cmake' >> $GITHUB_ENV
       - name: Run cargo test
         working-directory: "path has spaces/aws-lc-rs"
         run: cargo test --tests -p aws-lc-rs --features bindgen

--- a/aws-lc-fips-sys/builder/cmake_builder.rs
+++ b/aws-lc-fips-sys/builder/cmake_builder.rs
@@ -238,9 +238,16 @@ impl CmakeBuilder {
             }
             if target_os().trim() == "ios" {
                 cmake_cfg.define("CMAKE_SYSTEM_NAME", "iOS");
-                if effective_target().trim().ends_with("-ios-sim") {
+                if effective_target().ends_with("-ios-sim") || target_arch() == "x86_64" {
                     cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphonesimulator");
+                } else {
+                    cmake_cfg.define("CMAKE_OSX_SYSROOT", "iphoneos");
                 }
+                cmake_cfg.define("CMAKE_THREAD_LIBS_INIT", "-lpthread");
+            }
+            if target_os().trim() == "macos" {
+                cmake_cfg.define("CMAKE_SYSTEM_NAME", "Darwin");
+                cmake_cfg.define("CMAKE_OSX_SYSROOT", "macosx");
             }
         }
 

--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -16,8 +16,8 @@ mod x86_64_unknown_linux_musl;
 
 use crate::{
     cargo_env, effective_target, emit_warning, env_var_to_bool, execute_command, get_crate_cflags,
-    is_no_asm, option_env, out_dir, requested_c_std, target, target_arch, target_env, target_os,
-    target_vendor, CStdRequested, OutputLibType,
+    is_no_asm, optional_env_optional_crate_target, out_dir, requested_c_std, set_env_for_target,
+    target, target_arch, target_env, target_os, target_vendor, CStdRequested, OutputLibType,
 };
 use std::path::PathBuf;
 
@@ -28,7 +28,7 @@ pub(crate) struct CcBuilder {
     output_lib_type: OutputLibType,
 }
 
-use std::{env, fs};
+use std::fs;
 
 pub(crate) struct Library {
     name: &'static str,
@@ -198,11 +198,11 @@ impl CcBuilder {
             }
         }
 
-        if let Some(cc) = option_env("CC") {
-            emit_warning(&format!("CC environment variable set: {}", cc.clone()));
+        if let Some(cc) = optional_env_optional_crate_target("CC") {
+            set_env_for_target("CC", &cc);
         }
-        if let Some(cxx) = option_env("CXX") {
-            emit_warning(&format!("CXX environment variable set: {}", cxx.clone()));
+        if let Some(cxx) = optional_env_optional_crate_target("CXX") {
+            set_env_for_target("CC", &cxx);
         }
 
         if target_arch() == "x86" && !compiler_is_msvc {
@@ -328,10 +328,7 @@ impl CcBuilder {
         }
         let cflags = get_crate_cflags();
         if !cflags.is_empty() {
-            emit_warning(&format!(
-                "AWS_LC_SYS_CFLAGS found. Setting CFLAGS: '{cflags}'"
-            ));
-            env::set_var("CFLAGS", cflags);
+            set_env_for_target("CFLAGS", cflags);
         }
         cc_build
     }

--- a/aws-lc-sys/builder/cmake_builder.rs
+++ b/aws-lc-sys/builder/cmake_builder.rs
@@ -5,8 +5,9 @@ use crate::cc_builder::CcBuilder;
 use crate::OutputLib::{Crypto, RustWrapper, Ssl};
 use crate::{
     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
-    get_crate_cflags, is_crt_static, is_no_asm, is_no_pregenerated_src, option_env, target_arch,
-    target_env, target_os, target_underscored, test_nasm_command, use_prebuilt_nasm, OutputLibType,
+    get_crate_cflags, is_crt_static, is_no_asm, is_no_pregenerated_src, optional_env,
+    optional_env_optional_crate_target, set_env, set_env_for_target, target_arch, target_env,
+    target_os, test_nasm_command, use_prebuilt_nasm, OutputLibType,
 };
 use std::env;
 use std::ffi::OsString;
@@ -24,7 +25,7 @@ fn test_clang_cl_command() -> bool {
 }
 
 fn find_cmake_command() -> Option<OsString> {
-    if let Some(cmake) = option_env("CMAKE") {
+    if let Some(cmake) = optional_env_optional_crate_target("CMAKE") {
         emit_warning(&format!(
             "CMAKE environment variable set: {}",
             cmake.clone()
@@ -88,6 +89,9 @@ impl CmakeBuilder {
     #[allow(clippy::too_many_lines)]
     fn prepare_cmake_build(&self) -> cmake::Config {
         let mut cmake_cfg = self.get_cmake_config();
+        if let Some(generator) = optional_env_optional_crate_target("CMAKE_GENERATOR") {
+            set_env("CMAKE_GENERATOR", generator);
+        }
 
         if OutputLibType::default() == OutputLibType::Dynamic {
             cmake_cfg.define("BUILD_SHARED_LIBS", "1");
@@ -131,24 +135,20 @@ impl CmakeBuilder {
         }
 
         if cfg!(feature = "asan") {
-            env::set_var("CC", "clang");
-            env::set_var("CXX", "clang++");
-            env::set_var("ASM", "clang");
+            set_env_for_target("CC", "clang");
+            set_env_for_target("CXX", "clang++");
 
             cmake_cfg.define("ASAN", "1");
         }
 
-        if target_env() == "ohos" {
-            Self::configure_open_harmony(&mut cmake_cfg, get_crate_cflags());
-            return cmake_cfg;
-        }
-
         let cflags = get_crate_cflags();
         if !cflags.is_empty() {
-            emit_warning(&format!(
-                "AWS_LC_SYS_CFLAGS found. Setting CFLAGS: '{cflags}'"
-            ));
-            env::set_var("CFLAGS", cflags);
+            set_env_for_target("CFLAGS", cflags);
+        }
+
+        if target_env() == "ohos" {
+            Self::configure_open_harmony(&mut cmake_cfg);
+            return cmake_cfg;
         }
 
         // cmake-rs has logic that strips Optimization/Debug options that are passed via CFLAGS:
@@ -158,13 +158,8 @@ impl CmakeBuilder {
         Self::preserve_cflag_optimization_flags(&mut cmake_cfg);
 
         // Allow environment to specify CMake toolchain.
-        let toolchain_var_name = format!("CMAKE_TOOLCHAIN_FILE_{}", target_underscored());
-        if let Some(toolchain) =
-            option_env(&toolchain_var_name).or(option_env("CMAKE_TOOLCHAIN_FILE"))
-        {
-            emit_warning(&format!(
-                "CMAKE_TOOLCHAIN_FILE environment variable set: {toolchain}"
-            ));
+        if let Some(toolchain) = optional_env_optional_crate_target("CMAKE_TOOLCHAIN_FILE") {
+            set_env_for_target("CMAKE_TOOLCHAIN_FILE", toolchain);
             return cmake_cfg;
         }
         // We only consider compiler CFLAGS when no cmake toolchain is set
@@ -227,18 +222,18 @@ impl CmakeBuilder {
         // https://github.com/rust-lang/cmake-rs/blob/b689783b5448966e810d515c798465f2e0ab56fd/src/lib.rs#L450-L499
 
         // Log relevant environment variables.
-        if let Some(value) = option_env("ANDROID_NDK_ROOT") {
-            emit_warning(&format!("Found ANDROID_NDK_ROOT={value}"));
+        if let Some(value) = optional_env_optional_crate_target("ANDROID_NDK_ROOT") {
+            set_env("ANDROID_NDK_ROOT", value);
         } else {
             emit_warning("ANDROID_NDK_ROOT not set.");
         }
-        if let Some(value) = option_env("ANDROID_NDK") {
-            emit_warning(&format!("Found ANDROID_NDK={value}"));
+        if let Some(value) = optional_env_optional_crate_target("ANDROID_NDK") {
+            set_env("ANDROID_NDK", value);
         } else {
             emit_warning("ANDROID_NDK not set.");
         }
-        if let Some(value) = option_env("ANDROID_STANDALONE_TOOLCHAIN") {
-            emit_warning(&format!("Found ANDROID_STANDALONE_TOOLCHAIN={value}"));
+        if let Some(value) = optional_env_optional_crate_target("ANDROID_STANDALONE_TOOLCHAIN") {
+            set_env("ANDROID_STANDALONE_TOOLCHAIN", value);
         } else {
             emit_warning("ANDROID_STANDALONE_TOOLCHAIN not set.");
         }
@@ -247,16 +242,21 @@ impl CmakeBuilder {
     fn configure_windows(&self, cmake_cfg: &mut cmake::Config) {
         match (target_env().as_str(), target_arch().as_str()) {
             ("msvc", "aarch64") => {
-                cmake_cfg.generator_toolset(format!(
-                    "ClangCL{}",
-                    if cfg!(target_arch = "x86_64") {
-                        ",host=x64"
-                    } else {
-                        ""
-                    }
-                ));
+                // If CMAKE_GENERATOR is either not set or not set to "Ninja"
+                let cmake_generator = optional_env("CMAKE_GENERATOR");
+                if cmake_generator.is_none() || cmake_generator.unwrap().to_lowercase() != "ninja" {
+                    // The following is not supported by the Ninja generator
+                    cmake_cfg.generator_toolset(format!(
+                        "ClangCL{}",
+                        if cfg!(target_arch = "x86_64") {
+                            ",host=x64"
+                        } else {
+                            ""
+                        }
+                    ));
+                    cmake_cfg.define("CMAKE_GENERATOR_PLATFORM", "ARM64");
+                }
                 cmake_cfg.static_crt(is_crt_static());
-                cmake_cfg.define("CMAKE_GENERATOR_PLATFORM", "ARM64");
                 cmake_cfg.define("CMAKE_SYSTEM_NAME", "Windows");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", "ARM64");
             }
@@ -321,25 +321,20 @@ impl CmakeBuilder {
         }
     }
 
-    fn configure_open_harmony(cmake_cfg: &mut cmake::Config, crate_cflags: &str) {
-        env::set_var("CFLAGS", crate_cflags);
+    fn configure_open_harmony(cmake_cfg: &mut cmake::Config) {
         let mut cflags = vec!["-Wno-unused-command-line-argument"];
         let mut asmflags = vec![];
 
-        let toolchain_var_name = format!("CMAKE_TOOLCHAIN_FILE_{}", target_underscored());
         // If a toolchain is not specified by the environment
-        if option_env(&toolchain_var_name)
-            .or(option_env("CMAKE_TOOLCHAIN_FILE"))
-            .is_none()
-        {
+        if optional_env_optional_crate_target("CMAKE_TOOLCHAIN_FILE").is_none() {
             if let Ok(ndk) = env::var("OHOS_NDK_HOME") {
-                env::set_var(
-                    toolchain_var_name,
+                set_env_for_target(
+                    "CMAKE_TOOLCHAIN_FILE",
                     format!("{ndk}/native/build/cmake/ohos.toolchain.cmake"),
                 );
             } else if let Ok(sdk) = env::var("OHOS_SDK_NATIVE") {
-                env::set_var(
-                    toolchain_var_name,
+                set_env_for_target(
+                    "CMAKE_TOOLCHAIN_FILE",
                     format!("{sdk}/build/cmake/ohos.toolchain.cmake"),
                 );
             } else {


### PR DESCRIPTION
### Issues:
Addresses:
* #765 
* #764 

### Description of changes: 
* Improvements/fixes for how a few CI tests were setting up environment variables.
* Fix MacOS FIPS build for CMake 4.0.
* Support, and give preference to, target-specific environment variables. 
* Support an `AWS_LC_SYS_EFFECTIVE_TARGET` environment variable.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
