### PR TITLE
Support MSAN and TSAN sanitizer builds via environment variable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,6 +214,7 @@ jobs:
           AWS_LC_FIPS_SYS_SANITIZER: msan
           RUSTFLAGS: -Zsanitizer=memory -Zsanitizer-memory-track-origins
           RUSTDOCFLAGS: -Zsanitizer=memory -Zsanitizer-memory-track-origins
+          AWS_LC_RS_DISABLE_SLOW_TESTS: 1
         working-directory: ./aws-lc-rs
         run: cargo test -Zbuild-std ${{ matrix.args }} --lib --bins --tests --examples --target x86_64-unknown-linux-gnu ${{ matrix.features }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,6 +185,71 @@ jobs:
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }} --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --features asan
 
+  aws-lc-rs-msan:
+    if: github.repository_owner == 'aws'
+    name: aws-lc-rs msan
+    strategy:
+      fail-fast: false
+      matrix:
+        args:
+          - ''
+          - --release
+        features:
+          - ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+          components: rust-src
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Run memory sanitizers
+        env:
+          AWS_LC_SYS_SANITIZER: msan
+          AWS_LC_FIPS_SYS_SANITIZER: msan
+          RUSTFLAGS: -Zsanitizer=memory -Zsanitizer-memory-track-origins
+          RUSTDOCFLAGS: -Zsanitizer=memory -Zsanitizer-memory-track-origins
+        working-directory: ./aws-lc-rs
+        run: cargo test -Zbuild-std ${{ matrix.args }} --lib --bins --tests --examples --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+
+  aws-lc-rs-tsan:
+    if: github.repository_owner == 'aws'
+    name: aws-lc-rs tsan
+    strategy:
+      fail-fast: false
+      matrix:
+        args:
+          - ''
+          - --release
+        features:
+          - ''
+          - --no-default-features --features fips
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+          components: rust-src
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Run thread sanitizers
+        env:
+          AWS_LC_SYS_SANITIZER: tsan
+          AWS_LC_FIPS_SYS_SANITIZER: tsan
+          RUSTFLAGS: -Zsanitizer=thread
+          RUSTDOCFLAGS: -Zsanitizer=thread
+        working-directory: ./aws-lc-rs
+        run: cargo test -Zbuild-std ${{ matrix.args }} --lib --bins --tests --examples --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+
   build-env-static-test:
     if: github.repository_owner == 'aws'
     name: aws-lc-rs build-env-static-test

--- a/aws-lc-rs/Makefile
+++ b/aws-lc-rs/Makefile
@@ -24,6 +24,21 @@ asan-fips:
 #	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --test ecdsa_tests          --target `rustc -vV | sed -n 's|host: ||p'` --no-default-features --features fips,asan
 	RUST_BACKTRACE=1 ASAN_OPTIONS=detect_leaks=1 RUSTFLAGS=-Zsanitizer=address RUSTDOCFLAGS=-Zsanitizer=address cargo +nightly test --lib --bins --tests --examples --target `rustc -vV | sed -n 's|host: ||p'` --no-default-features --features fips,asan
 
