### PR TITLE
Remove use of macos-13 GH runner

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-14, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-14, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -278,7 +278,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, macos-latest, windows-latest, windows-11-arm ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-latest, windows-latest, windows-11-arm ]
         c_std: [ "11", "99" ]
         cmake: [ '0', '1' ]
         exclude:

--- a/.github/workflows/fips-bindings-generator.yml
+++ b/.github/workflows/fips-bindings-generator.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest,  macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fips-bindings-generator.yml
+++ b/.github/workflows/fips-bindings-generator.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest,  macos-14 ]
+        os: [ ubuntu-latest,  macos-latest ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         args:
           - --release --all-targets --features fips,unstable
           - --profile release-lto --all-targets --features fips,unstable
@@ -60,7 +60,7 @@ jobs:
           brew uninstall --force cmake
           brew install --force cmake
           cmake --version
-          echo 'CMAKE=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/bin/cmake' >> $GITHUB_ENV
+          echo 'CMAKE=/opt/homebrew/bin/cmake' >> $GITHUB_ENV
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     env:
       GIT_CLONE_PROTECTION_ACTIVE: false
     steps:
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         latest: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v3
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         features: [ aws-lc-rs, aws-lc-rs-fips, aws-lc-sys, aws-lc-fips-sys ]
     steps:
       - uses: actions/checkout@v3
@@ -198,7 +198,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ windows-latest, ubuntu-latest, macos-13, macos-latest ]
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
         crate: [ aws-lc-sys, aws-lc-fips-sys ]
         args:
           - publish --dry-run
@@ -242,7 +242,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ windows-latest, ubuntu-latest, macos-13, macos-latest ]
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
         args:
           - publish --dry-run
     steps:
@@ -320,7 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -330,8 +330,8 @@ jobs:
       - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
-          echo 'LIBCLANG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/lib' >> $GITHUB_ENV
-          echo 'LLVM_CONFIG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
+          echo 'LIBCLANG_PATH=/opt/homebrew/opt/llvm/lib' >> $GITHUB_ENV
+          echo 'LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
       - name: Install NASM on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/sys-bindings-generator.yml
+++ b/.github/workflows/sys-bindings-generator.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -258,7 +258,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14 ]
+        os: [ ubuntu-latest, macos-14 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/sys-bindings-generator.yml
+++ b/.github/workflows/sys-bindings-generator.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -258,7 +258,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-14 ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-latest, ubuntu-24.04-arm ]
+        os: [ ubuntu-latest, macos-latest, ubuntu-24.04-arm ]
         args:
           - --all-targets --features unstable
           - --release --all-targets --features unstable
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         rust: [ stable ]
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         args:
           - --no-default-features --features aws-lc-sys,bindgen,unstable
           - --release --all-targets --features bindgen,unstable
@@ -73,8 +73,8 @@ jobs:
       - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
-          echo 'LIBCLANG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/lib' >> $GITHUB_ENV
-          echo 'LLVM_CONFIG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
+          echo 'LIBCLANG_PATH=/opt/homebrew/opt/llvm/lib' >> $GITHUB_ENV
+          echo 'LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         static: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -280,7 +280,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -337,13 +337,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         static: [ 0, 1 ]
         exclude:
           # The FIPS build on macOS can only produce shared libraries.
           - os: 'macos-latest'
-            static: 1
-          - os: 'macos-13'
             static: 1
     steps:
       - uses: actions/checkout@v4
@@ -365,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -400,7 +398,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -439,7 +437,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -470,7 +468,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13
           - macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -487,8 +484,8 @@ jobs:
       - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
-          echo 'LIBCLANG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/lib' >> $GITHUB_ENV
-          echo 'LLVM_CONFIG_PATH=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
+          echo 'LIBCLANG_PATH=/opt/homebrew/opt/llvm/lib' >> $GITHUB_ENV
+          echo 'LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
       - name: Set Rust toolchain override
         run: rustup override set ${{ steps.toolchain.outputs.name }}
       - uses: actions/setup-go@v4
@@ -539,7 +536,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         fips: [ 0, 1 ]
         exclude:
           # macOS aarch64 fix for FIPS pending the following PR applied to FIPS branch:
@@ -573,7 +570,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         pregen_src: [ 0, 1 ]
     steps:
       - uses: actions/checkout@v4
@@ -599,7 +596,7 @@ jobs:
           brew uninstall --force cmake
           brew install --force cmake
           cmake --version
-          echo 'CMAKE=${{ (matrix.os == 'macos-13' && '/usr/local') || '/opt/homebrew' }}/bin/cmake' >> $GITHUB_ENV
+          echo 'CMAKE=/opt/homebrew/bin/cmake' >> $GITHUB_ENV
       - name: Run cargo test
         working-directory: "path has spaces/aws-lc-rs"
         run: cargo test --tests -p aws-lc-rs --features bindgen


### PR DESCRIPTION

### Description of changes: 
Github is discontinuing support for the macos-13 runner: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down
* Removes all usage of `macos-13`
* Replaces use of `macos-14` with `macos-latest` in bindgen workflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
