### PR TITLE
Support ML-DSA context strings in signing and verification

### DIFF
--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -4,6 +4,8 @@
 use crate::aws_lc::{
     EVP_PKEY_CTX_pqdsa_set_params, EVP_PKEY_pqdsa_new_raw_private_key, EVP_PKEY, EVP_PKEY_PQDSA,
 };
+#[cfg(feature = "unstable")]
+use crate::aws_lc::{EVP_PKEY_CTX_set_signature_context, EVP_PKEY_CTX};
 use crate::encoding::{AsDer, AsRawBytes, Pkcs8V1Der, PqdsaPrivateKeyRaw};
 use crate::error::{KeyRejected, Unspecified};
 use crate::evp_pkey::No_EVP_PKEY_CTX_consumer;
@@ -242,6 +244,46 @@ impl PqdsaKeyPair {
             return Err(Unspecified);
         }
         let sig_bytes = self.evp_pkey.sign(msg, None, No_EVP_PKEY_CTX_consumer)?;
+        signature[0..sig_length].copy_from_slice(&sig_bytes);
+        Ok(sig_length)
+    }
+
+    /// Signs the message with a FIPS 204 context string.
+    ///
+    /// The `context` parameter is an octet string of at most 255 bytes that provides
+    /// domain separation per FIPS 204 §5.2. An empty context is equivalent to calling
+    /// [`Self::sign`].
+    ///
+    /// This method is gated behind the `unstable` feature: context strings are not
+    /// supported by the FIPS 204 module, so signing with a non-empty context fails
+    /// under the `fips` feature.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if signing fails or if `context` exceeds 255 bytes.
+    #[cfg(feature = "unstable")]
+    pub fn sign_with_context(
+        &self,
+        msg: &[u8],
+        context: &[u8],
+        signature: &mut [u8],
+    ) -> Result<usize, Unspecified> {
+        let sig_length = self.algorithm.signature_len();
+        if signature.len() < sig_length {
+            return Err(Unspecified);
+        }
+        let ctx_fn = |pctx: *mut EVP_PKEY_CTX| -> Result<(), ()> {
+            if context.is_empty() {
+                return Ok(());
+            }
+            if 1 == unsafe {
+                EVP_PKEY_CTX_set_signature_context(pctx, context.as_ptr(), context.len())
+            } {
+                Ok(())
+            } else {
+                Err(())
+            }
+        };
+        let sig_bytes = self.evp_pkey.sign(msg, None, Some(ctx_fn))?;
         signature[0..sig_length].copy_from_slice(&sig_bytes);
         Ok(sig_length)
     }

--- a/aws-lc-rs/src/pqdsa/signature.rs
+++ b/aws-lc-rs/src/pqdsa/signature.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::EVP_PKEY;
+#[cfg(feature = "unstable")]
+use crate::aws_lc::{EVP_PKEY_CTX_set_signature_context, EVP_PKEY_CTX};
 use crate::buffer::Buffer;
 use crate::digest::Digest;
 use crate::encoding::{AsDer, PublicKeyX509Der};
@@ -149,6 +151,44 @@ impl VerificationAlgorithm for PqdsaVerificationAlgorithm {
         _signature: &[u8],
     ) -> Result<(), Unspecified> {
         Err(Unspecified)
+    }
+}
+
+impl PqdsaVerificationAlgorithm {
+    /// Verifies the signature for `msg` using a FIPS 204 context string.
+    ///
+    /// The `context` parameter is an octet string of at most 255 bytes that provides
+    /// domain separation per FIPS 204 §5.2. An empty context is equivalent to calling
+    /// [`VerificationAlgorithm::verify_sig`].
+    ///
+    /// This method is gated behind the `unstable` feature: context strings are not
+    /// supported by the FIPS 204 module, so verifying against a non-empty context
+    /// fails under the `fips` feature.
+    ///
+    /// # Errors
+    /// `error::Unspecified` if the signature is invalid or `context` exceeds 255 bytes.
+    #[cfg(feature = "unstable")]
+    pub fn verify_sig_with_context(
+        &self,
+        public_key: &[u8],
+        msg: &[u8],
+        context: &[u8],
+        signature: &[u8],
+    ) -> Result<(), Unspecified> {
+        let evp_pkey = parse_pqdsa_public_key(public_key, self.id)?;
+        let ctx_fn = |pctx: *mut EVP_PKEY_CTX| -> Result<(), ()> {
+            if context.is_empty() {
+                return Ok(());
+            }
+            if 1 == unsafe {
+                EVP_PKEY_CTX_set_signature_context(pctx, context.as_ptr(), context.len())
+            } {
+                Ok(())
+            } else {
+                Err(())
+            }
+        };
+        evp_pkey.verify(msg, None, Some(ctx_fn), signature)
     }
 }
 