+msan:
+	RUST_BACKTRACE=1 AWS_LC_SYS_SANITIZER=msan RUSTFLAGS="-Zsanitizer=memory -Zsanitizer-memory-track-origins" RUSTDOCFLAGS="-Zsanitizer=memory -Zsanitizer-memory-track-origins" cargo +nightly test -Zbuild-std --lib --bins --tests --examples --target x86_64-unknown-linux-gnu
+
+msan-release:
+	RUST_BACKTRACE=1 AWS_LC_SYS_SANITIZER=msan RUSTFLAGS="-Zsanitizer=memory -Zsanitizer-memory-track-origins" RUSTDOCFLAGS="-Zsanitizer=memory -Zsanitizer-memory-track-origins" cargo +nightly test -Zbuild-std --release --lib --bins --tests --examples --target x86_64-unknown-linux-gnu
+
+tsan:
+	RUST_BACKTRACE=1 AWS_LC_SYS_SANITIZER=tsan RUSTFLAGS=-Zsanitizer=thread RUSTDOCFLAGS=-Zsanitizer=thread cargo +nightly test -Zbuild-std --lib --bins --tests --examples --target x86_64-unknown-linux-gnu
+
+tsan-release:
+	RUST_BACKTRACE=1 AWS_LC_SYS_SANITIZER=tsan RUSTFLAGS=-Zsanitizer=thread RUSTDOCFLAGS=-Zsanitizer=thread cargo +nightly test -Zbuild-std --release --lib --bins --tests --examples --target x86_64-unknown-linux-gnu
+
+tsan-fips:
+	RUST_BACKTRACE=1 AWS_LC_FIPS_SYS_SANITIZER=tsan RUSTFLAGS=-Zsanitizer=thread RUSTDOCFLAGS=-Zsanitizer=thread cargo +nightly test -Zbuild-std --lib --bins --tests --examples --target x86_64-unknown-linux-gnu --no-default-features --features fips
+
 coverage:
 	cargo llvm-cov --features "${AWS_LC_RS_COV_EXTRA_FEATURES}" --no-fail-fast --fail-under-lines 95 --ignore-filename-regex "aws-lc(-fips|)-sys/*" --lcov --output-path lcov.info
 
@@ -62,4 +77,4 @@ ci: format clippy msrv test coverage api-diff-pub
 readme:
 	cargo readme | tee README.md
 
-.PHONY: asan asan-fips asan-release ci clippy coverage coverage-fips test msrv clippy clippy-fix
+.PHONY: asan asan-fips asan-release msan msan-release tsan tsan-release tsan-fips ci clippy coverage coverage-fips test msrv clippy clippy-fix

