### PR TITLE
docs: Document dev-tests-only feature and improve platform support clarity

### DIFF
--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -106,6 +106,23 @@ Use of prebuilt NASM objects is prevented if either of the following conditions 
 Be aware that [features are additive](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification);
 by enabling this feature, it is enabled for all crates within the same build.
 
+##### dev-tests-only
+
+Enables the `rand::unsealed` module, which re-exports the normally sealed `SecureRandom` trait.
+This allows consumers to provide their own implementations of `SecureRandom` (e.g., a
+deterministic RNG) for testing purposes. When enabled, a `mut_fill` method is also available on
+`SecureRandom`.
+
+This feature is restricted to **dev/debug profile builds only** — attempting to use it in a
+release build will result in a compile-time error.
+
+It can be enabled in two ways:
+* **Feature flag:** `cargo test --features dev-tests-only`
+* **Environment variable:** `AWS_LC_RS_DEV_TESTS_ONLY=1 cargo test`
+
+> **⚠️ Warning:** This feature is intended **only** for development and testing. It must not be
+> used in production builds.
+
 ## Use of prebuilt NASM objects
 
 Prebuilt NASM objects are **only** applicable to Windows x86-64 platforms. They are **never** used on any other platform (Linux, macOS, etc.).

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -7,22 +7,21 @@ While we aim to be API-compatible with `ring` v0.16 there are some differences i
 
 ## Can I run `aws-lc-rs` on *X* platform or architecture?
 
