### PR TITLE
Fix: Add -Wa,--noexecstack to cc_builder for assembly files (resolves #939)

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -354,6 +354,14 @@ impl CcBuilder {
         if !cflags.is_empty() {
             set_env_for_target("CFLAGS", cflags);
         }
+
+        // Add --noexecstack flag for assembly files to prevent executable stacks
+        // This matches the behavior of AWS-LC's CMake build which uses -Wa,--noexecstack
+        // See: https://github.com/aws/aws-lc/blob/main/crypto/CMakeLists.txt#L77
+        if target_os() == "linux" || target_os().ends_with("bsd") {
+            cc_build.asm_flag("-Wa,--noexecstack");
+        }
+
         cc_build
     }
 


### PR DESCRIPTION
## Summary

Fixes missing `.note.GNU-stack` sections in ML-KEM assembly object files when using `cc_builder`, which causes executable stacks on older Linux systems.

## Problem

ML-KEM native x86_64 assembly files compiled by `cc_builder` are missing `.note.GNU-stack` sections. On older Linux systems, this results in executable stacks, bypassing DEP/NX protections.

## Root Cause

- AWS-LC's CMake build uses `-Wa,--noexecstack` ([crypto/CMakeLists.txt:77](https://github.com/aws/aws-lc/blob/main/crypto/CMakeLists.txt#L77))
- `cmake_builder` passes this through correctly ✓
- `cc_builder` was missing this flag ✗

ML-KEM assembly files rely on the build system to add `.note.GNU-stack` sections via assembler flags (unlike s2n-bignum which has them in source).

## Solution

Add `-Wa,--noexecstack` using `cc-rs`'s `asm_flag()` method in `prepare_builder()`.

## Verification

Tested on x86_64 Linux:

**Before fix:**
```
readelf -S nttfrombytes.o | grep "\.note\.GNU-stack"
(no output - section missing)
```

**After fix:**
```
readelf -S nttfrombytes.o | grep "\.note\.GNU-stack"
[17] .note.GNU-stack   PROGBITS        0000000000000000  00000140
```

Full verification script available: [verify-execstack-fix.sh](https://gist.github.com/psifertex/d8caca2f04bdbdfc3d92af33d5bc02a1)

## Impact

- **Affected:** aws-lc-rs >= v0.32.3 on x86_64 Linux using `cc_builder`
- **Severity:** Medium - Older Linux systems get executable stacks
- **Modern systems:** Unaffected (kernel defaults to non-executable stacks)

## References

- mlkem-native handled this with linker flags: [Issue #590](https://github.com/pq-code-package/mlkem-native/issues/590), [PR #592](https://github.com/pq-code-package/mlkem-native/pull/592)
- [Hardened GNU stack quickstart](https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.