### PR TITLE
Failure when CFLAGS provides -O3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -603,3 +603,23 @@ jobs:
       - name: Run cargo test
         working-directory: "path has spaces/aws-lc-rs"
         run: cargo test --tests -p aws-lc-rs --features bindgen
+
+  hostile-environment:
+    if: github.repository_owner == 'aws'
+    name: Hostile environment
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    env:
+      CFLAGS: '-O3'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run tests
+        run: cargo test -p aws-lc-rs --all-targets
+      - name: Run tests w/ FIPS
+        run: cargo test -p aws-lc-rs --all-targets --features fips


### PR DESCRIPTION
### Context
In build environments where CFLAGS provides a flag enabling optimization, this can cause compilation of the CPU jitter entropy logic to fail due to `cc-rs` prioritizing `CFLAGS` over the flags provided by the build script.

### Description of changes: 
This change ensures that the last optimization flag provided by CFLAGS (when compiling the cpu jitter entropy logic) disables optimization: `-O0`.

### Callout
This depends upon the expectation that the environment variables are read and applied during the invocation of `get_compiler`:
* Collection of environment variable: https://github.com/rust-lang/cc-rs/blob/6fb2a8f27d10a991203d5a892fd8320056f7fe41/src/lib.rs#L1977
* Application of flags: https://github.com/rust-lang/cc-rs/blob/6fb2a8f27d10a991203d5a892fd8320056f7fe41/src/lib.rs#L2017

### Testing:
Added CI job to cover this scenario.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
