### PR TITLE
aws-lc-sys: make bindgen optional

### DIFF
--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -71,12 +71,7 @@ cmake.workspace = true
 dunce.workspace = true
 fs_extra.workspace = true
 cc = { workspace = true, features = ["parallel"] }
-
-[target.'cfg(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu")))'.build-dependencies]
 bindgen = { workspace = true, optional = true }
-
-[target.'cfg(not(any(all(any(target_arch="x86_64",target_arch="aarch64"),any(target_os="linux",target_os="macos",target_os="windows"),any(target_env="gnu",target_env="musl",target_env="msvc",target_env="")),all(target_arch="x86",target_os="windows",target_env="msvc"),all(target_arch="x86",target_os="linux",target_env="gnu"))))'.build-dependencies]
-bindgen.workspace = true
 
 [package.metadata.aws-lc-sys]
 commit-hash = "7187ab572ddcdae4fa408e932d3e878c9941137b"


### PR DESCRIPTION
### Description of changes: 
Make bindgen always an optional dependency

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
