### PR TITLE
Add opt-in 2TDEA and 3TDEA cipher support behind a `legacy-3des` feature

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -37,6 +37,8 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
         args:
           - --release --all-targets --features fips,unstable
+          - --release --all-targets --features fips,unstable,legacy-3des
+          - --release --all-targets --features fips,legacy-3des
           - --profile release-lto --all-targets --features fips,unstable
           - --no-default-features --features fips,unstable
           - --no-default-features --features fips,ring-io,unstable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest, ubuntu-24.04-arm ]
         args:
           - --all-targets --features unstable
+          - --all-targets --features unstable,legacy-3des
+          - --all-targets --features legacy-3des
           - --release --all-targets --features unstable
           - --no-default-features --features non-fips,unstable
           - --no-default-features --features non-fips,ring-io,unstable

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "aws_lc_rs_docsrs"]
-features = ["unstable"]
+features = ["unstable", "legacy-3des"]
 
 [features]
 alloc = []

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -39,6 +39,7 @@ test_logging = []
 unstable = []
 prebuilt-nasm = ["aws-lc-sys?/prebuilt-nasm"]
 dev-tests-only = []
+legacy-3des = ["aws-lc-sys?/all-bindings"]
 
 # require non-FIPS
 non-fips = ["aws-lc-sys"]

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -124,6 +124,27 @@ It can be enabled in two ways:
 used in production builds. The `rand::unsealed` module and `mut_fill` method are not part of the
 stable public API and may change without notice.
 
+##### legacy-3des
+
+Enables Triple DES as an opt-in symmetric cipher under the `cipher` module, exposing
+both `DES_EDE_FOR_LEGACY_USE_ONLY` (2-key Triple DES / DES-EDE) and
+`DES_EDE3_FOR_LEGACY_USE_ONLY` (3-key Triple DES / DES-EDE3), together with the
+supporting key-length and IV-length constants. Only CBC and ECB operating modes are
+supported.
+
+**⚠️ Warning:** Triple DES is a legacy algorithm. It has been disallowed for
+encryption by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
+2-key Triple DES since 2015, and 3-key Triple DES after 2023. This feature exists
+solely to support interoperability with existing systems that cannot yet migrate to
+AES. All exposed items are marked `#[deprecated]` so that any use site produces a
+compiler warning. **Do not use Triple DES in new designs.** If you only need
+confidentiality, prefer AES-GCM or another AEAD from the `aead` module; if you
+specifically need a block cipher, prefer one of the AES algorithms in `cipher`.
+
+This feature also enables `aws-lc-sys?/all-bindings`, which is required to expose the
+`DES_*` bindings when the consuming build uses `bindgen` rather than the pre-generated
+bindings.
+
 ## Use of prebuilt NASM objects
 
 Prebuilt NASM objects are **only** applicable to Windows x86-64 platforms. They are **never** used on any other platform (Linux, macOS, etc.).

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -134,16 +134,17 @@ supported.
 
 **⚠️ Warning:** Triple DES is a legacy algorithm. It has been disallowed for
 encryption by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
-2-key Triple DES since 2015, and 3-key Triple DES after 2023. This feature exists
+2-key Triple DES after 2015, and 3-key Triple DES after 2023. This feature exists
 solely to support interoperability with existing systems that cannot yet migrate to
 AES. All exposed items are marked `#[deprecated]` so that any use site produces a
 compiler warning. **Do not use Triple DES in new designs.** If you only need
 confidentiality, prefer AES-GCM or another AEAD from the `aead` module; if you
 specifically need a block cipher, prefer one of the AES algorithms in `cipher`.
 
-This feature also enables `aws-lc-sys?/all-bindings`, which is required to expose the
-`DES_*` bindings when the consuming build uses `bindgen` rather than the pre-generated
-bindings.
+The universal bindings used by default from `aws-lc-sys` do not expose the `DES_*` symbols. Thus,
+this feature enables `aws-lc-sys?/all-bindings` so that bindings are available for all AWS-LC
+libcrypto functions. On platforms where pre-generated bindings are unavailable, `bindgen` is
+invoked at build time and the generated bindings will include the full symbol set.
 
 ## Use of prebuilt NASM objects
 

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -135,11 +135,11 @@ supported.
 **⚠️ Warning:** Triple DES is a legacy algorithm. It has been disallowed for
 encryption by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
 2-key Triple DES after 2015, and 3-key Triple DES after 2023. This feature exists
-solely to support interoperability with existing systems that cannot yet migrate to
-AES. All exposed items are marked `#[deprecated]` so that any use site produces a
-compiler warning. **Do not use Triple DES in new designs.** If you only need
-confidentiality, prefer AES-GCM or another AEAD from the `aead` module; if you
-specifically need a block cipher, prefer one of the AES algorithms in `cipher`.
+solely to support interoperability. All exposed items are marked `#[deprecated]`
+so that any use site produces a compiler warning. **Do not use Triple DES in new
+designs.** If you only need confidentiality, prefer AES-GCM or another AEAD from
+the `aead` module; if you specifically need a block cipher, prefer one of the AES
+algorithms in `cipher`.
 
 The universal bindings used by default from `aws-lc-sys` do not expose the `DES_*` symbols. Thus,
 this feature enables `aws-lc-sys?/all-bindings` so that bindings are available for all AWS-LC

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -71,7 +71,7 @@ pub type Sample = [u8; SAMPLE_LEN];
 
 /// A QUIC Header Protection Algorithm.
 pub struct Algorithm {
-    init: fn(key: &[u8]) -> Result<SymmetricCipherKey, error::Unspecified>,
+    init: fn(key: &[u8]) -> Result<SymmetricCipherKey, error::KeyRejected>,
 
     key_len: usize,
     id: AlgorithmID,
@@ -162,6 +162,10 @@ fn cipher_new_mask(
             let input = block::Block::zero();
             let counter = u32::from_ne_bytes(*counter_bytes).to_le();
             encrypt_block_chacha20(raw_key, input, nonce, counter)?
+        }
+        #[cfg(feature = "legacy-3des")]
+        SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
+            return Err(error::Unspecified)
         }
     };
 

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -489,8 +489,7 @@ pub const AES_256: Algorithm = Algorithm {
 /// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
 /// by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
 /// since 2015 — several years earlier than 3-key Triple DES. It is retained here
-/// solely for interoperability with existing systems that cannot yet migrate.
-/// New designs must use an AES-based algorithm.
+/// solely for interoperability. New designs must use an AES-based algorithm.
 ///
 /// Only CBC and ECB operating modes are supported. K1 must differ from K2; if
 /// they are equal the cipher degenerates to single-DES and key construction
@@ -1529,11 +1528,10 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_rejects_degenerate_keys() {
-        // SP 800-67r2 Appendix A: 3TDEA requires K1, K2, and K3 to be
-        // independently chosen. We enforce that all three subkeys are
-        // pairwise distinct so the cipher cannot degenerate to single-DES
-        // (K1 == K2 or K2 == K3) or to 2TDEA (K1 == K3). Callers who want
-        // 2TDEA must use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key.
+        // SP 800-67 §2 (Keying Option 1) requires K1, K2, and K3 to be pairwise
+        // independent. We enforce that all three subkeys are distinct so the cipher
+        // cannot degenerate to single-DES (K1==K2 or K2==K3) or to 2TDEA (K1==K3).
+        // Callers who want 2TDEA must use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key.
         let k1_eq_k2 = from_hex("0123456789abcdef0123456789abcdef456789abcdef0123").unwrap();
         assert!(
             UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k1_eq_k2)

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -509,8 +509,8 @@ pub const DES_EDE_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 ///
 /// 3DES is a legacy algorithm and has been disallowed for encryption by
 /// [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
-/// after 2023. It is retained here solely for interoperability with existing
-/// systems that cannot yet migrate. New designs must use an AES-based algorithm.
+/// after 2023. It is retained here solely for interoperability. New designs
+/// must use an AES-based algorithm.
 ///
 /// Only CBC and ECB operating modes are supported. K1, K2, and K3 must all
 /// be distinct; any pairwise equality causes 3TDEA to degenerate (to either

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -262,6 +262,7 @@ pub use crate::cipher::aes::AES_256_KEY_LEN;
 /// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
 /// by NIST SP 800-131A Rev. 2 since 2015. It is retained for interoperability only.
 #[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
 #[deprecated(
     note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
@@ -272,6 +273,7 @@ pub use crate::cipher::des::DES_EDE_KEY_LEN;
 /// 3DES is a legacy algorithm and has been disallowed for encryption by
 /// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
 #[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
 #[deprecated(
     note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
@@ -293,6 +295,7 @@ pub use crate::cipher::aes::AES_CFB_IV_LEN;
 /// 3DES is a legacy algorithm and has been disallowed for encryption by
 /// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
 #[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
 #[deprecated(
     note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
@@ -379,6 +382,7 @@ macro_rules! define_cipher_context {
 
             /// A 64-bit Initialization Vector (used by 3DES).
             #[cfg(feature = "legacy-3des")]
+            #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
             Iv64(FixedLength<IV_LEN_64_BIT>),
 
             /// No Cipher Context
@@ -443,7 +447,10 @@ pub enum AlgorithmId {
     /// 2-key Triple DES has been disallowed for encryption by
     /// NIST SP 800-131A Rev. 2 since 2015.
     #[cfg(feature = "legacy-3des")]
-    #[deprecated]
+    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+    #[deprecated(
+        note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+    )]
     DesEdeForLegacyUseOnly,
 
     /// 3TDEA (for legacy use only).
@@ -451,7 +458,10 @@ pub enum AlgorithmId {
     /// 3DES has been disallowed for encryption by NIST SP 800-131A Rev. 2
     /// after 2023.
     #[cfg(feature = "legacy-3des")]
-    #[deprecated]
+    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+    #[deprecated(
+        note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+    )]
     DesEde3ForLegacyUseOnly,
 }
 
@@ -491,10 +501,16 @@ pub const AES_256: Algorithm = Algorithm {
 /// since 2015 — several years earlier than 3-key Triple DES. It is retained here
 /// solely for interoperability. New designs must use an AES-based algorithm.
 ///
-/// Only CBC and ECB operating modes are supported. K1 must differ from K2; if
-/// they are equal the cipher degenerates to single-DES and key construction
-/// will fail.
+/// Only CBC and ECB operating modes are supported. Key material is validated
+/// beyond the length check: weak and semi-weak DES subkeys are rejected, and
+/// K1 must differ from K2 (otherwise the cipher degenerates to single-DES).
+/// This validation is deferred — constructing an [`UnboundCipherKey`] only
+/// checks length; the weak-key and pairwise-distinctness checks fire when the
+/// [`UnboundCipherKey`] is passed to an [`EncryptingKey`], [`DecryptingKey`],
+/// [`PaddedBlockEncryptingKey`], [`PaddedBlockDecryptingKey`],
+/// [`StreamingEncryptingKey`], or [`StreamingDecryptingKey`] constructor.
 #[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
 #[allow(deprecated)]
 #[deprecated(
     note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
@@ -512,14 +528,21 @@ pub const DES_EDE_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 /// after 2023. It is retained here solely for interoperability. New designs
 /// must use an AES-based algorithm.
 ///
-/// Only CBC and ECB operating modes are supported. K1, K2, and K3 must all
-/// be distinct; any pairwise equality causes 3TDEA to degenerate (to either
-/// single-DES or 2TDEA) and is rejected at key construction time.
+/// Only CBC and ECB operating modes are supported. Key material is validated
+/// beyond the length check: weak and semi-weak DES subkeys are rejected, and
+/// K1, K2, and K3 must all be pairwise distinct (otherwise 3TDEA degenerates
+/// to either single-DES or 2TDEA). This validation is deferred —
+/// constructing an [`UnboundCipherKey`] only checks length; the weak-key and
+/// pairwise-distinctness checks fire when the [`UnboundCipherKey`] is passed
+/// to an [`EncryptingKey`], [`DecryptingKey`], [`PaddedBlockEncryptingKey`],
+/// [`PaddedBlockDecryptingKey`], [`StreamingEncryptingKey`], or
+/// [`StreamingDecryptingKey`] constructor.
 ///
 /// Callers who specifically need 2-key Triple DES (2TDEA) must use
 /// [`DES_EDE_FOR_LEGACY_USE_ONLY`] (16-byte key) rather than encoding 2TDEA
 /// as a 24-byte `K1 ‖ K2 ‖ K1` key here.
 #[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
 #[allow(deprecated)]
 #[deprecated(
     note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
@@ -758,6 +781,9 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   support CTR mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CTR)
     }
@@ -771,6 +797,9 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   support CFB128 mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128)
     }
@@ -791,6 +820,11 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn cbc(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC)
     }
@@ -811,6 +845,11 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB)
     }
