### PR TITLE
Fix jitterentropy CFLAGS filtering for HOST_CFLAGS and TARGET_CFLAGS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -756,16 +756,19 @@ jobs:
 
   hostile-environment:
     if: github.repository_owner == 'aws'
-    name: Hostile environment
+    name: Hostile environment - ${{ matrix.env_name }}=${{ matrix.env_value }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        cflags:
-          - '-O3'
-          - '-flto=auto -ffat-lto-objects'
-    env:
-      CFLAGS: ${{ matrix.cflags }}
+        include:
+          - env_name: CFLAGS
+            env_value: '-O3'
+          - env_name: CFLAGS
+            env_value: '-flto=auto -ffat-lto-objects'
+          - env_name: HOST_CFLAGS
+            env_value: '-O2'
+          - env_name: TARGET_CFLAGS
+            env_value: '-O2'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -776,9 +779,13 @@ jobs:
         with:
           go-version: '>=1.18'
       - name: Run tests
-        run: cargo test -p aws-lc-rs --all-targets
+        run: |
+          export ${{ matrix.env_name }}="${{ matrix.env_value }}"
+          cargo test -p aws-lc-rs --all-targets
       - name: Run tests w/ FIPS
-        run: cargo test -p aws-lc-rs --all-targets --features fips
+        run: |
+          export ${{ matrix.env_name }}="${{ matrix.env_value }}"
+          cargo test -p aws-lc-rs --all-targets --features fips
 
   hardened-environment:
     if: github.repository_owner == 'aws'

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -19,13 +19,14 @@ mod win_x86_64;
 
 use crate::nasm_builder::NasmBuilder;
 use crate::{
-    cargo_env, emit_warning, env_name_for_target, env_var_to_bool, execute_command, find_clang_cl,
-    get_crate_cc, get_crate_cflags, get_crate_cxx, is_no_asm, out_dir, requested_c_std,
-    set_env_for_target, should_build_jitter_entropy, target, target_arch, target_env, target_os,
-    target_vendor, CStdRequested, EnvGuard, OutputLibType,
+    cargo_env, emit_warning, env_var_to_bool, execute_command, find_clang_cl, get_crate_cc,
+    get_crate_cflags, get_crate_cxx, is_no_asm, out_dir, requested_c_std, set_env_for_target,
+    should_build_jitter_entropy, target, target_arch, target_env, target_os, target_vendor,
+    CStdRequested, EnvGuard, OutputLibType,
 };
 use std::cell::Cell;
 use std::collections::HashMap;
+use std::env;
 use std::path::PathBuf;
 
 #[non_exhaustive]
@@ -470,21 +471,44 @@ impl CcBuilder {
     /// which means CFLAGS optimization flags override build script flags.
     /// Jitterentropy MUST be compiled with -O0, so we temporarily override
     /// CFLAGS to replace any optimization flags with -O0.
-    fn jitter_entropy_cflags_guard(is_like_msvc: bool) -> Option<EnvGuard> {
-        let cflags = get_crate_cflags()?;
-        let filtered: String = cflags
-            .split_whitespace()
-            .filter(|flag| !flag.starts_with("-O") && !flag.starts_with("/O"))
-            .collect::<Vec<_>>()
-            .join(" ");
-        let new_cflags = if is_like_msvc {
-            format!("{filtered} -Od").trim().to_string()
-        } else {
-            format!("{filtered} -O0 -U_FORTIFY_SOURCE")
-                .trim()
-                .to_string()
+    ///
+    /// The cc crate collects flags from ALL matching CFLAGS env vars (not just
+    /// the highest-priority one), so we must filter every variable it checks:
+    ///   1. `CFLAGS_{target}` (e.g. `CFLAGS_x86_64_unknown_freebsd`)
+    ///   2. `HOST_CFLAGS` or `TARGET_CFLAGS`
+    ///   3. `CFLAGS`
+    fn jitter_entropy_cflags_guards(is_like_msvc: bool) -> Vec<EnvGuard> {
+        let target_u = target().to_lowercase().replace('-', "_");
+
+        let cflags_env_names: Vec<String> = vec![
+            format!("CFLAGS_{target_u}"),
+            "HOST_CFLAGS".to_string(),
+            "TARGET_CFLAGS".to_string(),
+            "CFLAGS".to_string(),
+        ];
+
+        let filter_cflags = |value: &str| -> String {
+            let filtered: String = value
+                .split_whitespace()
+                .filter(|flag| !flag.starts_with("-O") && !flag.starts_with("/O"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            if is_like_msvc {
+                format!("{filtered} -Od").trim().to_string()
+            } else {
+                format!("{filtered} -O0 -U_FORTIFY_SOURCE")
+                    .trim()
+                    .to_string()
+            }
         };
-        Some(EnvGuard::new(&env_name_for_target("CFLAGS"), &new_cflags))
+
+        cflags_env_names
+            .into_iter()
+            .filter_map(|name| {
+                let value = env::var(&name).ok()?;
+                Some(EnvGuard::new(&name, filter_cflags(&value)))
+            })
+            .collect()
     }
 
     fn add_all_files(&self, sources: &[&'static str], cc_build: &mut cc::Build) {
@@ -578,7 +602,7 @@ impl CcBuilder {
             cc_build.object(object);
         }
         if should_build_jitter_entropy() {
-            let _je_cflags_guard = Self::jitter_entropy_cflags_guard(compiler.is_like_msvc());
+            let _je_cflags_guards = Self::jitter_entropy_cflags_guards(compiler.is_like_msvc());
             let jitter_entropy_object_files = jitter_entropy_builder.compile_intermediates();
             for object in jitter_entropy_object_files {
                 cc_build.object(object);

--- a/scripts/generate/_generate_bindings.sh
+++ b/scripts/generate/_generate_bindings.sh
@@ -40,12 +40,10 @@ if [[ -z "${GOPROXY:+x}" ]]; then
   export GOPROXY=direct
 fi
 
-cargo clean --target-dir "${TEMP_TARGET_DIR}"
 # Sets AWS_LC_SYS_PREGENERATING_BINDINGS=1 which will cause the generation bindings for a specific platform. This feature
 # is only intended for internal use thus is not a cargo feature. Requires bindgen to be enabled. The internal_bindgen
 # config is enabled so that the final crates doesn't expect to find the dynamically generated bindings.rs
 env AWS_LC_SYS_PREGENERATING_BINDINGS=1 AWS_LC_FIPS_SYS_PREGENERATING_BINDINGS=1 cargo build --target-dir "${TEMP_TARGET_DIR}" --features bindgen
-cargo clean --target-dir "${TEMP_TARGET_DIR}"
 
 popd &>/dev/null # ${CRATE_DIR}
 


### PR DESCRIPTION

### Issues:
* #1097

### Description of changes:
The cc crate (v1.2+) collects flags from ALL matching CFLAGS env vars — not just the highest-priority one. It checks `CFLAGS_{target}`, `HOST_CFLAGS` (native builds) or `TARGET_CFLAGS` (cross builds), and `CFLAGS`, appending flags from each in priority order. The previous guard only filtered and overrode `CFLAGS_{target}`, so optimization flags arriving via `HOST_CFLAGS` or `TARGET_CFLAGS` would land after our `-O0` on the command line and win.

The fix filters optimization flags from every variable the cc crate reads: `CFLAGS_{target}`, `HOST_CFLAGS`, `TARGET_CFLAGS`, and `CFLAGS`.

### Call-outs:
We filter both `HOST_CFLAGS` and `TARGET_CFLAGS` unconditionally rather than trying to mirror the cc crate's host-vs-cross selection logic. Filtering a variable the cc crate doesn't read for a given build is harmless, and this avoids coupling to the cc crate's internal branching.

The old `hostile-environment` CI matrix had an unused `os` dimension (`runs-on` was hardcoded to `ubuntu-latest` regardless of `matrix.os`). The new matrix drops that and instead parameterizes the env var name, covering `CFLAGS`, `HOST_CFLAGS`, and `TARGET_CFLAGS`.

### Testing:
The `hostile-environment` CI job now covers `HOST_CFLAGS="-O2"` and `TARGET_CFLAGS="-O2"` — both of which fail on `main` and pass with this change. Verified locally that all CFLAGS variants (`CFLAGS`, `HOST_CFLAGS`, `TARGET_CFLAGS`, and combinations) build successfully with `-O2`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