--- a/aws-lc-rs/tests/pqdsa_test.rs
+++ b/aws-lc-rs/tests/pqdsa_test.rs
@@ -323,3 +323,67 @@ fn test_mldsa_seed_functional_equivalence() {
             .expect("reconstructed signature should verify");
     }
 }
+
+// The context-string API is gated behind `unstable`, and ML-DSA context strings
+// are not supported by the FIPS module (signing with a non-empty context fails
+// under `fips`). Exercise this only in non-FIPS `unstable` builds; the
+// empty-context path is covered by the sigver KATs.
+#[cfg(all(not(feature = "fips"), feature = "unstable"))]
+#[test]
+fn test_mldsa_context_string() {
+    for (signing_alg, verify_alg) in [
+        (&ML_DSA_44_SIGNING, &ML_DSA_44),
+        (&ML_DSA_65_SIGNING, &ML_DSA_65),
+        (&ML_DSA_87_SIGNING, &ML_DSA_87),
+    ] {
+        let kp = PqdsaKeyPair::generate(signing_alg).unwrap();
+        let msg = b"context string test message";
+        let ctx = b"my-application-context";
+        let mut sig = vec![0u8; signing_alg.signature_len()];
+
+        // Sign with context, verify with same context
+        let sig_len = kp.sign_with_context(msg, ctx, &mut sig).unwrap();
+        assert_eq!(sig_len, signing_alg.signature_len());
+        verify_alg
+            .verify_sig_with_context(kp.public_key().as_ref(), msg, ctx, &sig)
+            .expect("same context should verify");
+
+        // Wrong context fails
+        assert!(
+            verify_alg
+                .verify_sig_with_context(kp.public_key().as_ref(), msg, b"wrong", &sig)
+                .is_err(),
+            "wrong context should fail"
+        );
+
+        // No context fails for signature made with context
+        assert!(
+            verify_alg
+                .verify_sig(kp.public_key().as_ref(), msg, &sig)
+                .is_err(),
+            "no context should fail for context-signed signature"
+        );
+
+        // Empty context matches default sign()
+        let mut sig_empty = vec![0u8; signing_alg.signature_len()];
+        kp.sign_with_context(msg, b"", &mut sig_empty).unwrap();
+        verify_alg
+            .verify_sig(kp.public_key().as_ref(), msg, &sig_empty)
+            .expect("empty context should match default");
+
+        // Context > 255 bytes rejected
+        let long_ctx = [0x41u8; 256];
+        assert!(
+            kp.sign_with_context(msg, &long_ctx, &mut sig).is_err(),
+            "context > 255 bytes should be rejected"
+        );
+
+        // Max context (255 bytes) accepted
+        let max_ctx = [0x42u8; 255];
+        kp.sign_with_context(msg, &max_ctx, &mut sig)
+            .expect("255-byte context should be accepted");
+        verify_alg
+            .verify_sig_with_context(kp.public_key().as_ref(), msg, &max_ctx, &sig)
+            .expect("255-byte context should verify");
+    }
+}


### PR DESCRIPTION
### Issues:
Resolves: https://github.com/aws/aws-lc-rs/issues/1079
Depends on aws/aws-lc#3135.

### Description of changes: 
Add `sign_with_context` and `verify_sig_with_context` methods to `PqdsaKeyPair` and `PqdsaVerificationAlgorithm` respectively, allowing callers to specify FIPS 204 context strings (up to 255 bytes) for ML-DSA operations.

These methods use the existing `EVP_PKEY_CTX_set_signature_context` FFI binding (already available in aws-lc-sys) via the `EVP_PKEY_CTX_consumer` closure pattern. Empty contexts are equivalent to the existing context-free sign/verify methods.

### Testing:
Update the `mldsa_sigver_test` macro to exercise `verify_sig_with_context` with test vector context strings. Add dedicated test covering round-trip sign+verify with context, mismatched context failure, empty context backward compatibility, >255 byte rejection, and max-length (255 byte) acceptance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
