### PR TITLE
Drop explicit/pinned libloading dependency

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -344,6 +344,7 @@ jobs:
       - name: Update dependencies
         run: |
           cargo +1.70.0 update
+          cargo +1.70.0 update -p libloading --precise 0.8.8
           cargo +1.70.0 tree
 
       - name: Verify msrv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,6 @@ untrusted = "0.7.1"
 zeroize = "1.8.1"
 toml_edit = "0.23.0"
 
-# libloading v0.8.9 has MSRV of 1.71.0
-libloading = "=0.8.8"
-
 [profile.bench]
 lto = true
 

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -70,8 +70,6 @@ dunce.workspace = true
 fs_extra.workspace = true
 cc.workspace = true
 regex.workspace = true
-# libloading v0.8.9 has MSRV of 1.71.0
-libloading.workspace = true
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), any(target_os = "linux", target_os = "macos"), any(target_env = "gnu", target_env = "musl", target_env = "")))'.build-dependencies]
 bindgen = { workspace = true, optional = true }
@@ -84,6 +82,3 @@ regex.workspace = true
 
 [package.metadata.aws-lc-fips-sys]
 commit-hash = "fcd86b8478a66721b3356e1fe85a0d1e31a4e834"
-
-[package.metadata.cargo-udeps.ignore]
-build = ["libloading"]

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -69,8 +69,6 @@ cmake.workspace = true
 dunce.workspace = true
 fs_extra.workspace = true
 cc = { workspace = true, features = ["parallel"] }
-# libloading v0.8.9 has MSRV of 1.71.0
-libloading.workspace = true
 
 [target.'cfg(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu")))'.build-dependencies]
 bindgen = { workspace = true, optional = true }
@@ -80,6 +78,3 @@ bindgen.workspace = true
 
 [package.metadata.aws-lc-sys]
 commit-hash = "8ca0b29b141bb8c7eae06ef324e2091d5648d819"
-
-[package.metadata.cargo-udeps.ignore]
-build = ["libloading"]


### PR DESCRIPTION
### Description of changes: 

Unlike clap and criterion, which are pinned dev-dependencies, libloading shows up in downstream dependency graphs. As such, pinning libloading to 0.8.8 in these crates holds back its use in all downstream projects, the vast majority of which will have a newer MSRV. As such, pinning is not a great solution for the problem at hand. Instead, adjust the MSRV CI workflow to make sure an older libloading is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
