### PR TITLE
Deprecate KeySize::Rsa2048

### DIFF
--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -42,6 +42,11 @@ use zeroize::Zeroize;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeySize {
     /// 2048-bit key
+    #[deprecated(
+        note = "RSA 2048-bit keys are not recommended for new key generation. \
+                NIST SP 800-131A Rev. 3 (draft) deprecates RSA keys smaller than \
+                3072 bits after 2030. Use `KeySize::Rsa3072` or larger."
+    )]
     Rsa2048,
 
     /// 3072-bit key
@@ -55,6 +60,7 @@ pub enum KeySize {
 }
 
 #[allow(clippy::len_without_is_empty)]
+#[allow(deprecated)]
 impl KeySize {
     /// Returns the size of the key in bytes.
     #[inline]


### PR DESCRIPTION
### Description of changes
`KeySize::Rsa2048` is currently treated the same as larger key sizes. This adds `#[deprecated]` to discourage its use for new key generation and guide users toward `Rsa3072` or larger. RSA 2048 remains fully supported; no behavior is changed.

### Call-outs
RSA 2048 remains acceptable for current use under NIST SP 800-131A Rev. 3 (draft), with deprecation of `<3072`-bit keys expected - after 2030. This deprecation is forward-looking guidance only and does not affect current FIPS compliance. The change is intentionally ahead of finalized guidance; maintainers may want to confirm this aligns with aws-lc-rs policy on tracking external standards. `#[allow(deprecated)]` is added within the `KeySize` impl to suppress warnings when matching over all variants.

### Testing
No behavior changes introduced. Build and existing tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.