### PR TITLE
Update for s2n-bignum-imported

### DIFF
--- a/scripts/build/collect_build_src.sh
+++ b/scripts/build/collect_build_src.sh
@@ -131,7 +131,7 @@ function cleanup_source_files() {
             #FILE=$(realpath "${FILE}")
             echo "${FILE}" | \
                 sed -e "s/.*\/aws-lc-sys\/aws-lc\///" | \
-                sed -e "s/.*\/out\/build\/aws-lc\/crypto\/fipsmodule\/\(.*\.S\)\.S$/third_party\/s2n-bignum\/${S2N_BN_DIR}\/\1/" | \
+                sed -e "s/.*\/out\/build\/aws-lc\/crypto\/fipsmodule\/\(.*\.S\)\.S$/third_party\/s2n-bignum\/s2n-bignum-imported\/${S2N_BN_DIR}\/\1/" | \
                 sed -e "s/.*\/out\/build\/aws-lc\//generated-src\/${GS_DIR}\//" | \
                 sed -e 's/\(.*\)\/[^\/]*\/crypto\/err_data\.c/\1\/err_data.c/'
         fi


### PR DESCRIPTION
### Description of changes: 
Recent [commit upstream](https://github.com/aws/aws-lc/pull/2324) changed the directory that the s2n-bignum source files are located.
* Due to factors unique to ARM64 macOS, the debug information in the binary points to post-processed s2n-bignum source files in the build directory instead of their original location. The script was making a bad assumption as to the original location of the s2n-bignum source files.

### Callout
* The "aws-lc-rs" CI integration test for AWS-LC will continue to fail until this is merged.

### Testing
* I updated my local workspace to align with the latest aws-lc commit on main. I then ran the `test-bindgen-pregen.sh` script to verify that it succeeds against the latest commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
