### PR TITLE
Implement `AsRef<[u8]>` for `UnparsedPublicKey`

### DIFF
--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -360,6 +360,13 @@ impl<B: AsRef<[u8]>> Debug for UnparsedPublicKey<B> {
     }
 }
 
+impl<B: AsRef<[u8]>> AsRef<[u8]> for UnparsedPublicKey<B> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
 impl<B: AsRef<[u8]>> UnparsedPublicKey<B> {
     /// Construct a new `UnparsedPublicKey`.
     ///

--- a/aws-lc-rs/tests/ecdsa_tests.rs
+++ b/aws-lc-rs/tests/ecdsa_tests.rs
@@ -184,7 +184,10 @@ fn test_signature_ecdsa_verify_asn1(data_file: test::File) {
             }
         };
 
-        let actual_result = UnparsedPublicKey::new(alg, &public_key).verify(&msg, &sig);
+        let upk = UnparsedPublicKey::new(alg, &public_key);
+        assert_eq!(upk.as_ref(), public_key.as_slice());
+
+        let actual_result = upk.verify(&msg, &sig);
         assert_eq!(actual_result.is_ok(), is_valid);
 
         Ok(())


### PR DESCRIPTION
### Issues:
Resolves #788 

### Description of changes: 
 
Implement the `AsRef<[u8]>` trait for the UnparsedPublicKey type to get access to the raw key. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.