### PR TITLE
Exclude CI jobs for invalid param combinations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -334,6 +334,12 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-13, macos-latest ]
         static: [ 0, 1 ]
+        exclude:
+          # The FIPS build on macOS can only produce shared libraries.
+          - os: 'macos-latest'
+            static: 1
+          - os: 'macos-13'
+            static: 1
     steps:
       - uses: actions/checkout@v4
         with:
@@ -343,7 +349,6 @@ jobs:
         with:
           go-version: '>=1.18'
       - name: Run cargo test
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.static != 1 }}
         run: cargo test -p aws-lc-rs --no-default-features --features fips
 
   build-env-no-asm-test:
@@ -531,6 +536,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
         fips: [ 0, 1 ]
+        exclude:
+          # macOS aarch64 fix for FIPS pending the following PR applied to FIPS branch:
+          # https://github.com/aws/aws-lc/pull/2005
+          - os: 'macos-latest'
+            fips: 1
     steps:
       - uses: actions/checkout@v4
         with:
@@ -544,9 +554,6 @@ jobs:
         with:
           go-version: '>=1.18'
       - name: Run cargo test
-        # macOS aarch64 fix for FIPS pending the following PR applied to FIPS branch:
-        # https://github.com/aws/aws-lc/pull/2005
-        if: ${{ matrix.fips == 0 || matrix.os != 'macos-latest' }}
         working-directory: "path has spaces/aws-lc-rs"
         run: cargo test --tests -p aws-lc-rs --no-default-features --features ${{ (matrix.fips == 1 && 'fips') || 'aws-lc-sys' }}
 


### PR DESCRIPTION
### Description of changes: 
Explicitly exclude CI jobs for invalid parameter combinations.+

### Call-outs:
Currently these jobs show up and appear to pass even for completely broken builds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
