### PR TITLE
Fix unexpected +1.70.0 compiler error

### DIFF
--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -158,7 +158,7 @@
 //! let seal_prepared_nonce = sealing_key.prepare_nonce()?;
 //!
 //! // Query the nonce that will be used for our seal operation with our prepared nonce
-//! let seal_nonce_bytes = Vec::from(seal_prepared_nonce.nonce().as_ref());
+//! let seal_nonce_bytes = Vec::from(seal_prepared_nonce.nonce().as_ref().as_slice());
 //!
 //! // Use the prepared nonce and seal the plaintext
 //! seal_prepared_nonce.seal_in_place_append_tag(Aad::empty(), &mut in_out)?;
@@ -167,7 +167,7 @@
 //! let open_prepared_nonce = opening_key.prepare_nonce()?;
 //!
 //! // Query the nonce that will be used for our seal operation with our prepared nonce
-//! let open_nonce_bytes = Vec::from(open_prepared_nonce.nonce().as_ref());
+//! let open_nonce_bytes = Vec::from(open_prepared_nonce.nonce().as_ref().as_slice());
 //!
 //! // Since we initialized the Counter32Builder the same between both builders the nonce here
 //! // will match the one from the opening key.

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -694,8 +694,8 @@ fn prepare_nonce() {
     for _ in 0..(LIMIT / 2) {
         let skpn = sk.prepare_nonce().unwrap();
         let okpn = ok.prepare_nonce().unwrap();
-        let so_nonce = Vec::from(skpn.nonce().as_ref());
-        let oo_nonce = Vec::from(okpn.nonce().as_ref());
+        let so_nonce = Vec::from(skpn.nonce().as_ref().as_slice());
+        let oo_nonce = Vec::from(okpn.nonce().as_ref().as_slice());
 
         assert_eq!(so_nonce.as_slice(), oo_nonce.as_slice());
         assert!(!nonces.contains(&so_nonce));
@@ -714,8 +714,8 @@ fn prepare_nonce() {
 
         let so = sk.prepare_nonce().unwrap();
         let oo = ok.prepare_nonce().unwrap();
-        let so_nonce = Vec::from(so.nonce().as_ref());
-        let oo_nonce = Vec::from(oo.nonce().as_ref());
+        let so_nonce = Vec::from(so.nonce().as_ref().as_slice());
+        let oo_nonce = Vec::from(oo.nonce().as_ref().as_slice());
 
         assert_eq!(so_nonce.as_slice(), oo_nonce.as_slice());
         assert!(!nonces.contains(&so_nonce));


### PR DESCRIPTION
### Description of changes: 
I'm not sure why, but I've started seeing a compiler error when building w/ v1.70.0.

* The compile error:
```
> cargo +1.70.0 test -p aws-lc-rs
...
error[E0277]: the trait bound `Vec<_, _>: From<&[u8; 12]>` is not satisfied
   --> aws-lc-rs/tests/aead_test.rs:697:34
    |
697 |         let so_nonce = Vec::from(skpn.nonce().as_ref());
    |                        --------- ^^^^^^^^^^^^^^^^^^^^^ the trait `From<&[u8; 12]>` is not implemented for `Vec<_, _>`
    |                        |
    |                        required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
              <Vec<T, A> as From<Box<[T], A>>>
              <Vec<T, A> as From<VecDeque<T, A>>>
              <Vec<T> as From<&[T]>>
              <Vec<T> as From<&mut [T]>>
              <Vec<T> as From<BinaryHeap<T>>>
              <Vec<T> as From<Cow<'a, [T]>>>
              <Vec<T> as From<[T; N]>>
              <Vec<u8> as From<&str>>
            and 2 others
...
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
