### PR TITLE
Disallow external bindgen when AWS_LC_SYS_EXTERNAL_BINDGEN=0

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -48,7 +48,7 @@ jobs:
           - [ powerpc64-unknown-linux-gnu, 1, 0 ]
           - [ powerpc64le-unknown-linux-gnu, 1, 0 ]
           - [ riscv64gc-unknown-linux-gnu, 0, 1 ]
-          - [ s390x-unknown-linux-gnu, 0, 1 ]
+          - [ s390x-unknown-linux-gnu, 0, 0 ]
           - [ x86_64-pc-windows-gnu, 0, 1 ] # Requires release build. See: https://github.com/rust-lang/rust/issues/139380
           - [ x86_64-unknown-linux-musl, 0, 1 ]
           - [ x86_64-unknown-illumos, 0, 0 ]

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -23,6 +23,12 @@ jobs:
     if: github.repository_owner == 'aws'
     name: cross tests ${{ matrix.target[0] }}
     runs-on: ubuntu-22.04
+    env:
+      # The flag below is set to avoid the following error with GCC 11.4.0 on the riscv64 platform:
+      #   /home/runner/work/aws-lc-rs/aws-lc-rs/aws-lc-sys/aws-lc/crypto/pem/pem_lib.c:707:11: error: 'strncmp' of strings of length 1 and 9 and bound of 9 evaluates to nonzero [-Werror=string-compare]
+      #    707 |       if (strncmp(buf, "-----END ", 9) == 0) {
+      #        |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      AWS_LC_SYS_CFLAGS_riscv64gc_unknown_linux_gnu: '-Wno-string-compare'
     strategy:
       fail-fast: false
       matrix:
@@ -62,13 +68,6 @@ jobs:
           target: ${{ matrix.target[0] }}
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
-      # The flag below is set to avoid the following error with GCC 11.4.0 on the riscv64 platform:
-      #   /home/runner/work/aws-lc-rs/aws-lc-rs/aws-lc-sys/aws-lc/crypto/pem/pem_lib.c:707:11: error: 'strncmp' of strings of length 1 and 9 and bound of 9 evaluates to nonzero [-Werror=string-compare]
-      #    707 |       if (strncmp(buf, "-----END ", 9) == 0) {
-      #        |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      - if: ${{ matrix.target[0] == 'riscv64gc-unknown-linux-gnu' }}
-        run: |
-          echo 'AWS_LC_SYS_CFLAGS=-Wno-string-compare' >> "$GITHUB_ENV"
       - if: ${{ !startsWith(matrix.target[0], 'x86_64') }}
         run: |
           echo 'AWS_LC_RS_DISABLE_SLOW_TESTS=1' >> "$GITHUB_ENV"


### PR DESCRIPTION
### Description of changes: 
Disallow external bindgen usage when `AWS_LC_SYS_EXTERNAL_BINDGEN=0` is set in the environment.
* This allows us to verify that the pregenerated bindings are being used.

### Testing
* `s390x-unknown-linux-gnu` fails when this is set: https://github.com/aws/aws-lc-rs/actions/runs/14978763694/job/42077580194?pr=808#step:10:1085
```
...
   --- stderr
  Failure invoking external bindgen! external bindgen usage prevented by AWS_LC_SYS_EXTERNAL_BINDGEN=0

  thread 'main' panicked at aws-lc-sys/builder/main.rs:753:5:
  aws-lc-sys build failed. Please enable the 'bindgen' feature on aws-lc-rs or aws-lc-sys.For more information, see the aws-lc-rs User Guide: https://aws.github.io/aws-lc-rs/index.html
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
