### PR TITLE
Speedup CI completion

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -239,6 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CROSS_CONFIG: "./Cross.toml.x86_64-unknown-linux-gnu"
+      AWS_LC_RS_DISABLE_SLOW_TESTS: 1
     strategy:
       fail-fast: false
       matrix:
@@ -336,6 +337,8 @@ jobs:
   cargo-xwin:
     if: github.repository_owner == 'aws'
     runs-on: ${{ matrix.host }}
+    env:
+      AWS_LC_RS_DISABLE_SLOW_TESTS: 1
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -405,6 +405,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       AWS_LC_SYS_NO_ASM: 1
+      AWS_LC_RS_DISABLE_SLOW_TESTS: 1
     strategy:
       fail-fast: false
       matrix:
@@ -440,6 +441,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       AWS_LC_FIPS_SYS_NO_ASM: 1
+      AWS_LC_RS_DISABLE_SLOW_TESTS: 1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Description of changes: 
Set `AWS_LC_RS_DISABLE_SLOW_TESTS` for several slow running (>=30 minute) CI jobs that we have. (Setting this environment variable allows skipping slower tests, such as RSA 8192 key generation.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
