### PR TITLE
Align aws-lc-sys v0.30.0 w/ AWS-LC 1.51.0

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -47,7 +47,7 @@ fips = ["dep:aws-lc-fips-sys"]
 
 [dependencies]
 untrusted = { version = "0.7.1", optional = true }
-aws-lc-sys = { version = "0.29.0", path = "../aws-lc-sys", optional = true }
+aws-lc-sys = { version = "0.30.0", path = "../aws-lc-sys", optional = true }
 aws-lc-fips-sys = { version = "0.13.1", path = "../aws-lc-fips-sys", optional = true }
 zeroize = "1.7"
 

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "aws-lc-sys"
 description = "AWS-LC is a general-purpose cryptographic library maintained by the AWS Cryptography team for AWS and their customers. It іs based on code from the Google BoringSSL project and the OpenSSL project."
-version = "0.29.0"
-links = "aws_lc_0_29_0"
+version = "0.30.0"
+links = "aws_lc_0_30_0"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"


### PR DESCRIPTION
### Issues:
Resolves `CryptoAlg-3084`

### Description of changes: 
Bump aws-lc-sys to v0.30.0. Aligns with [AWS-LC v1.51.0](https://github.com/aws/aws-lc/releases/tag/v1.51.0). needed for new APIs from: https://github.com/aws/aws-lc/commit/995e1231539e3e1cd0c7d8f34c6fc0ac49b8755c

### Call-outs:
Manual commit: https://github.com/aws/aws-lc-rs/commit/a83e32cb94d2879e60dae8adce0493ed5dfd76cd


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
