### PR TITLE
[DRAFT] Avoid doctests in cross-compile CI

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -75,9 +75,15 @@ jobs:
         run: |
           echo 'AWS_LC_SYS_EXTERNAL_BINDGEN=0' >> "$GITHUB_ENV"
       - if: ${{ matrix.target[0] == 'x86_64-unknown-illumos' }}
-        # TODO: Restructure the build options
         run: |
           echo 'CROSS_TEST_EXTRA_FLAG=--no-run' >> "$GITHUB_ENV"
+      - if: ${{ matrix.target[0] != 'x86_64-unknown-illumos' }}
+        # Since Rust 1.89, doctests run by default.
+        # When cross-compiling, doctests do not have the environment setup properly to link to shared libraries.
+        # Per documentation:
+        #       --all-targets       Test all targets (does not include doctests)
+        run: |
+          echo 'CROSS_TEST_EXTRA_FLAG=--all-targets' >> "$GITHUB_ENV"
       - name: Cross-compilation (test release)
         run: cross test -p aws-lc-rs --release "${CROSS_TEST_EXTRA_FLAG}" --features unstable --target ${{ matrix.target[0] }}
       - if: ${{ matrix.target[1] == 1 }}


### PR DESCRIPTION
### Description of changes: 
Avoid doctest when cross-compiling.

### Call-outs:
As of [Rust v1.89.0](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#cross-compiled-doctests), doctests run when cross-compiling.  However, doctests do not have the environment setup properly for linking to the shared library that we build (on several platforms) for FIPS.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
