### PR TITLE
Support Windows 7

### DIFF
--- a/aws-lc-sys/builder/cc_builder.rs
+++ b/aws-lc-sys/builder/cc_builder.rs
@@ -406,9 +406,10 @@ impl CcBuilder {
             if target().ends_with("-win7-windows-msvc") {
                 // 0x0601 is the value of `_WIN32_WINNT_WIN7`
                 build_options.push(BuildOption::define("_WIN32_WINNT", "0x0601"));
-                emit_warning(
-                    "Setting _WIN32_WINNT to _WIN32_WINNT_WIN7 for x86_64-win7-windows-msvc target",
-                );
+                emit_warning(format!(
+                    "Setting _WIN32_WINNT to _WIN32_WINNT_WIN7 for {} target",
+                    target()
+                ));
             }
         }
     }


### PR DESCRIPTION
### Issues:
Addresses aws/aws-lc#1997

### Description of changes: 
When targeting Windows 7, ensure that there's a definition for `_WIN32_WINNT)`.
* Related: aws/aws-lc#2940

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