--- a/aws-lc-rs/src/aead/poly1305.rs
+++ b/aws-lc-rs/src/aead/poly1305.rs
@@ -41,7 +41,12 @@ impl Context {
     #[inline]
     pub(super) fn from_key(Key { key_and_nonce }: Key) -> Self {
         unsafe {
-            let mut state = MaybeUninit::<poly1305_state>::uninit();
+            // Use `zeroed()` instead of `uninit()` for MSAN compatibility.
+            // `CRYPTO_poly1305_init` may not write all 512 bytes of the opaque
+            // `poly1305_state` buffer, so MSAN would flag `assume_init()` as
+            // reading uninitialized memory. Zeroing is safe since the underlying
+            // type is `[u8; 512]`.
+            let mut state = MaybeUninit::<poly1305_state>::zeroed();
             CRYPTO_poly1305_init(state.as_mut_ptr().cast(), key_and_nonce.as_ptr());
             Self {
                 state: state.assume_init(),

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -89,6 +89,22 @@
 //! ["Address Sanitizer" section](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#addresssanitizer)
 //! of the [Rust Unstable Book](https://doc.rust-lang.org/beta/unstable-book/).
 //!
+//! **Preferred alternative:** Instead of the `asan` feature flag, you can set the
+//! `AWS_LC_SYS_SANITIZER` environment variable (or `AWS_LC_FIPS_SYS_SANITIZER` for FIPS builds)
+//! to one of: `asan`, `msan`, `tsan`. This approach does not require forwarding a feature through
+//! the dependency graph and also supports MemorySanitizer and ThreadSanitizer.
+//! MSAN and TSAN require the standard library to be rebuilt with sanitizer instrumentation, so
+//! you must install the `rust-src` component and pass `-Zbuild-std` to Cargo. For example:
+//!
+//! ```bash
+//! rustup component add rust-src --toolchain nightly
+//! AWS_LC_SYS_SANITIZER=msan RUSTFLAGS="-Zsanitizer=memory -Zsanitizer-memory-track-origins" \
+//!     cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu
+//! ```
+//!
+//! **Note:** MSAN is not currently supported for FIPS builds due to a missing preprocessor guard
+//! in the upstream AWS-LC `bcm.c` integrity check.
+//!
 //! #### bindgen
 //!
 //! Causes `aws-lc-sys` or `aws-lc-fips-sys` to generates fresh bindings for AWS-LC instead of using

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -6,7 +6,7 @@ use crate::OutputLib::{Crypto, Ssl};
 use crate::{
     allow_prebuilt_nasm, cargo_env, disable_jitter_entropy, effective_target, emit_warning,
     execute_command, get_crate_cflags, is_crt_static, is_fips_build, is_no_asm,
-    is_no_pregenerated_src, optional_env, optional_env_optional_crate_target, set_env,
+    is_no_pregenerated_src, optional_env, optional_env_optional_crate_target, sanitizer, set_env,
     set_env_for_target, target_arch, target_env, target_os, test_clang_cl_command,
     test_nasm_command, use_prebuilt_nasm, OutputLibType,
 };
@@ -189,12 +189,7 @@ impl CmakeBuilder {
             }
         }
 
-        if cfg!(feature = "asan") {
-            set_env_for_target("CC", "clang");
-            set_env_for_target("CXX", "clang++");
-
-            cmake_cfg.define("ASAN", "1");
-        }
+        Self::configure_sanitizer(&mut cmake_cfg);
 
         if let Some(cflags) = get_crate_cflags() {
             let cflags = if is_fips_build() {
@@ -492,6 +487,77 @@ impl CmakeBuilder {
             "CMAKE_ASM_NASM_COMPILE_OPTIONS_MSVC_DEBUG_INFORMATION_FORMAT_ProgramDatabase",
             "",
         );
+    }
+
+    /// Configure the `CMake` build for sanitizer instrumentation.
+    ///
+    /// Resolves the active sanitizer from either the `asan` Cargo feature flag
+    /// (kept for backward compatibility) or the `AWS_LC_SYS_SANITIZER` /
+    /// `AWS_LC_FIPS_SYS_SANITIZER` environment variable (preferred). Supported
+    /// values: `asan`, `msan`, `tsan`.
+    fn configure_sanitizer(cmake_cfg: &mut cmake::Config) {
+        let feature_sanitizer = if cfg!(feature = "asan") {
+            Some("asan")
+        } else {
+            None
+        };
+        let env_sanitizer = sanitizer();
+        let env_sanitizer = env_sanitizer.as_deref();
+
+        let active_sanitizer = match (feature_sanitizer, env_sanitizer) {
+            (Some(f), Some(e)) if f != e => {
+                panic!(
+                    "Conflicting sanitizer configuration: feature flag '{f}' and \
+                     AWS_LC_SYS_SANITIZER='{e}'. Remove one to resolve the conflict."
+                );
+            }
+            (Some(f), _) => Some(f),
+            (_, Some(e)) => Some(e),
+            _ => None,
+        };
+
+        if let Some(san) = active_sanitizer {
+            set_env_for_target("CC", "clang");
+            set_env_for_target("CXX", "clang++");
+
+            match san {
+                "asan" => {
+                    cmake_cfg.define("ASAN", "1");
+                }
+                "msan" => {
+                    // AWS-LC's CMakeLists.txt correctly skips the FIPS
+                    // delocator when MSAN is set, but bcm.c guards the
+                    // integrity-test symbols with `#if !defined(OPENSSL_ASAN)`
+                    // only — it does not check OPENSSL_MSAN. Until the
+                    // upstream C guard is broadened, MSAN + FIPS will produce
+                    // undefined-symbol link errors for BORINGSSL_bcm_text_*.
+                    assert!(
+                        !is_fips_build(),
+                        "MemorySanitizer is not supported for FIPS builds. \
+                         The FIPS integrity check in bcm.c lacks an \
+                         OPENSSL_MSAN guard, causing undefined-symbol link \
+                         errors (BORINGSSL_bcm_text_start/end/hash)."
+                    );
+                    cmake_cfg.define("MSAN", "1");
+                }
+                "tsan" => {
+                    cmake_cfg.define("TSAN", "1");
+                    // AWS-LC's CMakeLists.txt defines BORINGSSL_DISPATCH_TEST for
+                    // non-FIPS, non-release builds. That macro enables non-atomic
+                    // writes to a global BORINGSSL_function_hit[] array from ~15
+                    // dispatch points (C and assembly), which TSAN flags as data
+                    // races. The writes are benign (idempotent store of 1), but
+                    // suppressing every function name is impractical. Force the C
+                    // library to build in Release mode so the macro is never
+                    // defined. This matches AWS-LC's own sanitizer CI, which
+                    // always uses -DCMAKE_BUILD_TYPE=Release.
+                    cmake_cfg.profile("Release");
+                }
+                other => {
+                    panic!("Unsupported sanitizer: '{other}'. Supported values: asan, msan, tsan")
+                }
+            }
+        }
     }
 
     fn configure_open_harmony(cmake_cfg: &mut cmake::Config) {

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -560,7 +560,7 @@ fn get_builder(prefix: &Option<String>, manifest_dir: &Path, out_dir: &Path) -> 
         };
         builder.check_dependencies().unwrap();
         return builder;
-    } else if is_no_asm() {
+    } else if is_no_asm() || sanitizer().is_some() {
         let builder = cmake_builder_builder();
         builder.check_dependencies().unwrap();
         return builder;
@@ -615,6 +615,7 @@ static mut SYS_EFFECTIVE_TARGET: String = String::new();
 static mut SYS_NO_JITTER_ENTROPY: Option<bool> = None;
 static mut SYS_NO_U1_BINDINGS: Option<bool> = None;
 static mut SYS_INCLUDES: Option<Vec<PathBuf>> = None;
+static mut SYS_SANITIZER: Option<String> = None;
 
 static mut SYS_C_STD: CStdRequested = CStdRequested::None;
 
@@ -634,6 +635,7 @@ fn initialize() {
         SYS_NO_U1_BINDINGS = env_crate_var_to_bool("NO_U1_BINDINGS");
         SYS_INCLUDES =
             optional_env_crate_target("INCLUDES").map(|v| std::env::split_paths(&v).collect());
+        SYS_SANITIZER = optional_env_crate_target("SANITIZER").map(|v| v.to_lowercase());
     }
 
     assert!(
@@ -734,6 +736,11 @@ fn is_external_bindgen_requested() -> Option<bool> {
 
 fn is_no_asm() -> bool {
     unsafe { SYS_NO_ASM }
+}
+
+#[allow(static_mut_refs)]
+fn sanitizer() -> Option<String> {
+    unsafe { SYS_SANITIZER.clone() }
 }
 
 fn is_cmake_builder() -> Option<bool> {


### PR DESCRIPTION
### Issues:
Resolves #1077

### Description of changes:
Adds MemorySanitizer (MSAN) and ThreadSanitizer (TSAN) support for aws-lc-rs builds. Rather than adding new Cargo feature flags (as proposed in #1077), this uses an `AWS_LC_SYS_SANITIZER` environment variable (or `AWS_LC_FIPS_SYS_SANITIZER` for FIPS builds) that accepts `asan`, `msan`, or `tsan`. This avoids the ergonomic pain of propagating feature flags through the dependency graph for what is inherently a nightly-only dev workflow. The existing `asan` feature flag continues to work.

### Call-outs:
- **TSAN forces the C library to build in Release mode** to suppress `BORINGSSL_DISPATCH_TEST`, which enables non-atomic writes to a global `BORINGSSL_function_hit[]` array that TSAN would flag as data races. This matches AWS-LC's own sanitizer CI.
- **`poly1305_state` initialization changed from `uninit()` to `zeroed()`** because `CRYPTO_poly1305_init` may not write all 512 bytes of the opaque `poly1305_state` buffer, which MSAN would flag. Safe since the underlying type is `[u8; 512]`.
- **MSAN + FIPS is currently blocked** with a build-time assertion. AWS-LC's `bcm.c` guards the FIPS integrity-test symbols with `#if !defined(OPENSSL_ASAN)` only — it does not check `OPENSSL_MSAN`. The CMake build correctly skips the delocator for MSAN, but the C code still references `BORINGSSL_bcm_text_start/end/hash`, causing link failures. This will be unblocked once the upstream guard is broadened.
- Setting the sanitizer env var forces the CMake builder path, even if the user had previously configured a cc-builder preference.

### Testing:
New CI jobs for MSAN (debug + release) and TSAN (debug + release × default + FIPS). Makefile targets added for local use: `msan`, `msan-release`, `tsan`, `tsan-release`, `tsan-fips`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
