### PR TITLE
Optionally disable padding in StreamingDecryptingKey

### DIFF
--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
+use aws_lc::EVP_CIPHER_CTX_set_padding;
+
 use crate::aws_lc::{
     EVP_CIPHER_CTX_new, EVP_CIPHER_iv_length, EVP_CIPHER_key_length, EVP_DecryptFinal_ex,
     EVP_DecryptInit_ex, EVP_DecryptUpdate, EVP_EncryptFinal_ex, EVP_EncryptInit_ex,
@@ -470,6 +472,15 @@ impl StreamingDecryptingKey {
         context: DecryptionContext,
     ) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, context)
+    }
+
+    /// Disables padding for the decryption operation.
+    ///
+    /// Offered for computability purposes only.
+    /// This will decrypt the padding data into the regular output where it
+    /// will need to be validated and removed afterwards.
+    pub fn disable_padding(&mut self) {
+        unsafe { EVP_CIPHER_CTX_set_padding(*self.cipher_ctx.as_mut(), 0) };
     }
 
     // Constructs a `StreamingDecryptingKey` for decrypting using the CFB128 cipher mode.


### PR DESCRIPTION
### Issues:

Continuation of #847.

Some applications (e.g. [EBICS](https://en.wikipedia.org/wiki/Electronic_Banking_Internet_Communication_Standard)) still require compatibility with padding schemes like ISO 10126 and ANSI X9.23.

### Description of changes: 

This PR adds the method `StreamDecryptingKey::disable_padding()` as a safe wrapper for the existing `EVP_CIPHER_CTX_set_padding()` function. This allows applications to decrypt data padded with one of these padding schemes and validate the padding without adding complexity to aws-lc-rs.

### Testing:

Testing will be added. What kind of coverage is expected?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
