### PR TITLE
Update MacOS GH runners

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -145,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -176,7 +176,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -156,7 +156,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, macos-latest, windows-latest ]
         c_std: [ "11", "99" ]
         cmake: [ '0', '1' ]
     steps:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -129,7 +129,7 @@ jobs:
   aws-lc-rs-ios-aarch64:
     if: github.repository_owner == 'aws'
     name: iOS aarch64 cross-platform build
-    runs-on: macos-14-xlarge
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -149,7 +149,7 @@ jobs:
   aws-lc-rs-ios-x86_64:
     if: github.repository_owner == 'aws'
     name: iOS x86-64 cross-platform build
-    runs-on: macos-14-xlarge
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/fips-bindings-generator.yml
+++ b/.github/workflows/fips-bindings-generator.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         args:
           - --release --all-targets --features fips,unstable
           - --profile release-lto --all-targets --features fips,unstable

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
     env:
       GIT_CLONE_PROTECTION_ACTIVE: false
     steps:
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         latest: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
         features: [ aws-lc-rs, aws-lc-rs-fips, aws-lc-sys, aws-lc-fips-sys ]
     steps:
       - uses: actions/checkout@v3
@@ -158,7 +158,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ windows-latest, ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ windows-latest, ubuntu-latest, macos-13, macos-latest ]
         crate: [ aws-lc-sys, aws-lc-rs, aws-lc-fips-sys ]
         args:
           - publish --dry-run
@@ -232,7 +232,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/sys-bindings-generator.yml
+++ b/.github/workflows/sys-bindings-generator.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -244,7 +244,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-14 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         args:
           - --all-targets --features unstable
           - --release --all-targets --features unstable
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         args:
           - --no-default-features --features aws-lc-sys,bindgen,unstable
           - --release --all-targets --features bindgen,unstable
@@ -189,7 +189,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         static: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -274,7 +274,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -331,7 +331,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         static: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -354,7 +354,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -389,7 +389,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -428,7 +428,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -460,7 +460,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-13
-          - macos-14-xlarge
+          - macos-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -494,7 +494,7 @@ jobs:
   clang-19-bindgen:
     if: github.repository_owner == 'aws'
     name: Clang 19.1 + bindgen tests
-    runs-on: macos-14-xlarge
+    runs-on: macos-latest
     env:
       LIBCLANG_PATH: '/opt/homebrew/opt/llvm@19/lib'
       LLVM_CONFIG_PATH: '/opt/homebrew/opt/llvm@19/bin/llvm-config'
@@ -528,7 +528,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
         fips: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -545,7 +545,7 @@ jobs:
       - name: Run cargo test
         # macOS aarch64 fix for FIPS pending the following PR applied to FIPS branch:
         # https://github.com/aws/aws-lc/pull/2005
-        if: ${{ matrix.fips == 0 || matrix.os != 'macos-14-xlarge' }}
+        if: ${{ matrix.fips == 0 || matrix.os != 'macos-latest' }}
         working-directory: "path has spaces/aws-lc-rs"
         run: cargo test --tests -p aws-lc-rs --no-default-features --features ${{ (matrix.fips == 1 && 'fips') || 'aws-lc-sys' }}
 
@@ -560,7 +560,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14-xlarge ]
+        os: [ ubuntu-latest, macos-13, macos-latest ]
         pregen_src: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description of changes: 
Update macOS GH runners.

### Call-outs:
The following runner information can be found [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

| Virtual Machine | Processor (CPU) | Memory (RAM) | Storage (SSD) | Architecture | Workflow label |
|-----------------|----------------|--------------|--------------|--------------|----------------|
| macOS | 4 | 14 GB | 14 GB | Intel | macos-13 |
| macOS | 3 (M1) | 7 GB | 14 GB | arm64 | macos-latest, macos-14, macos-15 |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