-The answer to this question is dependent on several factors based on the target environment:
+**For non-FIPS builds:** If your target platform is supported by both [AWS-LC] and the
+[Rust compiler (with std support)][Rust compiler's platform support], then `aws-lc-rs` should work
+out of the box. The `aws-lc-sys` crate provides **universal pre-generated bindings** that work
+across all supported platforms — bindgen, CMake, and Go are **never** required. The only build
+requirement is a C/C++ compiler.
 
-* Must be a platform and CPU architecture supported by [AWS-LC].
-* Must be a platform supported by the Rust compiler with support for the full standard library.
-  See the [Rust compiler's platform support] documentation.
-* **For non-FIPS builds:** Bindgen is **never** required. The `aws-lc-sys` crate provides universal pre-generated
-  bindings that cover all functions used by `aws-lc-rs`.
-* **For FIPS builds:** If `aws-lc-fips-sys` doesn't have pre-generated bindings for your target platform,
-  you must use the `bindgen` crate feature of `aws-lc-rs`, or have the [bindgen-cli] installed, to enable
-  generation of the FFI bindings for the desired platform and architecture.
+**For FIPS builds:** Additional tooling is always required (CMake, Go), and bindgen is also required
+unless `aws-lc-fips-sys` has pre-generated bindings for your target platform. If bindgen is needed,
+you can either use the `bindgen` crate feature of `aws-lc-rs`, or have the [bindgen-cli] installed.
 
 > **Note:** If you take a direct dependency on `aws-lc-sys` (not through `aws-lc-rs`) and need access to the
 > complete AWS-LC API, you may want to use target-specific bindings or enable bindgen for complete API coverage.
 
-* See [Requirements](requirements/README.md) and [Platform Support](platform_support.md) for more details on
-  build requirements for various platforms.
+See [Requirements](requirements/README.md) and [Platform Support](platform_support.md) for more
+details on build requirements for various platforms.
 
 If there is a platform or architecture you are interested in seeing support for, please create a GitHub [issue].
 
@@ -37,3 +36,57 @@ If there is a platform or architecture you are interested in seeing support for,
 [issue]: https://github.com/aws/aws-lc-rs/issues/new/choose
 
 [bindgen-cli]: https://crates.io/crates/bindgen-cli
+
+## How can I use a custom or deterministic RNG for testing?
+
+The `dev-tests-only` feature unseals the `rand::SecureRandom` trait, allowing you to provide your
+own implementation of `SecureRandom` for custom random number generation in tests.
+This is useful when you need reproducible test vectors or want to control the random bytes returned
+during testing.
+
+To enable this functionality, either:
+
+* Add the `dev-tests-only` feature flag:
+
+```toml
+[dev-dependencies]
+aws-lc-rs = { version = "1", features = ["dev-tests-only"] }
+```
+
+* Or set the `AWS_LC_RS_DEV_TESTS_ONLY` environment variable:
+
+```shell
+AWS_LC_RS_DEV_TESTS_ONLY=1 cargo test
+```
+
+Once enabled, you can implement `aws_lc_rs::rand::unsealed::SecureRandom` for your own type.
+A blanket implementation will automatically provide the public `SecureRandom` trait for your type:
+
+```rust
+use aws_lc_rs::error::Unspecified;
+use aws_lc_rs::rand::{unsealed, SecureRandom};
+
+#[derive(Debug)]
+struct DeterministicRandom {
+    seed: u8,
+}
+
+impl unsealed::SecureRandom for DeterministicRandom {
+    fn fill_impl(&self, dest: &mut [u8]) -> Result<(), Unspecified> {
+        for (i, byte) in dest.iter_mut().enumerate() {
+            *byte = self.seed.wrapping_add(i as u8);
+        }
+        Ok(())
+    }
+}
+
+// DeterministicRandom now implements SecureRandom and can be used
+// anywhere a &dyn SecureRandom is expected.
+```
+
+> **Note:** The `dev-tests-only` feature is restricted to dev/debug profile builds only. Attempting
+> to use it in a release build will result in a compile-time error. This is a safety measure to
+> prevent deterministic or weakened RNG implementations from being used in production code.
+
+See the [`unsealed_rand_test.rs`](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-rs/tests/unsealed_rand_test.rs)
+file in the repository for additional examples.

--- a/book/src/platform_support.md
+++ b/book/src/platform_support.md
@@ -1,44 +1,37 @@
 # Platform Support
 
-## Pre-generated bindings
+## Non-FIPS Builds (`aws-lc-sys`)
 
-`aws-lc-rs` can utilize pre-generated bindings when operating on the following
-build targets.
+For non-FIPS builds, `aws-lc-sys` provides **universal pre-generated bindings** that work across
+**all** supported platforms. Bindgen is never required, CMake is never required, and Go is never
+required. The only build requirement is a C/C++ compiler.
 
-| Platform                     | `aws-lc-sys` | `aws-lc-fips-sys` | 
-|------------------------------|--------------|-------------------|
-| `aarch64-apple-darwin`       | ✓            | ✓                 | 
-| `aarch64-pc-windows-msvc`    | ✓            | ✓ ²               |
-| `aarch64-unknown-linux-gnu`  | ✓            | ✓                 |
-| `aarch64-unknown-linux-musl` | ✓            | ✓                 |
-| `i686-pc-windows-msvc`       | ✓            | **Not Supported** |
-| `i686-unknown-linux-gnu`     | ✓            | **Not Supported** |
-| `x86_64-apple-darwin`        | ✓            | ✓                 |             
-| `x86_64-pc-windows-gnu`      | ✓            | **Not Supported** |
-| `x86_64-pc-windows-msvc`     | ✓            | ✓ ²               |
-| `x86_64-unknown-linux-gnu`   | ✓            | ✓                 |
-| `x86_64-unknown-linux-musl`  | ✓            | ✓                 |
+This means that if your target platform is supported by both [AWS-LC] and the
+[Rust compiler (with std support)][platform-support], `aws-lc-rs` should work out of the box
+without any additional tooling beyond a C/C++ compiler.
 
-² FIPS is supported but requires bindgen (no pre-generated FIPS bindings are available for Windows platforms)
+## FIPS Builds (`aws-lc-fips-sys`)
 
-## Tested platforms
+FIPS builds always require **CMake** and **Go** in addition to a C/C++ compiler. FIPS builds also
+require **bindgen** unless pre-generated bindings are available for the target platform.
 
-In addition to the platforms with pre-generated bindings listed above, `aws-lc-rs` CI builds and/or tests on many additional platforms.
-See our [CI workflow configuration](https://github.com/aws/aws-lc-rs/blob/main/.github/workflows/cross.yml) for the complete list of tested platforms.
+### Pre-generated FIPS Bindings
 
-### Build Requirements Summary
+Pre-generated bindings for `aws-lc-fips-sys` are available for the following targets. All other
+FIPS targets require bindgen.
 
-**For non-FIPS builds (`aws-lc-sys`):**
-- C/C++ Compiler: Required
-- CMake: **Never** required
-- Bindgen: **Never** required (universal pre-generated bindings are provided)
-- Go: **Never** required
+| Platform                     | Pre-generated FIPS Bindings |
+|------------------------------|-----------------------------|
+| `aarch64-apple-darwin`       | ✓                           |
+| `aarch64-pc-windows-msvc`    | ✗ (bindgen required) ¹      |
+| `aarch64-unknown-linux-gnu`  | ✓                           |
+| `aarch64-unknown-linux-musl` | ✓                           |
+| `x86_64-apple-darwin`        | ✓                           |
+| `x86_64-pc-windows-msvc`     | ✗ (bindgen required) ¹      |
+| `x86_64-unknown-linux-gnu`   | ✓                           |
+| `x86_64-unknown-linux-musl`  | ✓                           |
 
-**For FIPS builds (`aws-lc-fips-sys`):**
-- C/C++ Compiler: Required
-- CMake: **Always** required
-- Go: **Always** required
-- Bindgen: Required **unless** the target has pre-generated bindings (see table above)
+¹ FIPS is supported on this platform but requires bindgen (no pre-generated FIPS bindings are available for Windows platforms)
 
 ### Bindgen for FIPS Builds
 
@@ -59,6 +52,20 @@ _**-- OR --**_
 ```shell
 cargo install --force --locked bindgen-cli
 ```
+
+## Tested Platforms
+
+`aws-lc-rs` CI builds and/or tests on many platforms beyond those listed in the FIPS bindings table above.
+See our [CI workflow configuration](https://github.com/aws/aws-lc-rs/blob/main/.github/workflows/cross.yml) for the complete list of tested platforms.
+
+### Build Requirements Summary
+
+| Requirement       | Non-FIPS (`aws-lc-sys`)            | FIPS (`aws-lc-fips-sys`)                                  |
+|-------------------|------------------------------------|-----------------------------------------------------------|
+| C/C++ Compiler    | Required                           | Required                                                  |
+| CMake             | **Never** required                 | **Always** required                                       |
+| Bindgen           | **Never** required (universal pre-generated bindings) | Required unless target has pre-generated bindings |
+| Go                | **Never** required                 | **Always** required                                       |
 
 ### Linux Platforms
 
@@ -132,3 +139,6 @@ cargo install --force --locked bindgen-cli
 | OpenHarmony (aarch64)     | ✓     |       |
 | OpenWrt (aarch64-musl)    | ✓     |       |
 | Alpine Linux              | ✓     | ✓     |
+
+[AWS-LC]: https://github.com/aws/aws-lc
+[platform-support]: https://doc.rust-lang.org/rustc/platform-support.html

--- a/book/src/requirements/README.md
+++ b/book/src/requirements/README.md
@@ -25,8 +25,8 @@ required** for `aws-lc-rs` users.
 > [`aws-lc-sys/src/`](https://github.com/aws/aws-lc-rs/tree/main/aws-lc-sys/src).
 
 **FIPS (`aws-lc-fips-sys`):** Pre-generated bindings are available for a limited set of targets.
-See [`aws-lc-fips-sys/src/`](https://github.com/aws/aws-lc-rs/tree/main/aws-lc-fips-sys/src) for
-the list. Bindgen is required for all other targets.
+See the [Pre-generated FIPS Bindings](../platform_support.md#pre-generated-fips-bindings) table
+on the Platform Support page for the full list. Bindgen is required for all other targets.
 
 ### Tested Platforms
 

--- a/book/src/resources.md
+++ b/book/src/resources.md
@@ -143,6 +143,31 @@ The target-specific variant takes precedence when both are set.
   > It is primarily useful for selecting different pre-generated bindings or symbol prefixes
   > when building for targets that are compatible with another target's bindings.
 
+## `aws-lc-rs` Environment Variables
+
+The `aws-lc-rs` crate supports the following environment variables for configuring build behavior.
+
+* **`AWS_LC_RS_DEV_TESTS_ONLY`**
+
+  Enables development-only testing functionality without requiring the `dev-tests-only` feature flag.
+  When enabled, the `rand::unsealed` module is exposed, allowing consumers to provide their own
+  implementations of `SecureRandom` for deterministic or custom random number generation in tests.
+
+  - `1` - Enable development testing functionality
+  - `0` - Explicitly disable (overrides the `dev-tests-only` feature flag if set)
+
+  This setting is restricted to dev/debug profile builds. Attempting to use it in a release build
+  will result in a compilation panic.
+
+  > **Note:** This environment variable can also override the `dev-tests-only` Cargo feature flag.
+  > If both the feature flag and the environment variable are present, the environment variable
+  > takes precedence.
+
+* **`AWS_LC_RS_DISABLE_SLOW_TESTS`**
+
+  When set to `1`, disables slow-running tests in the `aws-lc-rs` test suite. This can be useful
+  for faster iteration during development.
+
 ## Links
 
 - [API Reference Guide](https://docs.rs/aws-lc-rs/latest)


### PR DESCRIPTION
### Issues:
Addresses #1020

### Description of changes:
Documents the `dev-tests-only` feature and related changes introduced in fcec9cd4ae4, and improves
the clarity of platform support documentation for non-FIPS users.

**`dev-tests-only` feature documentation:**
- Added `dev-tests-only` feature flag entry to the Feature Flags section in both `README.md` and
  `aws-lc-rs/README.md`.
- Added `AWS_LC_RS_DEV_TESTS_ONLY` and `AWS_LC_RS_DISABLE_SLOW_TESTS` environment variables to
  the Resources page in the user guide (`book/src/resources.md`).
- Added a new FAQ entry ("How can I use a custom or deterministic RNG for testing?") with usage
  instructions and a code example (`book/src/faq.md`).

**Platform support clarity:**
- Restructured `book/src/platform_support.md` so non-FIPS builds lead the page with a clear
  statement that universal bindings work on all supported platforms. The pre-generated bindings
  table is now scoped to FIPS only, avoiding the impression that non-FIPS support is
  platform-specific.
- Updated `book/src/requirements/README.md` to cross-reference the new FIPS bindings table
  instead of linking to a raw GitHub source directory.
- Streamlined the platform FAQ in `book/src/faq.md` to lead with the simple non-FIPS story
  before introducing FIPS caveats.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