@@ -908,6 +947,9 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
+    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   support CTR mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
         Self::new(key, OperatingMode::CTR)
     }
@@ -921,6 +963,9 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
+    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   support CFB128 mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128)
     }
@@ -941,6 +986,11 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn cbc(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
         Self::new(key, OperatingMode::CBC)
     }
@@ -961,6 +1011,11 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `DecryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB)
     }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -692,14 +692,19 @@ impl UnboundCipherKey {
     /// Validates the key material against algorithm-specific constraints beyond
     /// the length check performed by [`UnboundCipherKey::new`].
     ///
-    /// Rejects weak DES subkeys and degenerate key configurations
-    /// (e.g. K1 == K2 for 2TDEA). The streaming cipher constructors call this
-    /// because they pass raw key bytes directly to the EVP API rather than
-    /// going through [`SymmetricCipherKey`] construction, which would otherwise
-    /// perform these checks. This is necessary because the EVP layer internally
-    /// uses `DES_set_key_unchecked`, which skips weak-key detection.
-    #[cfg(feature = "legacy-3des")]
+    /// For DES algorithms (behind `legacy-3des`), this rejects weak DES subkeys
+    /// and degenerate key configurations (e.g. K1 == K2 for 2TDEA). For other
+    /// algorithms this is a no-op since the only constraint is key length.
+    ///
+    /// The streaming cipher constructors call this because they pass raw key
+    /// bytes directly to the EVP API rather than going through
+    /// [`SymmetricCipherKey`] construction, which would otherwise perform these
+    /// checks. This is necessary because the EVP layer internally uses
+    /// `DES_set_key_unchecked`, which skips weak-key detection.
+    #[allow(clippy::unused_self)]
+    #[allow(clippy::unnecessary_wraps)]
     fn validate_key_material(&self) -> Result<(), KeyRejected> {
+        #[cfg(feature = "legacy-3des")]
         #[allow(deprecated)]
         match self.algorithm.id() {
             AlgorithmId::DesEdeForLegacyUseOnly => {

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -221,6 +221,8 @@
 pub(crate) mod aes;
 pub(crate) mod block;
 pub(crate) mod chacha;
+#[cfg(feature = "legacy-3des")]
+pub(crate) mod des;
 pub(crate) mod key;
 mod padded;
 mod streaming;
@@ -233,10 +235,14 @@ use crate::aws_lc::{
     EVP_aes_192_cfb128, EVP_aes_192_ctr, EVP_aes_192_ecb, EVP_aes_256_cbc, EVP_aes_256_cfb128,
     EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
 };
+#[cfg(feature = "legacy-3des")]
+use crate::aws_lc::{EVP_des_ede, EVP_des_ede3_cbc, EVP_des_ede3_ecb, EVP_des_ede_cbc};
 use crate::buffer::Buffer;
-use crate::error::Unspecified;
+use crate::error::{KeyRejected, Unspecified};
 use crate::hkdf;
 use crate::hkdf::KeyType;
+#[cfg(feature = "legacy-3des")]
+use crate::iv::IV_LEN_64_BIT;
 use crate::iv::{FixedLength, IV_LEN_128_BIT};
 use crate::ptr::ConstPointer;
 use core::fmt::Debug;
@@ -251,6 +257,26 @@ pub use crate::cipher::aes::AES_192_KEY_LEN;
 /// The number of bytes in an AES 256-bit key
 pub use crate::cipher::aes::AES_256_KEY_LEN;
 
+/// The number of bytes in a 2TDEA (DES-EDE, 2-key Triple DES) key.
+///
+/// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
+/// by NIST SP 800-131A Rev. 2 since 2015. It is retained for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[deprecated(
+    note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub use crate::cipher::des::DES_EDE_KEY_LEN;
+
+/// The number of bytes in a 3TDEA (DES-EDE3, 3-key Triple DES) key.
+///
+/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[deprecated(
+    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub use crate::cipher::des::DES_EDE3_KEY_LEN;
+
 const MAX_CIPHER_KEY_LEN: usize = AES_256_KEY_LEN;
 
 /// The number of bytes for an AES-CBC initialization vector (IV)
@@ -262,7 +288,19 @@ pub use crate::cipher::aes::AES_CTR_IV_LEN;
 /// The number of bytes for an AES-CFB initialization vector (IV)
 pub use crate::cipher::aes::AES_CFB_IV_LEN;
 
+/// The number of bytes for a 3DES-CBC initialization vector (IV).
+///
+/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[deprecated(
+    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub use crate::cipher::des::DES_CBC_IV_LEN;
+
 use crate::cipher::aes::AES_BLOCK_LEN;
+#[cfg(feature = "legacy-3des")]
+use crate::cipher::des::DES_BLOCK_LEN;
 
 const MAX_CIPHER_BLOCK_LEN: usize = AES_BLOCK_LEN;
 
@@ -285,23 +323,44 @@ pub enum OperatingMode {
 
 impl OperatingMode {
     fn evp_cipher(&self, algorithm: &Algorithm) -> ConstPointer<'_, EVP_CIPHER> {
-        unsafe {
-            ConstPointer::new_static(match (self, algorithm.id) {
-                (OperatingMode::CBC, AlgorithmId::Aes128) => EVP_aes_128_cbc(),
-                (OperatingMode::CTR, AlgorithmId::Aes128) => EVP_aes_128_ctr(),
-                (OperatingMode::CFB128, AlgorithmId::Aes128) => EVP_aes_128_cfb128(),
-                (OperatingMode::ECB, AlgorithmId::Aes128) => EVP_aes_128_ecb(),
-                (OperatingMode::CBC, AlgorithmId::Aes192) => EVP_aes_192_cbc(),
-                (OperatingMode::CTR, AlgorithmId::Aes192) => EVP_aes_192_ctr(),
-                (OperatingMode::CFB128, AlgorithmId::Aes192) => EVP_aes_192_cfb128(),
-                (OperatingMode::ECB, AlgorithmId::Aes192) => EVP_aes_192_ecb(),
-                (OperatingMode::CBC, AlgorithmId::Aes256) => EVP_aes_256_cbc(),
-                (OperatingMode::CTR, AlgorithmId::Aes256) => EVP_aes_256_ctr(),
-                (OperatingMode::CFB128, AlgorithmId::Aes256) => EVP_aes_256_cfb128(),
-                (OperatingMode::ECB, AlgorithmId::Aes256) => EVP_aes_256_ecb(),
-            })
-            .unwrap()
-        }
+        let alg = match (self, algorithm.id) {
+            (OperatingMode::CBC, AlgorithmId::Aes128) => unsafe { EVP_aes_128_cbc() },
+            (OperatingMode::CTR, AlgorithmId::Aes128) => unsafe { EVP_aes_128_ctr() },
+            (OperatingMode::CFB128, AlgorithmId::Aes128) => unsafe { EVP_aes_128_cfb128() },
+            (OperatingMode::ECB, AlgorithmId::Aes128) => unsafe { EVP_aes_128_ecb() },
+            (OperatingMode::CBC, AlgorithmId::Aes192) => unsafe { EVP_aes_192_cbc() },
+            (OperatingMode::CTR, AlgorithmId::Aes192) => unsafe { EVP_aes_192_ctr() },
+            (OperatingMode::CFB128, AlgorithmId::Aes192) => unsafe { EVP_aes_192_cfb128() },
+            (OperatingMode::ECB, AlgorithmId::Aes192) => unsafe { EVP_aes_192_ecb() },
+            (OperatingMode::CBC, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cbc() },
+            (OperatingMode::CTR, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ctr() },
+            (OperatingMode::CFB128, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cfb128() },
+            (OperatingMode::ECB, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ecb() },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::CBC, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe {
+                EVP_des_ede_cbc()
+            },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::ECB, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe { EVP_des_ede() },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::CBC, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
+                EVP_des_ede3_cbc()
+            },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::ECB, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
+                EVP_des_ede3_ecb()
+            },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::CTR, AlgorithmId::DesEdeForLegacyUseOnly)
+            | (OperatingMode::CTR, AlgorithmId::DesEde3ForLegacyUseOnly)
+            | (OperatingMode::CFB128, AlgorithmId::DesEdeForLegacyUseOnly)
+            | (OperatingMode::CFB128, AlgorithmId::DesEde3ForLegacyUseOnly) => {
+                // `supports_mode()` rejects these combinations at key-construction
+                // time, so this branch is unreachable in practice.
+                unreachable!("DES does not support CTR or CFB128 modes")
+            }
+        };
+        unsafe { ConstPointer::new_static(alg).unwrap() }
     }
 }
 
@@ -313,6 +372,10 @@ macro_rules! define_cipher_context {
             /// A 128-bit Initialization Vector.
             Iv128(FixedLength<IV_LEN_128_BIT>),
 
+            /// A 64-bit Initialization Vector (used by 3DES).
+            #[cfg(feature = "legacy-3des")]
+            Iv64(FixedLength<IV_LEN_64_BIT>),
+
             /// No Cipher Context
             None,
         }
@@ -323,6 +386,8 @@ macro_rules! define_cipher_context {
             fn try_from(value: &'a $name) -> Result<Self, Unspecified> {
                 match value {
                     $name::Iv128(iv) => Ok(iv.as_ref()),
+                    #[cfg(feature = "legacy-3des")]
+                    $name::Iv64(iv) => Ok(iv.as_ref()),
                     _ => Err(Unspecified),
                 }
             }
@@ -332,6 +397,8 @@ macro_rules! define_cipher_context {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
                     Self::Iv128(_) => write!(f, "Iv128"),
+                    #[cfg(feature = "legacy-3des")]
+                    Self::Iv64(_) => write!(f, "Iv64"),
                     Self::None => write!(f, "None"),
                 }
             }
@@ -341,6 +408,8 @@ macro_rules! define_cipher_context {
             fn from(value: $other) -> Self {
                 match value {
                     $other::Iv128(iv) => $name::Iv128(iv),
+                    #[cfg(feature = "legacy-3des")]
+                    $other::Iv64(iv) => $name::Iv64(iv),
                     $other::None => $name::None,
                 }
             }
@@ -363,6 +432,20 @@ pub enum AlgorithmId {
 
     /// AES 192-bit
     Aes192,
+
+    /// 2TDEA (for legacy use only).
+    ///
+    /// 2-key Triple DES has been disallowed for encryption by
+    /// NIST SP 800-131A Rev. 2 since 2015.
+    #[cfg(feature = "legacy-3des")]
+    DesEdeForLegacyUseOnly,
+
+    /// 3TDEA (for legacy use only).
+    ///
+    /// 3DES has been disallowed for encryption by NIST SP 800-131A Rev. 2
+    /// after 2023.
+    #[cfg(feature = "legacy-3des")]
+    DesEde3ForLegacyUseOnly,
 }
 
 /// A cipher algorithm.
@@ -394,6 +477,53 @@ pub const AES_256: Algorithm = Algorithm {
     block_len: AES_BLOCK_LEN,
 };
 
+/// 2TDEA (DES-EDE, 2-key Triple DES) cipher, for legacy interoperability only.
+///
+/// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
+/// by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
+/// since 2015 — several years earlier than 3-key Triple DES. It is retained here
+/// solely for interoperability with existing systems that cannot yet migrate.
+/// New designs must use an AES-based algorithm.
+///
+/// Only CBC and ECB operating modes are supported. K1 must differ from K2; if
+/// they are equal the cipher degenerates to single-DES and key construction
+/// will fail.
+#[cfg(feature = "legacy-3des")]
+#[allow(deprecated)]
+#[deprecated(
+    note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub const DES_EDE_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+    id: AlgorithmId::DesEdeForLegacyUseOnly,
+    key_len: DES_EDE_KEY_LEN,
+    block_len: DES_BLOCK_LEN,
+};
+
+/// 3TDEA (DES-EDE3, 3-key Triple DES) cipher, for legacy interoperability only.
+///
+/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
+/// after 2023. It is retained here solely for interoperability with existing
+/// systems that cannot yet migrate. New designs must use an AES-based algorithm.
+///
+/// Only CBC and ECB operating modes are supported. K1, K2, and K3 must all
+/// be distinct; any pairwise equality causes 3TDEA to degenerate (to either
+/// single-DES or 2TDEA) and is rejected at key construction time.
+///
+/// Callers who specifically need 2-key Triple DES (2TDEA) must use
+/// [`DES_EDE_FOR_LEGACY_USE_ONLY`] (16-byte key) rather than encoding 2TDEA
+/// as a 24-byte `K1 ‖ K2 ‖ K1` key here.
+#[cfg(feature = "legacy-3des")]
+#[allow(deprecated)]
+#[deprecated(
+    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub const DES_EDE3_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+    id: AlgorithmId::DesEde3ForLegacyUseOnly,
+    key_len: DES_EDE3_KEY_LEN,
+    block_len: DES_BLOCK_LEN,
+};
+
 impl Algorithm {
     fn id(&self) -> &AlgorithmId {
         &self.id
@@ -417,6 +547,14 @@ impl Algorithm {
                 }
                 OperatingMode::ECB => Ok(EncryptionContext::None),
             },
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                match mode {
+                    OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
+                    OperatingMode::ECB => Ok(EncryptionContext::None),
+                    _ => Err(Unspecified),
+                }
+            }
         }
     }
 
@@ -431,6 +569,14 @@ impl Algorithm {
                     matches!(input, EncryptionContext::None)
                 }
             },
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                match mode {
+                    OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
+                    OperatingMode::ECB => matches!(input, EncryptionContext::None),
+                    _ => false,
+                }
+            }
         }
     }
 
@@ -445,6 +591,35 @@ impl Algorithm {
                     matches!(input, DecryptionContext::None)
                 }
             },
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                match mode {
+                    OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
+                    OperatingMode::ECB => matches!(input, DecryptionContext::None),
+                    _ => false,
+                }
+            }
+        }
+    }
+
+    /// Returns `true` if the algorithm supports the given operating mode.
+    ///
+    /// Used to reject invalid `(algorithm, mode)` combinations (e.g. DES with
+    /// CTR or CFB128) at key-construction time rather than deferring the
+    /// failure to the first encrypt/decrypt call.
+    fn supports_mode(&self, mode: OperatingMode) -> bool {
+        match self.id {
+            AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => matches!(
+                mode,
+                OperatingMode::CBC
+                    | OperatingMode::CTR
+                    | OperatingMode::CFB128
+                    | OperatingMode::ECB
+            ),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                matches!(mode, OperatingMode::CBC | OperatingMode::ECB)
+            }
         }
     }
 }
@@ -503,16 +678,50 @@ impl UnboundCipherKey {
     pub fn algorithm(&self) -> &'static Algorithm {
         self.algorithm
     }
+
+    /// Validates the key material against algorithm-specific constraints beyond
+    /// the length check performed by [`UnboundCipherKey::new`].
+    ///
+    /// For DES algorithms (behind `legacy-3des`), this rejects weak DES subkeys
+    /// and degenerate key configurations (e.g. K1 == K2 for 2TDEA). For other
+    /// algorithms this is a no-op since the only constraint is key length.
+    ///
+    /// The streaming cipher constructors call this because they pass raw key
+    /// bytes directly to the EVP API rather than going through
+    /// [`SymmetricCipherKey`] construction, which would otherwise perform these
+    /// checks. This is necessary because the EVP layer internally uses
+    /// `DES_set_key_unchecked`, which skips weak-key detection.
+    fn validate_key_material(&self) -> Result<(), KeyRejected> {
+        #[cfg(feature = "legacy-3des")]
+        match self.algorithm.id() {
+            AlgorithmId::DesEdeForLegacyUseOnly => {
+                let _ = SymmetricCipherKey::prepare_des_ede(self.key_bytes.as_ref())?;
+            }
+            AlgorithmId::DesEde3ForLegacyUseOnly => {
+                let _ = SymmetricCipherKey::prepare_des_ede3(self.key_bytes.as_ref())?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 impl TryInto<SymmetricCipherKey> for UnboundCipherKey {
-    type Error = Unspecified;
+    type Error = KeyRejected;
 
     fn try_into(self) -> Result<SymmetricCipherKey, Self::Error> {
         match self.algorithm.id() {
             AlgorithmId::Aes128 => SymmetricCipherKey::aes128(self.key_bytes.as_ref()),
             AlgorithmId::Aes192 => SymmetricCipherKey::aes192(self.key_bytes.as_ref()),
             AlgorithmId::Aes256 => SymmetricCipherKey::aes256(self.key_bytes.as_ref()),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly => {
+                SymmetricCipherKey::des_ede(self.key_bytes.as_ref())
+            }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEde3ForLegacyUseOnly => {
+                SymmetricCipherKey::des_ede3(self.key_bytes.as_ref())
+            }
         }
     }
 }
@@ -562,6 +771,9 @@ impl EncryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     pub fn cbc(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -579,6 +791,9 @@ impl EncryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -588,6 +803,9 @@ impl EncryptingKey {
     #[allow(clippy::unnecessary_wraps)]
     fn new(key: UnboundCipherKey, mode: OperatingMode) -> Result<Self, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(Self {
             algorithm,
@@ -703,6 +921,9 @@ impl DecryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
     pub fn cbc(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
@@ -720,6 +941,9 @@ impl DecryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `DecryptingKey`.
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -729,6 +953,9 @@ impl DecryptingKey {
     #[allow(clippy::unnecessary_wraps)]
     fn new(key: UnboundCipherKey, mode: OperatingMode) -> Result<Self, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(Self {
             algorithm,
@@ -797,10 +1024,18 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cbc_mode(key, context, in_out)
             }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                des::encrypt_cbc_mode(key, context, in_out)
+            }
         },
         OperatingMode::CTR => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ctr_mode(key, context, in_out)
+            }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
             }
         },
         // TODO: Hopefully support CFB1, and CFB8
@@ -808,10 +1043,18 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cfb_mode(key, mode, context, in_out)
             }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
+            }
         },
         OperatingMode::ECB => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ecb_mode(key, context, in_out)
+            }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                des::encrypt_ecb_mode(key, context, in_out)
             }
         },
     }
@@ -838,10 +1081,18 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cbc_mode(key, context, in_out)
             }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                des::decrypt_cbc_mode(key, context, in_out)
+            }
         },
         OperatingMode::CTR => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ctr_mode(key, context, in_out)
+            }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
             }
         },
         // TODO: Hopefully support CFB1, and CFB8
@@ -849,10 +1100,18 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cfb_mode(key, mode, context, in_out)
             }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
+            }
         },
         OperatingMode::ECB => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ecb_mode(key, context, in_out)
+            }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                des::decrypt_ecb_mode(key, context, in_out)
             }
         },
     }
@@ -1189,5 +1448,333 @@ mod tests {
         "000102030405060708090a0b0c0d0e0f",
         "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
         "f58c4c04d6e5f1ba779eabfb5f7bfbd69cfc4e967edb808d679f777bc6702c7d39f23369a9d9bacfa530e26304231461b2eb05e2c39be9fcda6c19078c6a9d1b"
+    );
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_rejects_k1_equal_k2() {
+        // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA. If K1 == K2 then
+        // 2TDEA collapses to single-DES (56-bit effective security).
+        let weak_key = from_hex("0123456789abcdef0123456789abcdef").unwrap();
+        let result = UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &weak_key)
+            .and_then(EncryptingKey::cbc);
+        assert!(result.is_err(), "expected K1 == K2 to be rejected");
+
+        // Sanity check: differing K1 and K2 of the same length is accepted.
+        let good_key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &good_key)
+            .and_then(EncryptingKey::cbc)
+            .expect("valid 2TDEA key should be accepted");
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_rejects_weak_subkey() {
+        // Each of DES_set_key's four weak keys must be rejected when used as
+        // either subkey of a 2TDEA key. The weak keys (with correct odd
+        // parity) are 0101..01, FEFE..FE, E0E0..E0F1F1..F1, and
+        // 1F1F..1F0E0E..0E; see openssl/des.h.
+        let weak_keys: [&str; 4] = [
+            "0101010101010101",
+            "fefefefefefefefe",
+            "e0e0e0e0f1f1f1f1",
+            "1f1f1f1f0e0e0e0e",
+        ];
+        let distinct = "23456789abcdef01";
+        for weak in &weak_keys {
+            // Weak K1, non-weak K2.
+            let key = from_hex(&format!("{}{}", weak, distinct)).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected weak DES K1 = {weak} to be rejected in 2TDEA"
+            );
+            // Non-weak K1, weak K2.
+            let key = from_hex(&format!("{}{}", distinct, weak)).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected weak DES K2 = {weak} to be rejected in 2TDEA"
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_rejects_degenerate_keys() {
+        // SP 800-67r2 Appendix A: 3TDEA requires K1, K2, and K3 to be
+        // independently chosen. We enforce that all three subkeys are
+        // pairwise distinct so the cipher cannot degenerate to single-DES
+        // (K1 == K2 or K2 == K3) or to 2TDEA (K1 == K3). Callers who want
+        // 2TDEA must use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key.
+        let k1_eq_k2 = from_hex("0123456789abcdef0123456789abcdef456789abcdef0123").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k1_eq_k2)
+                .and_then(EncryptingKey::cbc)
+                .is_err(),
+            "expected K1 == K2 to be rejected for 3TDEA"
+        );
+
+        let k2_eq_k3 = from_hex("0123456789abcdef23456789abcdef0123456789abcdef01").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k2_eq_k3)
+                .and_then(EncryptingKey::cbc)
+                .is_err(),
+            "expected K2 == K3 to be rejected for 3TDEA"
+        );
+
+        let k1_eq_k3 = from_hex("0123456789abcdef23456789abcdef010123456789abcdef").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k1_eq_k3)
+                .and_then(EncryptingKey::cbc)
+                .is_err(),
+            "expected K1 == K3 (2TDEA-in-3TDEA form) to be rejected for 3TDEA"
+        );
+
+        // All three distinct is accepted.
+        let good_key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &good_key)
+            .and_then(EncryptingKey::cbc)
+            .expect("valid 3TDEA key should be accepted");
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_rejects_weak_subkey() {
+        // Each of `DES_set_key`'s four weak keys must be rejected when used
+        // as any subkey of a 3TDEA key. The weak keys (with correct odd
+        // parity) are 0101..01, FEFE..FE, E0E0..E0F1F1..F1, and
+        // 1F1F..1F0E0E..0E; see openssl/des.h.
+        let weak_keys: [&str; 4] = [
+            "0101010101010101",
+            "fefefefefefefefe",
+            "e0e0e0e0f1f1f1f1",
+            "1f1f1f1f0e0e0e0e",
+        ];
+        let fillers = ["23456789abcdef01", "456789abcdef0123"];
+
+        for weak in &weak_keys {
+            for position in 0..3 {
+                // Place the weak key at `position` and fill the other two
+                // slots with distinct non-weak subkeys so that the K1 != K2
+                // and K2 != K3 checks do not short-circuit the weak-key
+                // rejection we are trying to exercise.
+                let mut parts = [""; 3];
+                parts[position] = *weak;
+                parts[(position + 1) % 3] = fillers[0];
+                parts[(position + 2) % 3] = fillers[1];
+                let key = from_hex(&format!("{}{}{}", parts[0], parts[1], parts[2])).unwrap();
+                assert!(
+                    UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key)
+                        .and_then(EncryptingKey::cbc)
+                        .is_err(),
+                    "expected weak DES subkey {weak} at position {position} to be rejected"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_rejects_unsupported_modes() {
+        // 2TDEA/3TDEA only support CBC and ECB in this crate; CTR and CFB128
+        // must be rejected at construction time rather than at encrypt time.
+        let key2 = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(EncryptingKey::ctr)
+                .is_err(),
+            "2TDEA + CTR (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(EncryptingKey::cfb128)
+                .is_err(),
+            "2TDEA + CFB128 (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(DecryptingKey::ctr)
+                .is_err(),
+            "2TDEA + CTR (decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(DecryptingKey::cfb128)
+                .is_err(),
+            "2TDEA + CFB128 (decrypt) should be rejected"
+        );
+
+        let key3 = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(EncryptingKey::ctr)
+                .is_err(),
+            "3TDEA + CTR (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(EncryptingKey::cfb128)
+                .is_err(),
+            "3TDEA + CFB128 (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(DecryptingKey::ctr)
+                .is_err(),
+            "3TDEA + CTR (decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(DecryptingKey::cfb128)
+                .is_err(),
+            "3TDEA + CFB128 (decrypt) should be rejected"
+        );
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_cbc() {
+        let key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        for i in 0..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE_FOR_LEGACY_USE_ONLY,
+                OperatingMode::CBC,
+                size,
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_ecb() {
+        let key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        for i in 0..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE_FOR_LEGACY_USE_ONLY,
+                OperatingMode::ECB,
+                size,
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_cbc() {
+        let key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        for i in 0..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE3_FOR_LEGACY_USE_ONLY,
+                OperatingMode::CBC,
+                size,
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_ecb() {
+        let key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        for i in 0..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE3_FOR_LEGACY_USE_ONLY,
+                OperatingMode::ECB,
+                size,
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    macro_rules! des_cipher_kat {
+        ($name:ident, $alg:expr, $mode:expr, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+            #[test]
+            #[allow(deprecated)]
+            fn $name() {
+                let key = from_hex($key).unwrap();
+                let input = from_hex($plaintext).unwrap();
+                let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+                let ec = if $iv.len() == 0 {
+                    EncryptionContext::None
+                } else {
+                    let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                    EncryptionContext::Iv64(FixedLength::from(iv_arr))
+                };
+
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = EncryptingKey::new(unbound_key, $mode).unwrap();
+                let mut in_out = input.clone();
+                let context = encrypting_key.less_safe_encrypt(&mut in_out, ec).unwrap();
+                assert_eq!(expected_ciphertext, in_out);
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key = DecryptingKey::new(unbound_key2, $mode).unwrap();
+                let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+                assert_eq!(input.as_slice(), plaintext);
+            }
+        };
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede_cbc,
+        &DES_EDE_FOR_LEGACY_USE_ONLY,
+        OperatingMode::CBC,
+        "0123456789abcdef23456789abcdef01",
+        "f69f2445df4f9b17",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "7401CE1EAB6D003CAFF84BF47B36CC2154F0238F9FFECD8F6ACF118392B45581"
+    );
+
+    #[cfg(feature = "legacy-3des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede_ecb,
+        &DES_EDE_FOR_LEGACY_USE_ONLY,
+        OperatingMode::ECB,
+        "0123456789abcdef23456789abcdef01",
+        "",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "06EDE3D82884090AFF322C19F0518486730576972A666E58B6C88CF107340D3D"
+    );
+
+    #[cfg(feature = "legacy-3des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede3_cbc,
+        &DES_EDE3_FOR_LEGACY_USE_ONLY,
+        OperatingMode::CBC,
+        "0123456789abcdef23456789abcdef01456789abcdef0123",
+        "f69f2445df4f9b17",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
+    );
+
+    #[cfg(feature = "legacy-3des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede3_ecb,
+        &DES_EDE3_FOR_LEGACY_USE_ONLY,
+        OperatingMode::ECB,
+        "0123456789abcdef23456789abcdef01456789abcdef0123",
+        "",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87"
     );
 }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -337,20 +337,25 @@ impl OperatingMode {
             (OperatingMode::CFB128, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cfb128() },
             (OperatingMode::ECB, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ecb() },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             (OperatingMode::CBC, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe {
                 EVP_des_ede_cbc()
             },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             (OperatingMode::ECB, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe { EVP_des_ede() },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             (OperatingMode::CBC, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
                 EVP_des_ede3_cbc()
             },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             (OperatingMode::ECB, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
                 EVP_des_ede3_ecb()
             },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             (OperatingMode::CTR, AlgorithmId::DesEdeForLegacyUseOnly)
             | (OperatingMode::CTR, AlgorithmId::DesEde3ForLegacyUseOnly)
             | (OperatingMode::CFB128, AlgorithmId::DesEdeForLegacyUseOnly)
@@ -438,6 +443,7 @@ pub enum AlgorithmId {
     /// 2-key Triple DES has been disallowed for encryption by
     /// NIST SP 800-131A Rev. 2 since 2015.
     #[cfg(feature = "legacy-3des")]
+    #[deprecated]
     DesEdeForLegacyUseOnly,
 
     /// 3TDEA (for legacy use only).
@@ -445,6 +451,7 @@ pub enum AlgorithmId {
     /// 3DES has been disallowed for encryption by NIST SP 800-131A Rev. 2
     /// after 2023.
     #[cfg(feature = "legacy-3des")]
+    #[deprecated]
     DesEde3ForLegacyUseOnly,
 }
 
@@ -548,6 +555,7 @@ impl Algorithm {
                 OperatingMode::ECB => Ok(EncryptionContext::None),
             },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 match mode {
                     OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
@@ -570,6 +578,7 @@ impl Algorithm {
                 }
             },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 match mode {
                     OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
@@ -592,6 +601,7 @@ impl Algorithm {
                 }
             },
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 match mode {
                     OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
@@ -617,6 +627,7 @@ impl Algorithm {
                     | OperatingMode::ECB
             ),
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 matches!(mode, OperatingMode::CBC | OperatingMode::ECB)
             }
@@ -693,6 +704,7 @@ impl UnboundCipherKey {
     /// `DES_set_key_unchecked`, which skips weak-key detection.
     fn validate_key_material(&self) -> Result<(), KeyRejected> {
         #[cfg(feature = "legacy-3des")]
+        #[allow(deprecated)]
         match self.algorithm.id() {
             AlgorithmId::DesEdeForLegacyUseOnly => {
                 let _ = SymmetricCipherKey::prepare_des_ede(self.key_bytes.as_ref())?;
@@ -715,10 +727,12 @@ impl TryInto<SymmetricCipherKey> for UnboundCipherKey {
             AlgorithmId::Aes192 => SymmetricCipherKey::aes192(self.key_bytes.as_ref()),
             AlgorithmId::Aes256 => SymmetricCipherKey::aes256(self.key_bytes.as_ref()),
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly => {
                 SymmetricCipherKey::des_ede(self.key_bytes.as_ref())
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEde3ForLegacyUseOnly => {
                 SymmetricCipherKey::des_ede3(self.key_bytes.as_ref())
             }
@@ -1025,6 +1039,7 @@ fn encrypt(
                 aes::encrypt_cbc_mode(key, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::encrypt_cbc_mode(key, context, in_out)
             }
@@ -1034,8 +1049,9 @@ fn encrypt(
                 aes::encrypt_ctr_mode(key, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                Err(Unspecified)
+                unreachable!("DES does not support CTR mode.")
             }
         },
         // TODO: Hopefully support CFB1, and CFB8
@@ -1044,8 +1060,9 @@ fn encrypt(
                 aes::encrypt_cfb_mode(key, mode, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                Err(Unspecified)
+                unreachable!("DES does not support CFB128 mode.")
             }
         },
         OperatingMode::ECB => match algorithm.id() {
@@ -1053,6 +1070,7 @@ fn encrypt(
                 aes::encrypt_ecb_mode(key, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::encrypt_ecb_mode(key, context, in_out)
             }
@@ -1082,6 +1100,7 @@ fn decrypt<'in_out>(
                 aes::decrypt_cbc_mode(key, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::decrypt_cbc_mode(key, context, in_out)
             }
@@ -1091,8 +1110,9 @@ fn decrypt<'in_out>(
                 aes::decrypt_ctr_mode(key, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                Err(Unspecified)
+                unreachable!("DES does not support CTR mode.")
             }
         },
         // TODO: Hopefully support CFB1, and CFB8
@@ -1101,8 +1121,9 @@ fn decrypt<'in_out>(
                 aes::decrypt_cfb_mode(key, mode, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                Err(Unspecified)
+                unreachable!("DES does not support CFB128 mode.")
             }
         },
         OperatingMode::ECB => match algorithm.id() {
@@ -1110,6 +1131,7 @@ fn decrypt<'in_out>(
                 aes::decrypt_ecb_mode(key, context, in_out)
             }
             #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::decrypt_ecb_mode(key, context, in_out)
             }
@@ -1575,6 +1597,92 @@ mod tests {
                         .and_then(EncryptingKey::cbc)
                         .is_err(),
                     "expected weak DES subkey {weak} at position {position} to be rejected"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_rejects_semi_weak_subkey() {
+        // DES_set_key also rejects semi-weak keys (return value -2).
+        // There are 6 semi-weak key pairs (12 keys total); each member of a
+        // pair encrypts what the other decrypts, making the cipher an
+        // involuntary self-inverse. The semi-weak keys are listed in
+        // openssl/des.h. We verify that using any one of them as either
+        // subkey of a 2TDEA key is rejected.
+        // The 12 DES semi-weak keys (6 pairs); each key in a pair is its own
+        // partner's inverse. These are exactly the keys for which DES_set_key
+        // returns -2 (along with the 4 weak keys already tested separately).
+        // Values taken from OpenSSL/AWS-LC des.h.
+        let semi_weak_keys: [&str; 12] = [
+            "01fe01fe01fe01fe",
+            "fe01fe01fe01fe01",
+            "1fe01fe00ef10ef1",
+            "e01fe01ff10ef10e",
+            "01e001e001f101f1",
+            "e001e001f101f101",
+            "1ffe1ffe0efe0efe",
+            "fe1ffe1ffe0efe0e",
+            "011f011f010e010e",
+            "1f011f010e010e01",
+            "e0fee0fef1fef1fe",
+            "fee0fee0fef1fef1",
+        ];
+        let distinct = "0123456789abcdef";
+        for semi_weak in &semi_weak_keys {
+            let key = from_hex(&format!("{}{}", semi_weak, distinct)).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected semi-weak DES K1 = {semi_weak} to be rejected in 2TDEA"
+            );
+            let key = from_hex(&format!("{}{}", distinct, semi_weak)).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected semi-weak DES K2 = {semi_weak} to be rejected in 2TDEA"
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_rejects_semi_weak_subkey() {
+        // Same 12 semi-weak keys as above; verify rejection at each of the
+        // three subkey positions in a 3TDEA key.
+        let semi_weak_keys: [&str; 12] = [
+            "01fe01fe01fe01fe",
+            "fe01fe01fe01fe01",
+            "1fe01fe00ef10ef1",
+            "e01fe01ff10ef10e",
+            "01e001e001f101f1",
+            "e001e001f101f101",
+            "1ffe1ffe0efe0efe",
+            "fe1ffe1ffe0efe0e",
+            "011f011f010e010e",
+            "1f011f010e010e01",
+            "e0fee0fef1fef1fe",
+            "fee0fee0fef1fef1",
+        ];
+        let fillers = ["0123456789abcdef", "23456789abcdef01"];
+
+        for semi_weak in &semi_weak_keys {
+            for position in 0..3 {
+                let mut parts = [""; 3];
+                parts[position] = *semi_weak;
+                parts[(position + 1) % 3] = fillers[0];
+                parts[(position + 2) % 3] = fillers[1];
+                let key = from_hex(&format!("{}{}{}", parts[0], parts[1], parts[2])).unwrap();
+                assert!(
+                    UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key)
+                        .and_then(EncryptingKey::cbc)
+                        .is_err(),
+                    "expected semi-weak DES subkey {semi_weak} at position {position} to be rejected in 3TDEA"
                 );
             }
         }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -692,17 +692,14 @@ impl UnboundCipherKey {
     /// Validates the key material against algorithm-specific constraints beyond
     /// the length check performed by [`UnboundCipherKey::new`].
     ///
-    /// For DES algorithms (behind `legacy-3des`), this rejects weak DES subkeys
-    /// and degenerate key configurations (e.g. K1 == K2 for 2TDEA). For other
-    /// algorithms this is a no-op since the only constraint is key length.
-    ///
-    /// The streaming cipher constructors call this because they pass raw key
-    /// bytes directly to the EVP API rather than going through
-    /// [`SymmetricCipherKey`] construction, which would otherwise perform these
-    /// checks. This is necessary because the EVP layer internally uses
-    /// `DES_set_key_unchecked`, which skips weak-key detection.
+    /// Rejects weak DES subkeys and degenerate key configurations
+    /// (e.g. K1 == K2 for 2TDEA). The streaming cipher constructors call this
+    /// because they pass raw key bytes directly to the EVP API rather than
+    /// going through [`SymmetricCipherKey`] construction, which would otherwise
+    /// perform these checks. This is necessary because the EVP layer internally
+    /// uses `DES_set_key_unchecked`, which skips weak-key detection.
+    #[cfg(feature = "legacy-3des")]
     fn validate_key_material(&self) -> Result<(), KeyRejected> {
-        #[cfg(feature = "legacy-3des")]
         #[allow(deprecated)]
         match self.algorithm.id() {
             AlgorithmId::DesEdeForLegacyUseOnly => {

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -40,7 +40,7 @@ pub(super) fn encrypt_cbc_mode(
     let mut iv = [0u8; DES_CBC_IV_LEN];
     iv.copy_from_slice(iv_bytes);
 
-    des_ede_cbc_encrypt(
+    des_cbc_encrypt(
         &key.0[0],
         &key.0[1],
         &key.0[2],
@@ -66,7 +66,7 @@ pub(super) fn decrypt_cbc_mode<'in_out>(
     let mut iv = [0u8; DES_CBC_IV_LEN];
     iv.copy_from_slice(iv_bytes);
 
-    des_ede_cbc_encrypt(
+    des_cbc_encrypt(
         &key.0[0],
         &key.0[1],
         &key.0[2],
@@ -94,7 +94,7 @@ pub(super) fn encrypt_ecb_mode(
 
     let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
     for block in in_out_iter.by_ref() {
-        des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
+        des_ecb_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
     }
     // Sanity check: `encrypt` validates that `in_out.len() % block_len == 0`
     // for ECB mode before dispatching here.
@@ -125,7 +125,7 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
     {
         let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
         for block in in_out_iter.by_ref() {
-            des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+            des_ecb_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
         }
         // Sanity check: `decrypt` validates that `in_out.len() % block_len == 0`
         // for ECB mode before dispatching here.
@@ -135,7 +135,7 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
     Ok(in_out)
 }
 
-fn des_ede_cbc_encrypt(
+fn des_cbc_encrypt(
     ks1: &DES_key_schedule,
     ks2: &DES_key_schedule,
     ks3: &DES_key_schedule,
@@ -166,7 +166,7 @@ fn des_ede_cbc_encrypt(
     });
 }
 
-fn des_ecb3_encrypt(
+fn des_ecb_encrypt(
     ks1: &DES_key_schedule,
     ks2: &DES_key_schedule,
     ks3: &DES_key_schedule,

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -1,0 +1,187 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+use crate::aws_lc::{
+    DES_cblock, DES_ecb3_encrypt, DES_ede3_cbc_encrypt, DES_key_schedule, DES_DECRYPT, DES_ENCRYPT,
+};
+use crate::error::Unspecified;
+use crate::fips::indicator_check;
+use zeroize::Zeroize;
+
+use super::{DecryptionContext, EncryptionContext, SymmetricCipherKey};
+
+/// Length of a 2TDEA (DES-EDE) key in bytes.
+pub const DES_EDE_KEY_LEN: usize = 16;
+
+/// Length of a 3TDEA (DES-EDE3) key in bytes.
+pub const DES_EDE3_KEY_LEN: usize = 24;
+
+/// The number of bytes for a DES CBC initialization vector (IV).
+pub const DES_CBC_IV_LEN: usize = 8;
+
+pub(crate) const DES_BLOCK_LEN: usize = 8;
+
+// `#[repr(transparent)]` documents that `DesKey` has the same layout as the
+// wrapped array, which the `Drop` impl in `key.rs` relies on when it zeroizes
+// the key schedule bytes through a byte-slice view.
+#[repr(transparent)]
+pub(crate) struct DesKey(pub(super) [DES_key_schedule; 3]);
+
+pub(super) fn encrypt_cbc_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    let iv_bytes: &[u8] = (&context).try_into()?;
+    let mut iv = [0u8; DES_CBC_IV_LEN];
+    iv.copy_from_slice(iv_bytes);
+
+    des_ede_cbc_encrypt(
+        &key.0[0],
+        &key.0[1],
+        &key.0[2],
+        &mut iv,
+        in_out,
+        DES_ENCRYPT,
+    );
+
+    iv.zeroize();
+    Ok(context.into())
+}
+
+pub(super) fn decrypt_cbc_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    let iv_bytes: &[u8] = (&context).try_into()?;
+    let mut iv = [0u8; DES_CBC_IV_LEN];
+    iv.copy_from_slice(iv_bytes);
+
+    des_ede_cbc_encrypt(
+        &key.0[0],
+        &key.0[1],
+        &key.0[2],
+        &mut iv,
+        in_out,
+        DES_DECRYPT,
+    );
+
+    iv.zeroize();
+    Ok(in_out)
+}
+
+pub(super) fn encrypt_ecb_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    if !matches!(context, EncryptionContext::None) {
+        unreachable!();
+    }
+
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
+    for block in in_out_iter.by_ref() {
+        des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
+    }
+    // Sanity check: `encrypt` validates that `in_out.len() % block_len == 0`
+    // for ECB mode before dispatching here.
+    debug_assert!(in_out_iter.into_remainder().is_empty());
+
+    Ok(context.into())
+}
+
+pub(super) fn decrypt_ecb_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    if !matches!(context, DecryptionContext::None) {
+        unreachable!();
+    }
+
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    // The inner scope ends the mutable borrow of `in_out` held by
+    // `in_out_iter` before we return `Ok(in_out)` below. `into_remainder()`
+    // would also consume the iterator and release the borrow, but it's inside
+    // a `debug_assert!` and therefore not evaluated in release builds, so we
+    // can't rely on it for that purpose. `encrypt_ecb_mode` doesn't need this
+    // scope because it doesn't return `in_out`.
+    {
+        let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
+        for block in in_out_iter.by_ref() {
+            des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+        }
+        // Sanity check: `decrypt` validates that `in_out.len() % block_len == 0`
+        // for ECB mode before dispatching here.
+        debug_assert!(in_out_iter.into_remainder().is_empty());
+    }
+
+    Ok(in_out)
+}
+
+fn des_ede_cbc_encrypt(
+    ks1: &DES_key_schedule,
+    ks2: &DES_key_schedule,
+    ks3: &DES_key_schedule,
+    iv: &mut [u8; DES_CBC_IV_LEN],
+    in_out: &mut [u8],
+    enc: i32,
+) {
+    // The caller (`encrypt`/`decrypt` in cipher.rs) validates block alignment
+    // for CBC mode; assert here as a safety net.
+    debug_assert_eq!(in_out.len() % DES_BLOCK_LEN, 0);
+
+    // DES is not FIPS-approved; `indicator_check!` will observe that the
+    // underlying call does not increment the approved-operation counter and
+    // correctly mark the service indicator as unapproved in FIPS builds.
+    //
+    // SAFETY: `DES_ede3_cbc_encrypt` supports in-place operation (in == out).
+    indicator_check!(unsafe {
+        DES_ede3_cbc_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            ks1,
+            ks2,
+            ks3,
+            iv.as_mut_ptr() as *mut DES_cblock,
+            enc,
+        );
+    });
+}
+
+fn des_ecb3_encrypt(
+    ks1: &DES_key_schedule,
+    ks2: &DES_key_schedule,
+    ks3: &DES_key_schedule,
+    block: &mut [u8],
+    enc: i32,
+) {
+    let input_block = block.as_ptr() as *const DES_cblock;
+    let output_block = block.as_mut_ptr() as *mut DES_cblock;
+    // DES is not FIPS-approved; `indicator_check!` will observe that the
+    // underlying call does not increment the approved-operation counter and
+    // correctly mark the service indicator as unapproved in FIPS builds.
+    //
+    // SAFETY: `input_block` and `output_block` point to the same allocation;
+    // `DES_ecb3_encrypt` supports in-place operation.
+    indicator_check!(unsafe {
+        DES_ecb3_encrypt(input_block, output_block, ks1, ks2, ks3, enc);
+    });
+}

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -16,7 +16,7 @@ pub const DES_EDE_KEY_LEN: usize = 16;
 /// Length of a 3TDEA (DES-EDE3) key in bytes.
 pub const DES_EDE3_KEY_LEN: usize = 24;
 
