### PR TITLE
Fix MSRV CI - libloading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ untrusted = "0.7.1"
 zeroize = "1.8.1"
 toml_edit = "0.23.0"
 
+# libloading v0.8.9 has MSRV of 1.71.0
+libloading = "=0.8.8"
+
 [profile.bench]
 lto = true
 

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -70,6 +70,8 @@ dunce.workspace = true
 fs_extra.workspace = true
 cc.workspace = true
 regex.workspace = true
+# libloading v0.8.9 has MSRV of 1.71.0
+libloading.workspace = true
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")))'.build-dependencies]
 bindgen = { workspace = true, optional = true }
@@ -82,3 +84,6 @@ regex.workspace = true
 
 [package.metadata.aws-lc-fips-sys]
 commit-hash = "fcd86b8478a66721b3356e1fe85a0d1e31a4e834"
+
+[package.metadata.cargo-udeps.ignore]
+build = ["libloading"]

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -69,6 +69,8 @@ cmake.workspace = true
 dunce.workspace = true
 fs_extra.workspace = true
 cc = { workspace = true, features = ["parallel"] }
+# libloading v0.8.9 has MSRV of 1.71.0
+libloading.workspace = true
 
 [target.'cfg(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu")))'.build-dependencies]
 bindgen = { workspace = true, optional = true }
@@ -78,3 +80,6 @@ bindgen.workspace = true
 
 [package.metadata.aws-lc-sys]
 commit-hash = "0fa8839018a3d98bae2fb24c557183d8ca02e6c5"
+
+[package.metadata.cargo-udeps.ignore]
+build = ["libloading"]


### PR DESCRIPTION
### Description of changes: 
Fix failing MSRV CI job.
* Latest version of [libloading bumps MSRV to 1.71.0](https://crates.io/crates/libloading/versions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
