### PR TITLE
CI to verify GNU-stack section is present

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -362,8 +362,14 @@ jobs:
 
   gnu-stack-check:
     if: github.repository_owner == 'aws'
-    name: Verify GNU-stack section in object files
-    runs-on: ubuntu-latest
+    name: Verify (${{ matrix.host }}) GNU-stack section
+    runs-on: ${{ matrix.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### Issues:
Addresses #939

### Description of changes: 
Verifies that all ELF object files contain a `.note.GNU-stack` section.

### Call-outs:
The `*/bcm_c_generated_asm.dir/bcm.c.o` is actually an archive of assembly files that is passed to the delocator for parsing. A failure on this file is ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