-/// The number of bytes for a DES CBC initialization vector (IV).
+/// The number of bytes for a 3DES-CBC initialization vector (IV).
 pub const DES_CBC_IV_LEN: usize = 8;
 
 pub(crate) const DES_BLOCK_LEN: usize = 8;

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -229,6 +229,7 @@ impl SymmetricCipherKey {
             (first_key, third_key),
         ] {
             any_equal |= u8::from(constant_time::verify_slices_are_equal(a, b).is_ok());
+            any_equal = core::hint::black_box(any_equal);
         }
         if any_equal != 0 {
             return Err(KeyRejected::inconsistent_components());

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
+#[cfg(feature = "legacy-3des")]
+use crate::aws_lc::{DES_cblock, DES_key_schedule, DES_set_key};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
+#[cfg(feature = "legacy-3des")]
+use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN};
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
-use crate::error::Unspecified;
+use crate::error::{KeyRejected, Unspecified};
 use core::mem::{size_of, MaybeUninit};
 use core::ptr::copy_nonoverlapping;
 // TODO: Uncomment when MSRV >= 1.64
@@ -14,10 +18,29 @@ use std::os::raw::c_uint;
 use zeroize::Zeroize;
 
 pub(crate) enum SymmetricCipherKey {
-    Aes128 { enc_key: AES_KEY, dec_key: AES_KEY },
-    Aes192 { enc_key: AES_KEY, dec_key: AES_KEY },
-    Aes256 { enc_key: AES_KEY, dec_key: AES_KEY },
-    ChaCha20 { raw_key: ChaCha20Key },
+    Aes128 {
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    Aes192 {
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    Aes256 {
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    ChaCha20 {
+        raw_key: ChaCha20Key,
+    },
+    #[cfg(feature = "legacy-3des")]
+    DesEde {
+        key: DesKey,
+    },
+    #[cfg(feature = "legacy-3des")]
+    DesEde3 {
+        key: DesKey,
+    },
 }
 
 unsafe impl Send for SymmetricCipherKey {}
@@ -44,6 +67,14 @@ impl Drop for SymmetricCipherKey {
                 dec_bytes.zeroize();
             },
             SymmetricCipherKey::ChaCha20 { .. } => {}
+            #[cfg(feature = "legacy-3des")]
+            SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => unsafe {
+                let key_bytes: &mut [u8; size_of::<DesKey>()] = (key as *mut DesKey)
+                    .cast::<[u8; size_of::<DesKey>()]>()
+                    .as_mut()
+                    .unwrap();
+                key_bytes.zeroize();
+            },
         }
     }
 }
