### PR TITLE
Set CFLAGS before init'ing cc::Build

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -345,14 +345,15 @@ impl CcBuilder {
     }
 
     pub fn prepare_builder(&self) -> cc::Build {
+        let cflags = get_crate_cflags();
+        if !cflags.is_empty() {
+            set_env_for_target("CFLAGS", cflags);
+        }
+
         let mut cc_build = self.create_builder();
         let (_, build_options) = self.collect_universal_build_options(&cc_build);
         for option in build_options {
             option.apply_cc(&mut cc_build);
-        }
-        let cflags = get_crate_cflags();
-        if !cflags.is_empty() {
-            set_env_for_target("CFLAGS", cflags);
         }
 
         // Add --noexecstack flag for assembly files to prevent executable stacks


### PR DESCRIPTION
### Issues
Addresses:
* #965 

### Description of changes: 
* cc-builder: Move the setting of CFLAGS to before initialization of `cc::Build`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
