### PR TITLE
Expose RsaSignatureEncoding

### DIFF
--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -238,13 +238,13 @@ use core::fmt::{Debug, Formatter};
 #[cfg(feature = "ring-sig-verify")]
 use untrusted::Input;
 
-pub use crate::rsa::signature::RsaEncoding;
+pub use crate::rsa::signature::{RsaEncoding, RsaSignatureEncoding};
 pub use crate::rsa::{
     KeyPair as RsaKeyPair, PublicKey as RsaSubjectPublicKey,
     PublicKeyComponents as RsaPublicKeyComponents, RsaParameters,
 };
 
-use crate::rsa::signature::{RsaSignatureEncoding, RsaSigningAlgorithmId};
+use crate::rsa::signature::RsaSigningAlgorithmId;
 use crate::rsa::RsaVerificationAlgorithmId;
 
 pub use crate::ec::key_pair::{EcdsaKeyPair, PrivateKey as EcdsaPrivateKey};


### PR DESCRIPTION
### Description of changes: 
Expose `RsaSignatureEncoding`. All other static types from this file are exposed and this is the only one missing. Exposing this is needed so other crates are able to map external types to `RsaSignatureEncoding` without needing to use traits such ` RsaEncoding` to erase this type.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
