### PR TITLE
Enable CI for mips64-unknown-linux-muslabi64

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -56,8 +56,7 @@ jobs:
           - [ i686-unknown-linux-gnu, 0, 0, 1]
           - [ mips-unknown-linux-gnu, 0, 1, 0]
           - [ mips-unknown-linux-musl, 0, 1, 0]
-          # Pending: https://github.com/aws/aws-lc-rs/issues/522
-          # - [ mips64-unknown-linux-muslabi64, 0, 1, 0]
+          - [ mips64-unknown-linux-muslabi64, 0, 1, 0]
           - [ mips64el-unknown-linux-muslabi64, 0, 1, 0]
           - [ powerpc-unknown-linux-gnu, 1, 0, 1]
           - [ powerpc64-unknown-linux-gnu, 1, 0, 1]


### PR DESCRIPTION
### Description of changes: 
Enable CI for `mips64-unknown-linux-muslabi64`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
