### PR TITLE
Support SIV in RandomizedNonceKey

### DIFF
--- a/aws-lc-rs/src/aead/rand_nonce.rs
+++ b/aws-lc-rs/src/aead/rand_nonce.rs
@@ -16,6 +16,8 @@ use super::{
 /// The following algorithms are supported:
 /// * `AES_128_GCM`
 /// * `AES_256_GCM`
+/// * `AES_128_GCM_SIV`
+/// * `AES_256_GCM_SIV`
 ///
 /// Prefer this type in place of `LessSafeKey`, `OpeningKey`, `SealingKey`.
 pub struct RandomizedNonceKey {


### PR DESCRIPTION
### Issues:
Addresses #842

### Description of changes: 
* Adds support for `AES_128_GCM_SIV` and `AES_256_GCM_SIV` to `RandomizedNonceKey`.

### Testing:
Updated tests to cover new algorithms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
