### PR TITLE
Change 'try_sign' to pub in ED25519 module

### DIFF
--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -410,7 +410,6 @@ impl Ed25519KeyPair {
     /// # Errors
     /// Returns `error::Unspecified` if the signing operation fails.
     #[inline]
-    #[must_use]
     pub fn try_sign(&self, msg: &[u8]) -> Result<Signature, Unspecified> {
         let sig_bytes = self.evp_pkey.sign(msg, None, No_EVP_PKEY_CTX_consumer)?;
 

--- a/aws-lc-rs/tests/ed25519_tests.rs
+++ b/aws-lc-rs/tests/ed25519_tests.rs
@@ -32,7 +32,7 @@ fn test_signature_ed25519() {
             let expected_sig = test_case.consume_bytes("SIG");
 
             let key_pair = Ed25519KeyPair::from_seed_unchecked(&seed).unwrap();
-            let actual_sig = key_pair.sign(&msg);
+            let actual_sig = key_pair.try_sign(&msg)?;
             assert_eq!(&expected_sig[..], actual_sig.as_ref());
 
             let key_pair = Ed25519KeyPair::from_seed_and_public_key(&seed, &public_key).unwrap();


### PR DESCRIPTION
### Description of changes: 
Currently, the only way to use ed25519 to sign a message is using the `sign` function. However, this function can panic, in the case that the signing operation failed. To allow a user of the library to try to sign a message and handle the error case (without relying on`std::panic::catch_unwind`) this change exposes the `try_sign` as public again. This was also the behaviour before the [rename of the function](https://github.com/aws/aws-lc-rs/commit/b43fca398e69a9bad85f2321cdf1af9ecd7ffaec#diff-1f32d2fbb7ef839cab8718f754391a1f2d04452131eff2eeb3c2d6b6d61b8664L218).

### Call-outs:
I added a docstring to the function, similar to the one on `sign`. However, I'm not sure if this function would need the FIPS disclaimer as well, or if that was related to the possible panic.  

### Testing:
There is no change in how the library works, only in what is exposed in the public interface. Therefore no additional testing effort / checks are necessary.  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.

Elena Gantner [elena.gantner@mercedes-benz.com](mailto:elena.gantner@mercedes-benz.com) on behalf of Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