@@ -76,33 +107,33 @@ impl SymmetricCipherKey {
         unsafe { Ok((enc_key.assume_init(), dec_key.assume_init())) }
     }
 
-    pub(crate) fn aes128(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn aes128(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != AES_128_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let (enc_key, dec_key) = SymmetricCipherKey::aes(key_bytes)?;
         Ok(SymmetricCipherKey::Aes128 { enc_key, dec_key })
     }
 
-    pub(crate) fn aes192(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn aes192(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != AES_192_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let (enc_key, dec_key) = SymmetricCipherKey::aes(key_bytes)?;
         Ok(SymmetricCipherKey::Aes192 { enc_key, dec_key })
     }
 
-    pub(crate) fn aes256(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn aes256(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != AES_256_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let (enc_key, dec_key) = SymmetricCipherKey::aes(key_bytes)?;
         Ok(SymmetricCipherKey::Aes256 { enc_key, dec_key })
     }
 
-    pub(crate) fn chacha20(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn chacha20(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != 32 {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let mut kb = MaybeUninit::<[u8; 32]>::uninit();
         unsafe {
@@ -111,6 +142,107 @@ impl SymmetricCipherKey {
                 raw_key: ChaCha20Key(kb.assume_init()),
             })
         }
+    }
+
+    /// Validates 2TDEA key material and computes the three DES key schedules.
+    ///
+    /// Returns the schedules as `[ks1, ks2, ks1]` (K3 = K1 for 2TDEA).
+    /// This is the shared validation/preparation step used by both
+    /// [`SymmetricCipherKey::des_ede`] and
+    /// [`UnboundCipherKey::validate_key_material`].
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn prepare_des_ede(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
+        if key_bytes.len() != DES_EDE_KEY_LEN {
+            return Err(KeyRejected::unspecified());
+        }
+        // `as_chunks` is only stable since Rust 1.88.0, so use explicit slicing
+        // instead to stay within the crate's MSRV.
+        let first_key: &[u8; 8] = key_bytes[0..8]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+        let second_key: &[u8; 8] = key_bytes[8..16]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+
+        // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA; if they are equal
+        // the cipher degenerates to single-DES (56-bit effective security).
+        if first_key == second_key {
+            return Err(KeyRejected::inconsistent_components());
+        }
+
+        // 2TDEA is defined as E_K1(D_K2(E_K1(.))), so K3 is always a copy of
+        // K1. `DES_key_schedule` is `Copy`, so we only need to run the key
+        // schedule for K1 once.
+        let ks1 = Self::des_set_key(first_key)?;
+        let ks2 = Self::des_set_key(second_key)?;
+        Ok([ks1, ks2, ks1])
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn des_ede(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
+        Ok(SymmetricCipherKey::DesEde {
+            key: DesKey(Self::prepare_des_ede(key_bytes)?),
+        })
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    fn des_set_key(key_bytes: &[u8; 8]) -> Result<DES_key_schedule, KeyRejected> {
+        let mut ks = MaybeUninit::<DES_key_schedule>::uninit();
+        // DES_set_key return values (see openssl/des.h):
+        //   0  => key is not weak and has odd parity (preferred)
+        //  -1  => key parity is not odd (schedule is still valid; most callers
+        //         do not maintain DES parity bits, so we accept this)
+        //  -2  => key is a weak DES key; reject it
+        // Any other non-zero value is treated as a failure.
+        match unsafe { DES_set_key(key_bytes.as_ptr() as *const DES_cblock, ks.as_mut_ptr()) } {
+            0 | -1 => Ok(unsafe { ks.assume_init() }),
+            _ => Err(KeyRejected::unspecified()),
+        }
+    }
+
+    /// Validates 3TDEA key material and computes the three DES key schedules.
+    ///
+    /// This is the shared validation/preparation step used by both
+    /// [`SymmetricCipherKey::des_ede3`] and
+    /// [`UnboundCipherKey::validate_key_material`].
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn prepare_des_ede3(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
+        if key_bytes.len() != DES_EDE3_KEY_LEN {
+            return Err(KeyRejected::unspecified());
+        }
+        // `as_chunks` is only stable since Rust 1.88.0, so use explicit slicing
+        // instead to stay within the crate's MSRV.
+        let first_key: &[u8; 8] = key_bytes[0..8]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+        let second_key: &[u8; 8] = key_bytes[8..16]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+        let third_key: &[u8; 8] = key_bytes[16..24]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+
+        // SP 800-67r2 Appendix A: for 3-Key TDEA, K1, K2 and K3 should be
+        // independently chosen. We enforce that all three subkeys are
+        // distinct. Callers who want the `K1 ‖ K2 ‖ K1` (2TDEA) form must
+        // use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key instead of
+        // encoding 2TDEA as a 24-byte 3TDEA key.
+        if first_key == second_key || second_key == third_key || first_key == third_key {
+            return Err(KeyRejected::inconsistent_components());
+        }
+
+        Ok([
+            Self::des_set_key(first_key)?,
+            Self::des_set_key(second_key)?,
+            Self::des_set_key(third_key)?,
+        ])
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn des_ede3(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
+        Ok(SymmetricCipherKey::DesEde3 {
+            key: DesKey(Self::prepare_des_ede3(key_bytes)?),
+        })
     }
 
     #[allow(dead_code)]
@@ -122,7 +254,13 @@ impl SymmetricCipherKey {
             | SymmetricCipherKey::Aes256 { enc_key, .. } => {
                 super::aes::encrypt_block(enc_key, block)
             }
-            SymmetricCipherKey::ChaCha20 { .. } => panic!("Unsupported algorithm!"),
+            SymmetricCipherKey::ChaCha20 { .. } => {
+                panic!("Unsupported algorithm!")
+            }
+            #[cfg(feature = "legacy-3des")]
+            SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
+                panic!("Unsupported algorithm!")
+            }
         }
     }
 }

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -157,12 +157,8 @@ impl SymmetricCipherKey {
         }
         // `as_chunks` is only stable since Rust 1.88.0, so use explicit slicing
         // instead to stay within the crate's MSRV.
-        let first_key: &[u8; 8] = key_bytes[0..8]
-            .try_into()
-            .map_err(|_| KeyRejected::unspecified())?;
-        let second_key: &[u8; 8] = key_bytes[8..16]
-            .try_into()
-            .map_err(|_| KeyRejected::unspecified())?;
+        let first_key: &[u8; 8] = key_bytes[0..8].try_into().expect("length already checked");
+        let second_key: &[u8; 8] = key_bytes[8..16].try_into().expect("length already checked");
 
         // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA; if they are equal
         // the cipher degenerates to single-DES (56-bit effective security).
@@ -192,7 +188,7 @@ impl SymmetricCipherKey {
         //   0  => key is not weak and has odd parity (preferred)
         //  -1  => key parity is not odd (schedule is still valid; most callers
         //         do not maintain DES parity bits, so we accept this)
-        //  -2  => key is a weak DES key; reject it
+        //  -2  => key is a weak or semi-weak DES key; reject it
         // Any other non-zero value is treated as a failure.
         match unsafe { DES_set_key(key_bytes.as_ptr() as *const DES_cblock, ks.as_mut_ptr()) } {
             0 | -1 => Ok(unsafe { ks.assume_init() }),
@@ -212,15 +208,11 @@ impl SymmetricCipherKey {
         }
         // `as_chunks` is only stable since Rust 1.88.0, so use explicit slicing
         // instead to stay within the crate's MSRV.
-        let first_key: &[u8; 8] = key_bytes[0..8]
-            .try_into()
-            .map_err(|_| KeyRejected::unspecified())?;
-        let second_key: &[u8; 8] = key_bytes[8..16]
-            .try_into()
-            .map_err(|_| KeyRejected::unspecified())?;
+        let first_key: &[u8; 8] = key_bytes[0..8].try_into().expect("length already checked");
+        let second_key: &[u8; 8] = key_bytes[8..16].try_into().expect("length already checked");
         let third_key: &[u8; 8] = key_bytes[16..24]
             .try_into()
-            .map_err(|_| KeyRejected::unspecified())?;
+            .expect("length already checked");
 
         // SP 800-67r2 Appendix A: for 3-Key TDEA, K1, K2 and K3 should be
         // independently chosen. We enforce that all three subkeys are

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -9,6 +9,8 @@ use crate::cipher::chacha::ChaCha20Key;
 #[cfg(feature = "legacy-3des")]
 use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN};
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
+#[cfg(feature = "legacy-3des")]
+use crate::constant_time;
 use crate::error::{KeyRejected, Unspecified};
 use core::mem::{size_of, MaybeUninit};
 use core::ptr::copy_nonoverlapping;
@@ -162,7 +164,7 @@ impl SymmetricCipherKey {
 
         // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA; if they are equal
         // the cipher degenerates to single-DES (56-bit effective security).
-        if first_key == second_key {
+        if constant_time::verify_slices_are_equal(first_key, second_key).is_ok() {
             return Err(KeyRejected::inconsistent_components());
         }
 
@@ -214,12 +216,21 @@ impl SymmetricCipherKey {
             .try_into()
             .expect("length already checked");
 
-        // SP 800-67r2 Appendix A: for 3-Key TDEA, K1, K2 and K3 should be
-        // independently chosen. We enforce that all three subkeys are
-        // distinct. Callers who want the `K1 ‖ K2 ‖ K1` (2TDEA) form must
-        // use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key instead of
+        // SP 800-67 §2 (Keying Option 1) requires K1, K2 and K3 to be
+        // pairwise independent. We enforce that all three subkeys are distinct
+        // so the cipher cannot degenerate to single-DES (K1==K2 or K2==K3)
+        // or to 2TDEA (K1==K3). Callers who want 2TDEA must use
+        // `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key instead of
         // encoding 2TDEA as a 24-byte 3TDEA key.
-        if first_key == second_key || second_key == third_key || first_key == third_key {
+        let mut any_equal: u8 = 0;
+        for (a, b) in [
+            (first_key, second_key),
+            (second_key, third_key),
+            (first_key, third_key),
+        ] {
+            any_equal |= u8::from(constant_time::verify_slices_are_equal(a, b).is_ok());
+        }
+        if any_equal != 0 {
             return Err(KeyRejected::inconsistent_components());
         }
 

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -114,13 +114,15 @@ impl PaddedBlockEncryptingKey {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn new(
         key: UnboundCipherKey,
         mode: OperatingMode,
         padding: PaddingStrategy,
     ) -> Result<PaddedBlockEncryptingKey, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(Self {
             algorithm,
@@ -255,13 +257,15 @@ impl PaddedBlockDecryptingKey {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn new(
         key: UnboundCipherKey,
         mode: OperatingMode,
         padding: PaddingStrategy,
     ) -> Result<PaddedBlockDecryptingKey, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(PaddedBlockDecryptingKey {
             algorithm,

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -97,6 +97,11 @@ impl PaddedBlockEncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
     }
@@ -110,6 +115,11 @@ impl PaddedBlockEncryptingKey {
     ///
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
@@ -218,6 +228,11 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
     }
@@ -235,6 +250,11 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn cbc_iso10126(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, PaddingStrategy::ISO10126)
     }
@@ -253,6 +273,11 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
+    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    ///   provided key material contains weak or semi-weak DES subkeys, or a
+    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
+    ///   pairwise equality for 3TDEA).
     pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -319,7 +319,9 @@ impl StreamingEncryptingKey {
     /// The resulting ciphertext will be the same length as the plaintext.
     ///
     /// # Errors
-    /// Returns and error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key`'s algorithm does not support CTR mode (e.g.
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key.algorithm().new_encryption_context(OperatingMode::CTR)?;
         Self::less_safe_ctr(key, context)
@@ -332,7 +334,9 @@ impl StreamingEncryptingKey {
     /// an `EncryptionContext` from a previously used initialization vector (IV).
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key`'s algorithm does not support CTR mode (e.g.
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn less_safe_ctr(
         key: UnboundCipherKey,
         context: EncryptionContext,
@@ -346,7 +350,11 @@ impl StreamingEncryptingKey {
     /// to fill the next block of ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
+    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
+    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key.algorithm().new_encryption_context(OperatingMode::CBC)?;
         Self::less_safe_cbc_pkcs7(key, context)
@@ -356,7 +364,9 @@ impl StreamingEncryptingKey {
     /// The resulting ciphertext will be the same length as the plaintext.
     ///
     /// # Errors
-    /// Returns and error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key
             .algorithm()
@@ -372,7 +382,11 @@ impl StreamingEncryptingKey {
     /// very likely not what you want to use.
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
+    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
+    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
     pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key.algorithm().new_encryption_context(OperatingMode::ECB)?;
         Self::new(key, OperatingMode::ECB, context)
@@ -385,7 +399,9 @@ impl StreamingEncryptingKey {
     /// an `EncryptionContext` from a previously used initialization vector (IV).
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn less_safe_cfb128(
         key: UnboundCipherKey,
         context: EncryptionContext,
@@ -402,7 +418,11 @@ impl StreamingEncryptingKey {
     /// an `EncryptionContext` from a previously used initialization vector (IV).
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
+    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
+    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
     pub fn less_safe_cbc_pkcs7(
         key: UnboundCipherKey,
         context: EncryptionContext,
@@ -615,7 +635,9 @@ impl StreamingDecryptingKey {
     /// The resulting plaintext will be the same length as the ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key`'s algorithm does not support CTR mode (e.g.
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey, context: DecryptionContext) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CTR, context)
     }
@@ -624,7 +646,11 @@ impl StreamingDecryptingKey {
     /// The resulting plaintext will be shorter than the ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
+    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
+    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
     pub fn cbc_pkcs7(
         key: UnboundCipherKey,
         context: DecryptionContext,
@@ -636,7 +662,9 @@ impl StreamingDecryptingKey {
     /// The resulting plaintext will be the same length as the ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey, context: DecryptionContext) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128, context)
     }
@@ -649,7 +677,11 @@ impl StreamingDecryptingKey {
     /// very likely not what you want to use.
     ///
     /// # Errors
-    /// Returns an error on an internal failure.
+    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
+    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
+    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
     pub fn ecb_pkcs7(
         key: UnboundCipherKey,
         context: DecryptionContext,

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -125,6 +125,14 @@ impl StreamingEncryptingKey {
         context: EncryptionContext,
     ) -> Result<Self, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
+        // The streaming path passes raw key bytes to the EVP API rather than
+        // going through `SymmetricCipherKey` construction.  Validate
+        // algorithm-specific key constraints (e.g. DES weak-key / K1!=K2
+        // checks) that would otherwise be missed.
+        key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);
         let key_bytes = key.key_bytes.as_ref();
@@ -136,6 +144,16 @@ impl StreamingEncryptingKey {
 
         match &context {
             ctx @ EncryptionContext::Iv128(..) => {
+                let iv = <&[u8]>::try_from(ctx)?;
+                debug_assert_eq!(
+                    iv.len(),
+                    <usize>::try_from(unsafe { EVP_CIPHER_iv_length(cipher.as_const_ptr()) })
+                        .unwrap()
+                );
+                evp_encrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
+            }
+            #[cfg(feature = "legacy-3des")]
+            ctx @ EncryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(
                     iv.len(),
@@ -410,8 +428,13 @@ impl StreamingDecryptingKey {
         mode: OperatingMode,
         context: DecryptionContext,
     ) -> Result<Self, Unspecified> {
-        let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
+        // See comment in `StreamingEncryptingKey::new`.
+        key.validate_key_material()?;
+        let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);
         let key_bytes = key.key_bytes.as_ref();
         if key_bytes.len()
@@ -422,6 +445,16 @@ impl StreamingDecryptingKey {
 
         match &context {
             ctx @ DecryptionContext::Iv128(..) => {
+                let iv = <&[u8]>::try_from(ctx)?;
+                debug_assert_eq!(
+                    iv.len(),
+                    <usize>::try_from(unsafe { EVP_CIPHER_iv_length(cipher.as_const_ptr()) })
+                        .unwrap()
+                );
+                evp_decrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
+            }
+            #[cfg(feature = "legacy-3des")]
+            ctx @ DecryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(
                     iv.len(),

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -132,6 +132,7 @@ impl StreamingEncryptingKey {
         // going through `SymmetricCipherKey` construction.  Validate
         // algorithm-specific key constraints (e.g. DES weak-key / K1!=K2
         // checks) that would otherwise be missed.
+        #[cfg(feature = "legacy-3des")]
         key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);
@@ -433,6 +434,7 @@ impl StreamingDecryptingKey {
             return Err(Unspecified);
         }
         // See comment in `StreamingEncryptingKey::new`.
+        #[cfg(feature = "legacy-3des")]
         key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -132,7 +132,6 @@ impl StreamingEncryptingKey {
         // going through `SymmetricCipherKey` construction.  Validate
         // algorithm-specific key constraints (e.g. DES weak-key / K1!=K2
         // checks) that would otherwise be missed.
-        #[cfg(feature = "legacy-3des")]
         key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);
@@ -434,7 +433,6 @@ impl StreamingDecryptingKey {
             return Err(Unspecified);
         }
         // See comment in `StreamingEncryptingKey::new`.
-        #[cfg(feature = "legacy-3des")]
         key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);

--- a/aws-lc-rs/src/cipher/tests/fips.rs
+++ b/aws-lc-rs/src/cipher/tests/fips.rs
@@ -207,6 +207,7 @@ block_api!(
     FipsServiceStatus::Approved
 );
 
+#[cfg(feature = "legacy-3des")]
 block_api!(
     block_des_ede_cbc_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -216,6 +217,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 block_api!(
     block_des_ede_ecb_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -225,6 +227,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 block_api!(
     block_des_ede3_cbc_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -234,6 +237,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 block_api!(
     block_des_ede3_ecb_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -243,6 +247,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 streaming_api!(
     streaming_des_ede_cbc_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -252,6 +257,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 streaming_api!(
     streaming_des_ede_ecb_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -261,6 +267,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 streaming_api!(
     streaming_des_ede3_cbc_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -270,6 +277,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
+#[cfg(feature = "legacy-3des")]
 streaming_api!(
     streaming_des_ede3_ecb_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,

--- a/aws-lc-rs/src/cipher/tests/fips.rs
+++ b/aws-lc-rs/src/cipher/tests/fips.rs
@@ -7,6 +7,9 @@ use crate::cipher::{
     DecryptingKey, EncryptingKey, PaddedBlockDecryptingKey, PaddedBlockEncryptingKey,
     StreamingDecryptingKey, StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
+#[cfg(feature = "legacy-3des")]
+#[allow(deprecated)]
+use crate::cipher::{DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY};
 use crate::fips::{assert_fips_status_indicator, FipsServiceStatus};
 
 const TEST_KEY_128_BIT: [u8; 16] = [
@@ -23,29 +26,34 @@ const TEST_KEY_256_BIT: [u8; 32] = [
     0x71, 0x0f, 0xd5, 0xe1, 0xd4, 0xfe, 0x95, 0xb3, 0x03, 0x46, 0xa5, 0x8e, 0x36, 0xad, 0x18, 0xe3,
 ];
 
+#[cfg(feature = "legacy-3des")]
+const TEST_KEY_DES_EDE: [u8; 16] = [
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01,
+];
+
+#[cfg(feature = "legacy-3des")]
+const TEST_KEY_DES_EDE3: [u8; 24] = [
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01,
+    0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23,
+];
+
 const TEST_MESSAGE: &str = "test message";
 
 macro_rules! block_api {
-    ($name:ident, $alg:expr, $encrypt_mode:path, $decrypt_mode:path, $key:expr) => {
+    ($name:ident, $alg:expr, $encrypt_mode:path, $decrypt_mode:path, $key:expr, $expect:path) => {
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = $encrypt_mode(UnboundCipherKey::new($alg, $key).unwrap()).unwrap();
 
             let mut in_out = Vec::from(TEST_MESSAGE);
 
-            let context = assert_fips_status_indicator!(
-                key.encrypt(&mut in_out),
-                FipsServiceStatus::Approved
-            )
-            .unwrap();
+            let context = assert_fips_status_indicator!(key.encrypt(&mut in_out), $expect).unwrap();
 
             let key = $decrypt_mode(UnboundCipherKey::new($alg, $key).unwrap()).unwrap();
 
-            let in_out = assert_fips_status_indicator!(
-                key.decrypt(&mut in_out, context),
-                FipsServiceStatus::Approved
-            )
-            .unwrap();
+            let in_out =
+                assert_fips_status_indicator!(key.decrypt(&mut in_out, context), $expect).unwrap();
 
             assert_eq!(TEST_MESSAGE.as_bytes(), in_out);
         }
@@ -53,8 +61,9 @@ macro_rules! block_api {
 }
 
 macro_rules! streaming_api {
-    ($name:ident, $alg:expr, $encrypt_mode:path, $decrypt_mode:path, $key:expr) => {
+    ($name:ident, $alg:expr, $encrypt_mode:path, $decrypt_mode:path, $key:expr, $expect:path) => {
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let mut key = $encrypt_mode(UnboundCipherKey::new($alg, $key).unwrap()).unwrap();
 
@@ -64,11 +73,9 @@ macro_rules! streaming_api {
             let mut buffer_update = key.update(&input, &mut encrypt_output).unwrap();
 
             let outlen = buffer_update.written().len();
-            let (context, buffer_update) = assert_fips_status_indicator!(
-                key.finish(buffer_update.remainder_mut()),
-                FipsServiceStatus::Approved
-            )
-            .unwrap();
+            let (context, buffer_update) =
+                assert_fips_status_indicator!(key.finish(buffer_update.remainder_mut()), $expect)
+                    .unwrap();
 
             let outlen = outlen + buffer_update.written().len();
 
@@ -80,11 +87,9 @@ macro_rules! streaming_api {
             let mut buffer_update = key.update(ciphertext, &mut decrypt_output).unwrap();
 
             let outlen = buffer_update.written().len();
-            let buffer_update = assert_fips_status_indicator!(
-                key.finish(buffer_update.remainder_mut()),
-                FipsServiceStatus::Approved
-            )
-            .unwrap();
+            let buffer_update =
+                assert_fips_status_indicator!(key.finish(buffer_update.remainder_mut()), $expect)
+                    .unwrap();
 
             let outlen = outlen + buffer_update.written().len();
             let plaintext = &decrypt_output[0..outlen];
@@ -99,7 +104,8 @@ streaming_api!(
     &AES_128,
     StreamingEncryptingKey::cbc_pkcs7,
     StreamingDecryptingKey::cbc_pkcs7,
-    &TEST_KEY_128_BIT
+    &TEST_KEY_128_BIT,
+    FipsServiceStatus::Approved
 );
 
 streaming_api!(
@@ -107,7 +113,8 @@ streaming_api!(
     &AES_128,
     StreamingEncryptingKey::ctr,
     StreamingDecryptingKey::ctr,
-    &TEST_KEY_128_BIT
+    &TEST_KEY_128_BIT,
+    FipsServiceStatus::Approved
 );
 
 streaming_api!(
@@ -115,7 +122,8 @@ streaming_api!(
     &AES_192,
     StreamingEncryptingKey::cbc_pkcs7,
     StreamingDecryptingKey::cbc_pkcs7,
-    &TEST_KEY_192_BIT
+    &TEST_KEY_192_BIT,
+    FipsServiceStatus::Approved
 );
 
 streaming_api!(
@@ -123,7 +131,8 @@ streaming_api!(
     &AES_192,
     StreamingEncryptingKey::ctr,
     StreamingDecryptingKey::ctr,
-    &TEST_KEY_192_BIT
+    &TEST_KEY_192_BIT,
+    FipsServiceStatus::Approved
 );
 
 streaming_api!(
@@ -131,14 +140,17 @@ streaming_api!(
     &AES_256,
     StreamingEncryptingKey::cbc_pkcs7,
     StreamingDecryptingKey::cbc_pkcs7,
-    &TEST_KEY_256_BIT
+    &TEST_KEY_256_BIT,
+    FipsServiceStatus::Approved
 );
+
 streaming_api!(
     streaming_aes_256_ctr,
     &AES_256,
     StreamingEncryptingKey::ctr,
     StreamingDecryptingKey::ctr,
-    &TEST_KEY_256_BIT
+    &TEST_KEY_256_BIT,
+    FipsServiceStatus::Approved
 );
 
 block_api!(
@@ -146,7 +158,8 @@ block_api!(
     &AES_128,
     PaddedBlockEncryptingKey::cbc_pkcs7,
     PaddedBlockDecryptingKey::cbc_pkcs7,
-    &TEST_KEY_128_BIT
+    &TEST_KEY_128_BIT,
+    FipsServiceStatus::Approved
 );
 
 block_api!(
@@ -154,7 +167,8 @@ block_api!(
     &AES_128,
     EncryptingKey::ctr,
     DecryptingKey::ctr,
-    &TEST_KEY_128_BIT
+    &TEST_KEY_128_BIT,
+    FipsServiceStatus::Approved
 );
 
 block_api!(
@@ -162,7 +176,8 @@ block_api!(
     &AES_192,
     PaddedBlockEncryptingKey::cbc_pkcs7,
     PaddedBlockDecryptingKey::cbc_pkcs7,
-    &TEST_KEY_192_BIT
+    &TEST_KEY_192_BIT,
+    FipsServiceStatus::Approved
 );
 
 block_api!(
@@ -170,7 +185,8 @@ block_api!(
     &AES_192,
     EncryptingKey::ctr,
     DecryptingKey::ctr,
-    &TEST_KEY_192_BIT
+    &TEST_KEY_192_BIT,
+    FipsServiceStatus::Approved
 );
 
 block_api!(
@@ -178,12 +194,87 @@ block_api!(
     &AES_256,
     PaddedBlockEncryptingKey::cbc_pkcs7,
     PaddedBlockDecryptingKey::cbc_pkcs7,
-    &TEST_KEY_256_BIT
+    &TEST_KEY_256_BIT,
+    FipsServiceStatus::Approved
 );
+
 block_api!(
     block_aes_256_ctr,
     &AES_256,
     EncryptingKey::ctr,
     DecryptingKey::ctr,
-    &TEST_KEY_256_BIT
+    &TEST_KEY_256_BIT,
+    FipsServiceStatus::Approved
+);
+
+block_api!(
+    block_des_ede_cbc_pkcs7,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    PaddedBlockEncryptingKey::cbc_pkcs7,
+    PaddedBlockDecryptingKey::cbc_pkcs7,
+    &TEST_KEY_DES_EDE,
+    FipsServiceStatus::NonApproved
+);
+
+block_api!(
+    block_des_ede_ecb_pkcs7,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    PaddedBlockEncryptingKey::ecb_pkcs7,
+    PaddedBlockDecryptingKey::ecb_pkcs7,
+    &TEST_KEY_DES_EDE,
+    FipsServiceStatus::NonApproved
+);
+
+block_api!(
+    block_des_ede3_cbc_pkcs7,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    PaddedBlockEncryptingKey::cbc_pkcs7,
+    PaddedBlockDecryptingKey::cbc_pkcs7,
+    &TEST_KEY_DES_EDE3,
+    FipsServiceStatus::NonApproved
+);
+
+block_api!(
+    block_des_ede3_ecb_pkcs7,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    PaddedBlockEncryptingKey::ecb_pkcs7,
+    PaddedBlockDecryptingKey::ecb_pkcs7,
+    &TEST_KEY_DES_EDE3,
+    FipsServiceStatus::NonApproved
+);
+
+streaming_api!(
+    streaming_des_ede_cbc_pkcs7,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    StreamingEncryptingKey::cbc_pkcs7,
+    StreamingDecryptingKey::cbc_pkcs7,
+    &TEST_KEY_DES_EDE,
+    FipsServiceStatus::NonApproved
+);
+
+streaming_api!(
+    streaming_des_ede_ecb_pkcs7,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    StreamingEncryptingKey::ecb_pkcs7,
+    StreamingDecryptingKey::ecb_pkcs7,
+    &TEST_KEY_DES_EDE,
+    FipsServiceStatus::NonApproved
+);
+
+streaming_api!(
+    streaming_des_ede3_cbc_pkcs7,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    StreamingEncryptingKey::cbc_pkcs7,
+    StreamingDecryptingKey::cbc_pkcs7,
+    &TEST_KEY_DES_EDE3,
+    FipsServiceStatus::NonApproved
+);
+
+streaming_api!(
+    streaming_des_ede3_ecb_pkcs7,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    StreamingEncryptingKey::ecb_pkcs7,
+    StreamingDecryptingKey::ecb_pkcs7,
+    &TEST_KEY_DES_EDE3,
+    FipsServiceStatus::NonApproved
 );

--- a/aws-lc-rs/src/iv.rs
+++ b/aws-lc-rs/src/iv.rs
@@ -10,6 +10,10 @@ use crate::error::Unspecified;
 use crate::rand;
 use zeroize::Zeroize;
 
+/// Length of a 64-bit IV in bytes (used by DES/3DES).
+#[cfg(feature = "legacy-3des")]
+pub(crate) const IV_LEN_64_BIT: usize = 8;
+
 /// Length of a 128-bit IV in bytes.
 pub const IV_LEN_128_BIT: usize = 16;
 

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -6,6 +6,9 @@ use aws_lc_rs::cipher::{
     PaddedBlockDecryptingKey, PaddedBlockEncryptingKey, StreamingDecryptingKey,
     StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
+#[cfg(feature = "legacy-3des")]
+#[allow(deprecated)]
+use aws_lc_rs::cipher::{DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY};
 use aws_lc_rs::iv::{FixedLength, IV_LEN_128_BIT};
 use aws_lc_rs::test;
 use aws_lc_rs::test::from_hex;
@@ -1109,6 +1112,523 @@ unpadded_cipher_kat!(
     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
     "00000000000000000000000000000000",
     "00112233445566778899aabbccddee"
+);
+
+#[cfg(feature = "legacy-3des")]
+macro_rules! des_streaming_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
+        paste! {
+        #[test]
+        #[allow(deprecated)]
+        fn [<$name _streaming>]() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            for step in ($from_step..=$to_step) {
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = StreamingEncryptingKey::ecb_pkcs7(unbound_key).unwrap();
+
+                let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
+
+                assert_eq!(expected_ciphertext.as_slice(), ciphertext.as_ref());
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    StreamingDecryptingKey::ecb_pkcs7(unbound_key2, decrypt_ctx).unwrap();
+
+                let plaintext = step_decrypt(decrypting_key, &ciphertext, step);
+                assert_eq!(input.as_slice(), plaintext.as_ref());
+            }
+        }
+        }
+    };
+
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
+        paste! {
+        #[test]
+        #[allow(deprecated)]
+        fn [<$name _streaming>]() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+            let iv = from_hex($iv).unwrap();
+
+            for step in ($from_step..=$to_step) {
+                let iv_arr: [u8; 8] = iv.clone().try_into().unwrap();
+                let ec = EncryptionContext::Iv64(FixedLength::from(iv_arr));
+
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = StreamingEncryptingKey::[<less_safe_ $constructor>](unbound_key, ec).unwrap();
+
+                let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
+
+                assert_eq!(expected_ciphertext.as_slice(), ciphertext.as_ref());
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    StreamingDecryptingKey::$constructor(unbound_key2, decrypt_ctx).unwrap();
+
+                let plaintext = step_decrypt(decrypting_key, &ciphertext, step);
+                assert_eq!(input.as_slice(), plaintext.as_ref());
+            }
+        }
+        }
+    };
+}
+
+#[cfg(feature = "legacy-3des")]
+macro_rules! des_streaming_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal, $from_step:literal, $to_step:literal) => {
+        paste! {
+        #[test]
+        #[allow(deprecated)]
+        fn [<$name _streaming>]() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            for step in ($from_step..=$to_step) {
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = StreamingEncryptingKey::$constructor(unbound_key).unwrap();
+
+                let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    StreamingDecryptingKey::$constructor(unbound_key2, decrypt_ctx).unwrap();
+
+                let plaintext = step_decrypt(decrypting_key, &ciphertext, step);
+                assert_eq!(input.as_slice(), plaintext.as_ref());
+            }
+        }
+        }
+    };
+}
+
+#[cfg(feature = "legacy-3des")]
+macro_rules! des_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+        #[test]
+        #[allow(deprecated)]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let enc_ctx = if $iv.len() == 0 {
+                EncryptionContext::None
+            } else {
+                let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                EncryptionContext::Iv64(FixedLength::from(iv_arr))
+            };
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key
+                .less_safe_encrypt(&mut in_out, enc_ctx)
+                .unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = DecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+    };
+
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal) => {
+        #[test]
+        #[allow(deprecated)]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            let enc_ctx = if $iv.len() == 0 {
+                EncryptionContext::None
+            } else {
+                let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                EncryptionContext::Iv64(FixedLength::from(iv_arr))
+            };
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            encrypting_key
+                .less_safe_encrypt(in_out.as_mut_slice(), enc_ctx)
+                .expect_err("expected encryption failure");
+        }
+    };
+}
+
+#[cfg(feature = "legacy-3des")]
+macro_rules! des_padded_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+        #[test]
+        #[allow(deprecated)]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = PaddedBlockEncryptingKey::ecb_pkcs7(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key
+                .less_safe_encrypt(&mut in_out, EncryptionContext::None)
+                .unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = PaddedBlockDecryptingKey::ecb_pkcs7(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+
+        des_streaming_cipher_kat!(
+            $name,
+            $alg,
+            $mode,
+            ecb_pkcs7,
+            $key,
+            $plaintext,
+            $ciphertext,
+            2,
+            9
+        );
+    };
+
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+        #[test]
+        #[allow(deprecated)]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let enc_ctx = if $iv.len() == 0 {
+                EncryptionContext::None
+            } else {
+                let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                EncryptionContext::Iv64(FixedLength::from(iv_arr))
+            };
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = PaddedBlockEncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key
+                .less_safe_encrypt(&mut in_out, enc_ctx)
+                .unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = PaddedBlockDecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+
+        des_streaming_cipher_kat!(
+            $name,
+            $alg,
+            $mode,
+            $constructor,
+            $key,
+            $iv,
+            $plaintext,
+            $ciphertext,
+            2,
+            9
+        );
+    };
+}
+
+#[cfg(feature = "legacy-3des")]
+macro_rules! des_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
+        #[test]
+        #[allow(deprecated)]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key.encrypt(in_out.as_mut_slice()).unwrap();
+            assert_ne!(input.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = DecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+    };
+}
+
+#[cfg(feature = "legacy-3des")]
+macro_rules! des_padded_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
+        #[test]
+        #[allow(deprecated)]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = PaddedBlockEncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key.encrypt(&mut in_out).unwrap();
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = PaddedBlockDecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+
+        des_streaming_cipher_rt!($name, $alg, $mode, $constructor, $key, $plaintext, 2, 9);
+    };
+}
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede_cbc_32_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede3_cbc_32_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede_ecb_32_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede3_ecb_32_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede_cbc_31_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede3_cbc_31_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede_ecb_31_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ede3_ecb_31_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_rt!(
+    test_rt_des_ede_cbc_32_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_rt!(
+    test_rt_des_ede3_cbc_32_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_rt!(
+    test_rt_des_ede_ecb_32_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_rt!(
+    test_rt_des_ede3_ecb_32_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede_cbc_pkcs7_32_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581dcb0d2607c9dd8a3"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede3_cbc_pkcs7_32_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da733830d1a78387028"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede_ecb_pkcs7_32_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d5db28100613ac225"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede3_ecb_pkcs7_32_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87832846b52f9e213d"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede_cbc_pkcs7_31_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede3_cbc_pkcs7_31_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede_ecb_pkcs7_31_bytes,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede3_ecb_pkcs7_31_bytes,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
 );
 
 #[test]

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -1411,6 +1411,11 @@ macro_rules! des_padded_cipher_rt {
     };
 }
 
+// The following DES KAT vectors are from the NIST SP 800-38A TDES example values:
+// https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+// The 2TDEA key is the first 16 bytes of the 3TDEA key.
+// PKCS#7-padded variants are not from NIST; their ciphertexts were computed
+// by applying PKCS#7 padding to the NIST plaintext before encryption.
 #[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede_cbc_32_bytes,
@@ -1510,7 +1515,7 @@ des_cipher_rt!(
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1520,7 +1525,7 @@ des_cipher_rt!(
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1530,7 +1535,7 @@ des_cipher_rt!(
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1540,7 +1545,7 @@ des_cipher_rt!(
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1598,7 +1603,7 @@ des_padded_cipher_rt!(
     OperatingMode::CBC,
     cbc_pkcs7,
     "0123456789abcdef23456789abcdef01",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1608,7 +1613,7 @@ des_padded_cipher_rt!(
     OperatingMode::CBC,
     cbc_pkcs7,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1618,7 +1623,7 @@ des_padded_cipher_rt!(
     OperatingMode::ECB,
     ecb_pkcs7,
     "0123456789abcdef23456789abcdef01",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[cfg(feature = "legacy-3des")]
@@ -1628,7 +1633,7 @@ des_padded_cipher_rt!(
     OperatingMode::ECB,
     ecb_pkcs7,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
-    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
 #[test]


### PR DESCRIPTION
### Description of changes:
Adds 2-key and 3-key Triple DES (`DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY`) to the `cipher` module, gated behind a new opt-in Cargo feature `legacy-3des`. Only CBC and ECB are supported; CTR and CFB128 are rejected at key-construction time.

Everything about 3DES is hidden by default: the module, the `AlgorithmId` variants, the `SymmetricCipherKey` variants, the new `Iv64` cipher-context variant, and all tests are `#[cfg(feature = "legacy-3des")]`-gated. When the feature is enabled, every public item is also `#[deprecated]` so downstream use sites produce a compiler warning, and the naming follows the existing `cmac::TDES_FOR_LEGACY_USE_ONLY` convention.

Key validation is stricter than what the underlying `EVP_des_*` primitives would do on their own:
* Weak DES subkeys (the four SP 800-67 weak keys) are rejected via `DES_set_key` for every subkey.
* 2TDEA requires K1 ≠ K2.
* 3TDEA requires K1, K2, and K3 to be pairwise distinct. Callers who want the `K1 ‖ K2 ‖ K1` form must use the 2TDEA variant rather than encoding 2TDEA as a 24-byte 3TDEA key.

The streaming cipher path passes raw key bytes to the EVP layer (which internally uses `DES_set_key_unchecked`), so a new `UnboundCipherKey::validate_key_material` step runs the same checks before EVP initialization. For non-DES algorithms it is a no-op.

FIPS builds are supported: the native DES calls are wrapped in `indicator_check!`, which observes that the approved-operation counter does not advance and correctly marks the service indicator as unapproved.

### Call-outs:
* **Feature flag posture is intentionally stricter than `cmac`.** `cmac::TDES_FOR_LEGACY_USE_ONLY` is currently unconditional and not deprecation-marked. This PR opts for the opposite (feature-gated, `#[deprecated]`) because the stated expectation is that 3DES should be clearly legacy in the API surface. Happy to discuss whether `cmac` should follow in a separate change.
* **`all-bindings` propagation.** The low-level `DES_*` symbols live in `openssl/des.h`, which is outside the default bindgen allowlist, so `legacy-3des` forces `aws-lc-sys?/all-bindings` on. `aws-lc-fips-sys` always exposes the full binding set, so nothing extra is needed for the FIPS path. The `EVP_des_*` symbols used on the streaming/cmac paths live in `evp.h` and are always available.
* **Small internal error-type refactor.** `SymmetricCipherKey::aes128/192/256/chacha20` and `TryInto<SymmetricCipherKey> for UnboundCipherKey` now return `KeyRejected` instead of `Unspecified`, so the DES validation path can surface a more specific error internally. All of these items are `pub(crate)`, and the `From<KeyRejected> for Unspecified` conversion handles the boundary at the public API, so this is not an API break. Worth a look during review since it is technically unrelated to DES.
* **New `Algorithm::supports_mode`.** Used to reject `(algorithm, mode)` combinations (e.g. 3DES + CTR) at key-construction time rather than deferring to the first encrypt/decrypt call. This is called from `EncryptingKey::new`, `DecryptingKey::new`, the padded variants, and the streaming variants.
* **No 3DES support was added to `aead::quic`.** QUIC header protection doesn't use 3DES; `cipher_new_mask` treats the new `SymmetricCipherKey` variants as an error.

### Testing:
Tested only with the `legacy-3des` feature enabled (default builds are unchanged and covered by the existing test suite).

* SP 800-67 known-answer tests for 2TDEA and 3TDEA in CBC and ECB mode, both via the one-shot `EncryptingKey`/`DecryptingKey` API and via `StreamingEncryptingKey`/`StreamingDecryptingKey` with step sizes 2 through 9 to exercise the EVP update boundaries.
* Round-trip tests on non-block-aligned plaintext for PKCS#7 CBC/ECB.
* Negative tests for all four DES weak keys, rotated through each of the three subkey positions and padded with distinct non-weak fillers so the pairwise-distinctness check does not short-circuit the weak-key check.
* Negative tests for every degenerate 3TDEA configuration (K1 == K2, K2 == K3, K1 == K3) and the 2TDEA K1 == K2 case.
* Negative tests for CTR and CFB128 on both encrypt and decrypt paths.
* Full library test suite passes with and without `legacy-3des`, and under `--features fips,legacy-3des`.
* `cargo clippy` is clean with the feature enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
