### PR TITLE
impl AsDer<PublicKeyX509Der<'static>> for ParsedPublicKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ deps/aws-lc-sys/src/bindings.rs
 /Cargo.lock
 
 lcov.info
+/.zed/

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -12,6 +12,7 @@ use crate::aws_lc::{
 use crate::digest::{self, match_digest_type, Digest};
 use crate::error::Unspecified;
 use crate::ptr::LcPtr;
+use crate::rsa::key::parse_rsa_public_key;
 use crate::sealed::Sealed;
 use crate::signature::{ParsedPublicKey, ParsedVerificationAlgorithm, VerificationAlgorithm};
 
@@ -108,7 +109,7 @@ impl VerificationAlgorithm for RsaParameters {
         msg: &[u8],
         signature: &[u8],
     ) -> Result<(), Unspecified> {
-        let evp_pkey = encoding::rfc8017::decode_public_key_der(public_key)?;
+        let evp_pkey = parse_rsa_public_key(public_key)?;
         verify_rsa_signature(
             self.digest_algorithm(),
             self.padding(),
@@ -128,7 +129,7 @@ impl VerificationAlgorithm for RsaParameters {
         if self.digest_algorithm() != digest.algorithm() {
             return Err(Unspecified);
         }
-        let evp_pkey = encoding::rfc8017::decode_public_key_der(public_key)?;
+        let evp_pkey = parse_rsa_public_key(public_key)?;
         verify_rsa_digest_signature(
             self.padding(),
             &evp_pkey,

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -260,7 +260,8 @@ pub use crate::ed25519::{
 use crate::digest::Digest;
 use crate::ec::encoding::parse_ec_public_key;
 use crate::ed25519::parse_ed25519_public_key;
-use crate::error::KeyRejected;
+use crate::encoding::{AsDer, PublicKeyX509Der};
+use crate::error::{KeyRejected, Unspecified};
 #[cfg(all(feature = "unstable", not(feature = "fips")))]
 use crate::pqdsa::{parse_pqdsa_public_key, signature::PqdsaVerificationAlgorithm};
 use crate::ptr::LcPtr;
@@ -506,6 +507,14 @@ impl ParsedPublicKey {
     ) -> Result<(), error::Unspecified> {
         self.parsed_algorithm
             .parsed_verify_digest_sig(self, digest, signature)
+    }
+}
+
+impl AsDer<PublicKeyX509Der<'static>> for ParsedPublicKey {
+    fn as_der(&self) -> Result<PublicKeyX509Der<'static>, Unspecified> {
+        Ok(PublicKeyX509Der::new(
+            self.key.as_const().marshal_rfc5280_public_key()?,
+        ))
     }
 }
 

--- a/aws-lc-rs/tests/ecdsa_tests.rs
+++ b/aws-lc-rs/tests/ecdsa_tests.rs
@@ -10,6 +10,7 @@ use aws_lc_rs::encoding::{AsBigEndian, AsDer, EcPrivateKeyRfc5915Der};
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{
     self, EcdsaKeyPair, KeyPair, ParsedPublicKey, Signature, UnparsedPublicKey,
+    VerificationAlgorithm,
 };
 use aws_lc_rs::{digest, test, test_file};
 
@@ -209,6 +210,10 @@ fn test_signature_ecdsa_verify_asn1(data_file: test::File) {
             let digest = digest::digest(digest_alg, &msg);
             let actual_digest_result = ppk.verify_digest_sig(&digest, &sig);
             assert_eq!(actual_digest_result.is_ok(), is_valid);
+
+            let x509_bytes = ppk.as_der().unwrap();
+            let actual_x509_result = alg.verify_sig(x509_bytes.as_ref(), &msg, &sig);
+            assert_eq!(actual_x509_result.is_ok(), is_valid);
         }
 
         Ok(())

--- a/aws-lc-rs/tests/ed25519_tests.rs
+++ b/aws-lc-rs/tests/ed25519_tests.rs
@@ -214,17 +214,27 @@ fn ed25519_test_public_key_coverage() {
 
     let public_key = key_pair.public_key();
     let public_key_raw_bytes = public_key.as_ref();
+    let parsed_public_key: ParsedPublicKey =
+        ParsedPublicKey::new(&ED25519, public_key_raw_bytes).unwrap();
+    let parsed_public_key_raw_bytes = parsed_public_key.as_ref();
     let public_key_x509 = public_key.as_der().unwrap();
+    let parsed_public_key_x509 = parsed_public_key.as_der().unwrap();
     let public_key_x509_bytes = public_key_x509.as_ref();
+    let parsed_public_key_x509_bytes = parsed_public_key_x509.as_ref();
 
     // Test `AsRef<[u8]>`
     assert_eq!(public_key_raw_bytes, PUBLIC_KEY);
+    assert_eq!(parsed_public_key_raw_bytes, PUBLIC_KEY);
+    assert_eq!(public_key_x509_bytes, parsed_public_key_x509_bytes);
 
     assert!(ED25519
         .verify_sig(public_key_raw_bytes, message, sig.as_ref())
         .is_ok());
     assert!(ED25519
         .verify_sig(public_key_x509_bytes, message, sig.as_ref())
+        .is_ok());
+    assert!(ED25519
+        .verify_sig(parsed_public_key_x509_bytes, message, sig.as_ref())
         .is_ok());
 
     // Test `Clone`.

--- a/aws-lc-rs/tests/pqdsa_test.rs
+++ b/aws-lc-rs/tests/pqdsa_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 #![cfg(all(not(feature = "fips"), feature = "unstable"))]
 
+use aws_lc_rs::encoding::AsDer;
 use aws_lc_rs::signature::{KeyPair, ParsedPublicKey, VerificationAlgorithm};
 use aws_lc_rs::unstable::signature::{
     PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING, ML_DSA_87,
@@ -46,6 +47,14 @@ macro_rules! mldsa_sigver_test {
 
             let ppk = ParsedPublicKey::new($verification, public_key.as_slice()).unwrap();
             let result = ppk.verify_sig(message.as_ref(), signature.as_ref());
+            if expected_result {
+                assert!(result.is_ok());
+            } else {
+                assert!(result.is_err());
+            }
+            let x509_bytes = ppk.as_der().unwrap();
+            let result =
+                $verification.verify_sig(x509_bytes.as_ref(), message.as_ref(), signature.as_ref());
             if expected_result {
                 assert!(result.is_ok());
             } else {

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -13,7 +13,7 @@ use aws_lc_rs::rsa::{
 };
 use aws_lc_rs::signature::{
     KeyPair, ParsedPublicKey, RsaKeyPair, RsaParameters, RsaPublicKeyComponents,
-    RsaSubjectPublicKey, UnparsedPublicKey,
+    RsaSubjectPublicKey, UnparsedPublicKey, VerificationAlgorithm,
 };
 use aws_lc_rs::test::to_hex_upper;
 use aws_lc_rs::{digest, rand, signature, test, test_file};
@@ -129,6 +129,14 @@ fn test_signature_rsa_pkcs1_sign() {
                 let digest = Digest::import_less_safe(og_digest.as_ref(), digest_alg).unwrap();
                 key_pair.sign_digest(alg, &digest, actual.as_mut_slice())?;
                 assert!(ppk.verify_digest_sig(&digest, actual.as_slice()).is_ok());
+
+                let x509_bytes = ppk.as_der().unwrap();
+                let actual_x509_result = verification_alg.verify_digest_sig(
+                    x509_bytes.as_ref(),
+                    &digest,
+                    actual.as_slice(),
+                );
+                assert!(actual_x509_result.is_ok());
             }
 
             Ok(())


### PR DESCRIPTION
### Issues:
Addresses: https://github.com/aws/aws-lc-rs/issues/849#issuecomment-3310576861

### Description of changes: 
Allows the encoding of a `ParsedPublicKey` into an X509 public key.

### Call-outs:
`verify_sig` and `verify_digest_sig` in `RsaParameters` was assuming an RFC8017 encoded public key.  I don't see any reason that it should not also accept X509.

### Testing:
Updated tests to provide coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
