### PR TITLE
update cmake-rs version to support vs2026

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 bindgen = "0.72.0"
 cc = "1.2.26"
 clap = "=4.4.18"# v4.5 is MSRV 1.74
-cmake = "0.1.54"
+cmake = "0.1.55"
 criterion = "0.5.1" # v0.6.0 depends on clap v4.5
 dunce = "1.0.5"
 fs_extra = "1.3.0"


### PR DESCRIPTION
### Issues:
cmake-rs supports vs18 (2026) from 0.1.55 [cmake-rs Add Visual Studio 2026 support](https://github.com/rust-lang/cmake-rs/pull/255)

### Description of changes: 
update cmake version 0.1.54 -> 0.1.55

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
