### PR TITLE
Add ML-DSA x86_64 native assembly to CC builder scripts

### DIFF
--- a/aws-lc-sys/scripts/cc_builder/apple_x86_64.sh
+++ b/aws-lc-sys/scripts/cc_builder/apple_x86_64.sh
@@ -14,6 +14,8 @@ declare -a SOURCE_FILES
 SOURCE_FILES=()
 mapfile -O 0 -t SOURCE_FILES < <(find crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src -name "*.S" -type f | sort -f)
 echo "${SOURCE_FILES[@]}"
+mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src -name "*.S" -type f | sort -f)
+echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find generated-src/mac-x86_64/crypto -name "*.S" -type f  | sort -f)
 echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(s2n_bignum_x86_64)

--- a/aws-lc-sys/scripts/cc_builder/linux_x86_64.sh
+++ b/aws-lc-sys/scripts/cc_builder/linux_x86_64.sh
@@ -14,6 +14,8 @@ declare -a SOURCE_FILES
 SOURCE_FILES=()
 mapfile -O 0 -t SOURCE_FILES < <(find crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src -name "*.S" -type f | sort -f)
 echo "${SOURCE_FILES[@]}"
+mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src -name "*.S" -type f | sort -f)
+echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find generated-src/linux-x86_64/crypto -name "*.S" -type f  | sort -f)
 echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(s2n_bignum_x86_64)


### PR DESCRIPTION
## Summary
- Add discovery of ML-DSA mldsa-native x86_64 assembly files in the CC builder scripts for `linux_x86_64.sh` and `apple_x86_64.sh`
- Follows the same pattern as ML-KEM's native assembly discovery

## Context
[aws/aws-lc#3195](https://github.com/aws/aws-lc/pull/3195) imports the mldsa-native x86_64 AVX2 backend into aws-lc, adding `.S` files under `crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/`. The `aws-lc-rs` CC builder needs to discover these files, otherwise the `aws-lc-rs-linux` CI job in aws-lc fails. This PR unblocks aws/aws-lc#3195.

This is the same pattern used when ML-KEM's x86_64 backend was first added.

## Changes
- `linux_x86_64.sh`: Add `find` for ML-DSA x86_64 assembly
- `apple_x86_64.sh`: Add `find` for ML-DSA x86_64 assembly

## Note
The generated `.rs` builder files will need regeneration after the aws-lc submodule is bumped to include the ML-DSA native backend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.