### PR TITLE
MSVC Fix: Improve bad intrinsic check on msvc

### DIFF
--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -750,13 +750,10 @@ impl CcBuilder {
         // try_compile_intermediates succeeds but __builtin_bswap* are unresolved at
         // link time. Without this guard the define is set and crypto/internal.h skips
         // the correct _MSC_VER path that uses _byteswap_* intrinsics.
+        if target_env() != "msvc"
+            && self.compiler_check("builtin_swap_check", Vec::<&'static str>::new())
         {
-            let compiler = cc::Build::default().get_compiler();
-            if (compiler.is_like_gnu() || compiler.is_like_clang())
-                && self.compiler_check("builtin_swap_check", Vec::<&'static str>::new())
-            {
-                cc_build.define("AWS_LC_BUILTIN_SWAP_SUPPORTED", Some("1"));
-            }
+            cc_build.define("AWS_LC_BUILTIN_SWAP_SUPPORTED", Some("1"));
         }
         if target_arch() == "aarch64"
             && self.compiler_check("neon_sha3_check", vec!["-march=armv8.4-a+sha3"])

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -746,8 +746,17 @@ impl CcBuilder {
         if self.compiler_check("stdalign_check", Vec::<&'static str>::new()) {
             cc_build.define("AWS_LC_STDALIGN_AVAILABLE", Some("1"));
         }
-        if self.compiler_check("builtin_swap_check", Vec::<&'static str>::new()) {
-            cc_build.define("AWS_LC_BUILTIN_SWAP_SUPPORTED", Some("1"));
+        // Only run builtin_swap_check for GCC/Clang (matching CMake). On MSVC,
+        // try_compile_intermediates succeeds but __builtin_bswap* are unresolved at
+        // link time. Without this guard the define is set and crypto/internal.h skips
+        // the correct _MSC_VER path that uses _byteswap_* intrinsics.
+        {
+            let compiler = cc::Build::default().get_compiler();
+            if (compiler.is_like_gnu() || compiler.is_like_clang())
+                && self.compiler_check("builtin_swap_check", Vec::<&'static str>::new())
+            {
+                cc_build.define("AWS_LC_BUILTIN_SWAP_SUPPORTED", Some("1"));
+            }
         }
         if target_arch() == "aarch64"
             && self.compiler_check("neon_sha3_check", vec!["-march=armv8.4-a+sha3"])


### PR DESCRIPTION
### Issues:
None
### Description of changes: 
Fixes the cc_builder check for builtin swap intrinsics to better match cmake behavior and avoid link-time failures on MSVC. the `builtin_swap_check` passes, but AWS_LC_BUILTIN_SWAP_SUPPORTED should never be set for MSVC.

### Call-outs:
Only reproducible on Windows.

### Testing:
I've tested locally on windows when compiling via bazel

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
