### PR TITLE
Prepare v1.16.0

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.15.4"
+version = "1.16.0"
 # this crate re-exports whatever sys crate that was selected
-links = "aws_lc_rs_1_15_4_sys"
+links = "aws_lc_rs_1_16_0_sys"
 edition = "2021"
 rust-version = "1.71.0"
 keywords = ["crypto", "cryptography", "security"]


### PR DESCRIPTION
### Description of changes: 
Prepare release v1.16.0.

### Call-outs:
```
Added items to the public API
=============================
+pub fn aws_lc_rs::kem::DecapsulationKey<Id>::key_bytes(&self) -> core::result::Result<aws_lc_rs::kem::DecapsulationKeyBytes<'static>, aws_lc_rs::error::Unspecified>
+pub fn aws_lc_rs::kem::DecapsulationKey<Id>::new(alg: &'static aws_lc_rs::kem::Algorithm<Id>, bytes: &[u8]) -> core::result::Result<Self, aws_lc_rs::error::KeyRejected>
+pub struct aws_lc_rs::kem::DecapsulationKeyBytes<'a>(_)
+impl core::fmt::Debug for aws_lc_rs::kem::DecapsulationKeyBytes<'_>
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), core::fmt::Error>
+impl<'a> core::ops::deref::Deref for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+pub type aws_lc_rs::kem::DecapsulationKeyBytes<'a>::Target = aws_lc_rs::buffer::Buffer<'a, aws_lc_rs::kem::buffer_type::DecapsulationKeyBytesType>
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::deref(&self) -> &Self::Target
+impl<'a> core::marker::Freeze for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+impl<'a> core::marker::Send for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+impl<'a> core::marker::Sync for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+impl<'a> core::marker::Unpin for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+impl<P, T> core::ops::deref::Receiver for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where P: core::ops::deref::Deref<Target = T> + ?core::marker::Sized, T: ?core::marker::Sized
+pub type aws_lc_rs::kem::DecapsulationKeyBytes<'a>::Target = T
+impl<T, U> core::convert::Into<U> for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where U: core::convert::From<T>
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where U: core::convert::Into<T>
+pub type aws_lc_rs::kem::DecapsulationKeyBytes<'a>::Error = core::convert::Infallible
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where U: core::convert::TryFrom<T>
+pub type aws_lc_rs::kem::DecapsulationKeyBytes<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where T: 'static + ?core::marker::Sized
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where T: ?core::marker::Sized
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aws_lc_rs::kem::DecapsulationKeyBytes<'a> where T: ?core::marker::Sized
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aws_lc_rs::kem::DecapsulationKeyBytes<'a>
+pub fn aws_lc_rs::kem::DecapsulationKeyBytes<'a>::from(t: T) -> T
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
