### PR TITLE
Should be BSD-3-Clause

### DIFF
--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -6,7 +6,7 @@ links = "aws_lc_0_39_0"
 authors = ["AWS-LC"]
 edition = "2021"
 repository = "https://github.com/aws/aws-lc-rs"
-license = "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3 AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)"
+license = "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)"
 rust-version = "1.71.0"
 include = [
     "LICENSE",


### PR DESCRIPTION

### Description of changes: 
Should be `BSD-3-Clause`: https://spdx.org/licenses/BSD-3-Clause.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
