### PR TITLE
Respect LDFLAGS in memcmp_check

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -582,6 +582,18 @@ impl CcBuilder {
             return;
         }
         let mut memcmp_compile_args = Vec::from(memcmp_compiler.args());
+
+        // This check invokes the compiled executable and hence needs to link
+        // it. CMake handles this via LDFLAGS but `cc` doesn't. In setups with
+        // custom linker setups this could lead to a mismatch between the
+        // expected and the actually used linker. Explicitly respecting LDFLAGS
+        // here brings us back to parity with CMake.
+        if let Ok(ldflags) = std::env::var("LDFLAGS") {
+            for flag in ldflags.split_whitespace() {
+                memcmp_compile_args.push(flag.into());
+            }
+        }
+
         memcmp_compile_args.push(
             self.manifest_dir
                 .join("aws-lc")


### PR DESCRIPTION
** The author of this is @aaronmondal

This check invokes the compiled executable and hence needs to link it. CMake handles this via LDFLAGS but `cc` doesn't. In setups with custom linker setups this could lead to a mismatch between the expected and the actually used linker. Explicitly respecting LDFLAGS here brings us back to parity with CMake.

Fixes https://github.com/aws/aws-lc-rs/issues/858 whose resolution is not applicable if ignoring compiler warnings is not an option.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
