### PR TITLE
Adds AES CBC mode no padding

### DIFF
--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -1151,4 +1151,44 @@ mod tests {
         "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
         "f3eed1bdb5d2a03c064b5a7e3db181f8591ccb10d410ed26dc5ba74a31362870b6ed21b99ca6f4f9f153e7b1beafed1d23304b7a39f9f3ff067d8d8f9e24ecc7"
     );
+
+    cipher_kat!(
+        test_sp800_38a_cbc_aes128,
+        &AES_128,
+        OperatingMode::CBC,
+        "2b7e151628aed2a6abf7158809cf4f3c",
+        "000102030405060708090a0b0c0d0e0f",
+        "6bc1bee22e409f96e93d7e117393172a",
+        "7649abac8119b246cee98e9b12e9197d"
+    );
+
+    cipher_kat!(
+        test_sp800_38a_cbc_aes256,
+        &AES_256,
+        OperatingMode::CBC,
+        "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+        "000102030405060708090a0b0c0d0e0f",
+        "6bc1bee22e409f96e93d7e117393172a",
+        "f58c4c04d6e5f1ba779eabfb5f7bfbd6"
+    );
+
+    cipher_kat!(
+        test_sp800_38a_cbc_aes128_multi_block,
+        &AES_128,
+        OperatingMode::CBC,
+        "2b7e151628aed2a6abf7158809cf4f3c",
+        "000102030405060708090a0b0c0d0e0f",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+        "7649abac8119b246cee98e9b12e9197d5086cb9b507219ee95db113a917678b273bed6b8e3c1743b7116e69e222295163ff1caa1681fac09120eca307586e1a7"
+    );
+
+    cipher_kat!(
+        test_sp800_38a_cbc_aes256_multi_block,
+        &AES_256,
+        OperatingMode::CBC,
+        "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4",
+        "000102030405060708090a0b0c0d0e0f",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
+        "f58c4c04d6e5f1ba779eabfb5f7bfbd69cfc4e967edb808d679f777bc6702c7d39f23369a9d9bacfa530e26304231461b2eb05e2c39be9fcda6c19078c6a9d1b"
+    );
 }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -551,7 +551,7 @@ impl EncryptingKey {
     /// Constructs an `EncryptingKey` operating in cipher block chaining (CBC) mode using the provided key.
     ///
     /// # ☠️ ️️️DANGER ☠️
-    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// Offered for compatibility purposes only. This is an extremely dangerous mode, and
     /// very likely not what you want to use.
     ///
     // # FIPS
@@ -568,7 +568,7 @@ impl EncryptingKey {
     /// Constructs an `EncryptingKey` operating in electronic code book mode (ECB) using the provided key.
     ///
     /// # ☠️ ️️️DANGER ☠️
-    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// Offered for compatibility purposes only. This is an extremely dangerous mode, and
     /// very likely not what you want to use.
     ///
     // # FIPS
@@ -692,7 +692,7 @@ impl DecryptingKey {
     /// Constructs an `DecryptingKey` operating in cipher block chaining (CBC) mode using the provided key and context.
     ///
     /// # ☠️ ️️️DANGER ☠️
-    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// Offered for compatibility purposes only. This is an extremely dangerous mode, and
     /// very likely not what you want to use.
     ///
     // # FIPS
@@ -709,7 +709,7 @@ impl DecryptingKey {
     /// Constructs an `DecryptingKey` operating in electronic code book (ECB) mode using the provided key.
     ///
     /// # ☠️ ️️️DANGER ☠️
-    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// Offered for compatibility purposes only. This is an extremely dangerous mode, and
     /// very likely not what you want to use.
     ///
     // # FIPS

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -548,6 +548,23 @@ impl EncryptingKey {
         Self::new(key, OperatingMode::CFB128)
     }
 
+    /// Constructs an `EncryptingKey` operating in cipher block chaining (CBC) mode using the provided key.
+    ///
+    /// # ☠️ ️️️DANGER ☠️
+    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// very likely not what you want to use.
+    ///
+    // # FIPS
+    // Use this function with an `UnboundCipherKey` constructed with one of the following algorithms:
+    // * `AES_128`
+    // * `AES_256`
+    //
+    /// # Errors
+    /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
+    pub fn cbc(key: UnboundCipherKey) -> Result<Self, Unspecified> {
+        Self::new(key, OperatingMode::CBC)
+    }
+
     /// Constructs an `EncryptingKey` operating in electronic code book mode (ECB) using the provided key.
     ///
     /// # ☠️ ️️️DANGER ☠️
@@ -670,6 +687,23 @@ impl DecryptingKey {
     /// * [`Unspecified`]: Returned if there is an error during decryption.
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128)
+    }
+
+    /// Constructs an `DecryptingKey` operating in cipher block chaining (CBC) mode using the provided key and context.
+    ///
+    /// # ☠️ ️️️DANGER ☠️
+    /// Offered for computability purposes only. This is an extremely dangerous mode, and
+    /// very likely not what you want to use.
+    ///
+    // # FIPS
+    // Use this function with an `UnboundCipherKey` constructed with one of the following algorithms:
+    // * `AES_128`
+    // * `AES_256`
+    //
+    /// # Errors
+    /// * [`Unspecified`]: Returned if there is an error during decryption.
+    pub fn cbc(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
+        Self::new(key, OperatingMode::CBC)
     }
 
     /// Constructs an `DecryptingKey` operating in electronic code book (ECB) mode using the provided key.
@@ -941,6 +975,27 @@ mod tests {
             from_hex("000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f").unwrap();
         for i in 0..=50 {
             helper_test_cipher_n_bytes(key.as_slice(), &AES_256, OperatingMode::CTR, i);
+        }
+    }
+
+    #[test]
+    fn test_aes_128_cbc() {
+        let key = from_hex("000102030405060708090a0b0c0d0e0f").unwrap();
+        // CBC mode requires input to be a multiple of block size (16 bytes)
+        for i in 0..=3 {
+            let size = i * 16; // Test with 0, 16, 32, 48 bytes
+            helper_test_cipher_n_bytes(key.as_slice(), &AES_128, OperatingMode::CBC, size);
+        }
+    }
+
+    #[test]
+    fn test_aes_256_cbc() {
+        let key =
+            from_hex("000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f").unwrap();
+        // CBC mode requires input to be a multiple of block size (16 bytes)
+        for i in 0..=3 {
+            let size = i * 16; // Test with 0, 16, 32, 48 bytes
+            helper_test_cipher_n_bytes(key.as_slice(), &AES_256, OperatingMode::CBC, size);
         }
     }
 


### PR DESCRIPTION
### Issues:
See SIM P307101963

### Description of changes: 
Currently, only the PaddedBlock keys and Streaming keys supports CBC mode.
This adds CBC mode for EncryptingKey and DecryptingKey. This allows AES CBC encryption/decryption with no padding.

### Call-outs:
Since no padding is used, input data must be block aligned, length of input must be a multiple of 16 bytes.
I also included the `DANGER` message in the doc string, since I think the use of this is unconventional.

### Testing:
Unit tests added following examples of existing unit tests.

#### KAT
Added known-answer tests from "Appendix F" of SP800-38a:
* https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
