### PR TITLE
impl Send for Streaming Keys

### DIFF
--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -24,6 +24,8 @@ pub struct StreamingEncryptingKey {
     context: EncryptionContext,
 }
 
+unsafe impl Send for StreamingEncryptingKey {}
+
 /// A struct indicating the portion of a buffer written to, and/or not written to, during an
 /// encryption/decryption operation.
 pub struct BufferUpdate<'a> {
@@ -341,6 +343,9 @@ pub struct StreamingDecryptingKey {
     mode: OperatingMode,
     cipher_ctx: LcPtr<EVP_CIPHER_CTX>,
 }
+
+unsafe impl Send for StreamingDecryptingKey {}
+
 impl StreamingDecryptingKey {
     #[allow(clippy::needless_pass_by_value)]
     fn new(

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -7,6 +7,7 @@ use aws_lc_rs::cipher::{
     StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
 use aws_lc_rs::iv::{FixedLength, IV_LEN_128_BIT};
+use aws_lc_rs::test;
 use aws_lc_rs::test::from_hex;
 use paste::paste;
 
@@ -1109,3 +1110,9 @@ unpadded_cipher_kat!(
     "00000000000000000000000000000000",
     "00112233445566778899aabbccddee"
 );
+
+#[test]
+fn test_streaming_cipher_traits() {
+    test::compile_time_assert_send::<StreamingEncryptingKey>();
+    test::compile_time_assert_send::<StreamingDecryptingKey>();
+}


### PR DESCRIPTION
### Issues:
Addresses #975

### Description of changes: 
Impl `Send` for `StreamingEncryptingKey` and `StreamingDecryptingKey`. 
* Both of these structs contain a `EVP_CIPHER_CTX` which contains no thread-local state and is safe to transfer between threads.

### Testing:
Added test to verify their `Send` trait at compile-time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
