### PR TITLE
Update criterion dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ zeroize = "1.8.1"
 # a dev-dependency or only used outside of our public crates.
 # These can be updated to the latest versions.
 clap = "4.4"
-criterion = "0.5.1"
+criterion = "0.8.2"
 hex = "0.4.3"
 lazy_static = "1.5.0"
 openssl = "0.10.73"

--- a/aws-lc-rs-testing/Cargo.toml
+++ b/aws-lc-rs-testing/Cargo.toml
@@ -3,7 +3,7 @@ name = "aws-lc-rs-testing"
 authors = ["AWS-LibCrypto"]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.86.0"
 publish = false
 
 [features]

--- a/aws-lc-rs-testing/benches/aead_benchmark.rs
+++ b/aws-lc-rs-testing/benches/aead_benchmark.rs
@@ -45,7 +45,7 @@ mod [<$pkg _benchmarks>]  {
 
     use $pkg::{aead, error};
 
-    use criterion::black_box;
+    use std::hint::black_box;
     use crate::AeadConfig;
     use aead::{
         Aad, BoundKey, Nonce, NonceSequence, OpeningKey, SealingKey, Tag, UnboundKey,

--- a/aws-lc-rs-testing/benches/digest_benchmark.rs
+++ b/aws-lc-rs-testing/benches/digest_benchmark.rs
@@ -30,7 +30,7 @@ macro_rules! benchmark_digest {
 
             use $pkg::{digest};
 
-            use criterion::black_box;
+            use std::hint::black_box;
             use crate::DigestConfig;
             use digest::{Context, Digest};
 

--- a/aws-lc-rs-testing/benches/hkdf_benchmark.rs
+++ b/aws-lc-rs-testing/benches/hkdf_benchmark.rs
@@ -31,7 +31,7 @@ macro_rules! benchmark_hkdf {
 
             use $pkg::{hkdf, digest};
 
-            use criterion::black_box;
+            use std::hint::black_box;
             use crate::HKDFConfig;
 
             pub fn algorithm(config: &crate::HKDFConfig) ->  hkdf::Algorithm {

--- a/aws-lc-rs-testing/benches/hmac_benchmark.rs
+++ b/aws-lc-rs-testing/benches/hmac_benchmark.rs
@@ -29,7 +29,7 @@ macro_rules! benchmark_hmac {
 
             use $pkg::{hmac, digest};
 
-            use criterion::black_box;
+            use std::hint::black_box;
             use crate::HMACConfig;
 
 

--- a/aws-lc-rs-testing/benches/pbkdf2_benchmark.rs
+++ b/aws-lc-rs-testing/benches/pbkdf2_benchmark.rs
@@ -31,7 +31,7 @@ macro_rules! benchmark_pbkdf2 {
             use $pkg::pbkdf2;
 
             use crate::PBKDF2Config;
-            use criterion::black_box;
+            use std::hint::black_box;
             use std::num::NonZeroU32;
 
             pub fn algorithm(config: &crate::PBKDF2Config) -> pbkdf2::Algorithm {

--- a/aws-lc-rs-testing/benches/quic_benchmark.rs
+++ b/aws-lc-rs-testing/benches/quic_benchmark.rs
@@ -42,7 +42,7 @@ macro_rules! benchmark_quic
 
             use $pkg::aead;
             use aead::quic;
-            use criterion::black_box;
+            use std::hint::black_box;
 
             fn algorithm(config: &crate::QuicConfig) -> &'static quic::Algorithm {
                 black_box(match &config.algorithm {


### PR DESCRIPTION
### Description of changes: 
- Updated criterion dependency version in workspace `Cargo.toml`
- Replaced `criterion::black_box` with `std::hint::black_box` in benchmark files (breaking API change in criterion 0.6.0+)

### Call-outs:
- `criterion::black_box` was deprecated in criterion 0.6.0; `std::hint::black_box()` is now the recommended approach
- This only affects dev-dependencies in `aws-lc-rs-testing`, so there is no impact to public crate MSRV

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
