### PR TITLE
Avoid Valgrind false-positives

### DIFF
--- a/.valgrind/rust-test.supp
+++ b/.valgrind/rust-test.supp
@@ -37,14 +37,18 @@
    ...
 }
 
-# Rust std::thread::Thread::new allocates thread metadata
-# This can appear as "possibly lost" due to interior pointers in Thread structure
+# Rust std::thread::Thread::new allocates thread metadata (e.g., Arc<Inner>)
+# This can appear as "possibly lost" due to interior pointers in the Thread structure.
+# The `...` between malloc and Thread::new allows for intermediate allocator frames
+# (alloc, alloc_impl, allocate, allocate_for_layout, etc.) which vary by Rust version.
 {
    rust_thread_new_interior_pointer
    Memcheck:Leak
    match-leak-kinds: possible
    fun:malloc
-   fun:*thread*Thread*new*
+   ...
+   fun:*Thread*new*
+   fun:*init_current*
    ...
 }
 


### PR DESCRIPTION
### Description of changes:

The `rust_thread_new_interior_pointer` Valgrind suppression rule assumed
`malloc` was immediately followed by `Thread::new` in the call stack. On
newer Rust versions the allocator internals (`alloc` → `alloc_impl` →
`allocate` → `allocate_for_layout` → `new_uninit_in`) are no longer
inlined, so intermediate frames appear between them and the rule stops
matching. This causes the CI Valgrind job to fail with a false-positive
"possibly lost: 48 bytes in 1 blocks" from the Rust test harness thread
initialization.

The fix adds a `...` wildcard between `malloc` and `Thread::new` to
allow any number of intermediate allocator frames, and anchors on
`init_current` to keep the rule scoped to the test harness path.

### Call-out:
```
==125044== 48 bytes in 1 blocks are possibly lost in loss record 1 of 2
==125044==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==125044==    by 0x8F658B: alloc (unix.rs:14)
==125044==    by 0x8F658B: alloc_impl (alloc.rs:151)
==125044==    by 0x8F658B: allocate (alloc.rs:214)
==125044==    by 0x8F658B: {closure#0}<std::thread::thread::Inner, std::alloc::System> (sync.rs:805)
==125044==    by 0x8F658B: allocate_for_layout<core::mem::maybe_uninit::MaybeUninit<std::thread::thread::Inner>, alloc::sync::{impl#17}::new_uninit_in::{closure_env#0}<std::thread::thread::Inner, std::alloc::System>, fn(*mut u8) -> *mut alloc::sync::ArcInner<core::mem::maybe_uninit::MaybeUninit<std::thread::thread::Inner>>> (sync.rs:2162)
==125044==    by 0x8F658B: new_uninit_in<std::thread::thread::Inner, std::alloc::System> (sync.rs:803)
==125044==    by 0x8F658B: std::thread::thread::Thread::new (thread.rs:102)
==125044==    by 0x8F67FF: std::thread::current::init_current (current.rs:294)
...
==125044==    by 0x447C08: test::test_main (lib.rs:101)
==125044==    by 0x432B7A: test::test_main_static (lib.rs:183)
==125044==    by 0x346262: aws_lc_rs::main (lib.rs:0)
==125044==    by 0x3B6E1A: core::ops::function::FnOnce::call_once (function.rs:250)
==125044==    by 0x34F6DD: std::sys::backtrace::__rust_begin_short_backtrace (backtrace.rs:166)
```

### Testing:

Verified locally under Valgrind with and without the suppression file.
The 48-byte "possibly lost" is properly suppressed, and `--strict-leaks`
confirms zero definitely/indirectly lost bytes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
