### PR TITLE
Fix nightly clippy warnings

### DIFF
--- a/aws-lc-rs/examples/digest.rs
+++ b/aws-lc-rs/examples/digest.rs
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
                 .and_then(|mut file| process(digest_alg, &mut file, &file_name))
             {
                 // Display error information
-                println!("digest: {}: {}", &file_name, e);
+                println!("digest: {file_name}: {e}");
                 error = Some(e);
             }
         }

--- a/aws-lc-rs/src/agreement/agreement_tests.rs
+++ b/aws-lc-rs/src/agreement/agreement_tests.rs
@@ -324,7 +324,7 @@ fn agreement_traits() {
     test::compile_time_assert_sync::<PrivateKey>();
 
     assert_eq!(
-        format!("{:?}", &private_key),
+        format!("{private_key:?}"),
         "PrivateKey { algorithm: Algorithm { curve: P256 } }"
     );
 
@@ -334,7 +334,7 @@ fn agreement_traits() {
     test::compile_time_assert_sync::<PrivateKey>();
 
     assert_eq!(
-        format!("{:?}", &ephemeral_private_key),
+        format!("{ephemeral_private_key:?}"),
         "PrivateKey { algorithm: Algorithm { curve: P256 } }"
     );
 
@@ -343,7 +343,7 @@ fn agreement_traits() {
         "PublicKey \\{ algorithm: Algorithm \\{ curve: P256 \\}, bytes: \"[0-9a-f]+\" \\}",
     )
     .unwrap();
-    let pubkey_debug = format!("{:?}", &public_key);
+    let pubkey_debug = format!("{public_key:?}");
 
     assert!(
         pubkey_re.is_match(&pubkey_debug),
@@ -353,7 +353,7 @@ fn agreement_traits() {
     #[allow(clippy::redundant_clone)]
     let pubkey_clone = public_key.clone();
     assert_eq!(public_key.as_ref(), pubkey_clone.as_ref());
-    assert_eq!(pubkey_debug, format!("{:?}", &pubkey_clone));
+    assert_eq!(pubkey_debug, format!("{pubkey_clone:?}"));
 
     test::compile_time_assert_clone::<PublicKey>();
     test::compile_time_assert_send::<PublicKey>();

--- a/aws-lc-rs/src/agreement/ephemeral.rs
+++ b/aws-lc-rs/src/agreement/ephemeral.rs
@@ -347,7 +347,7 @@ mod tests {
         test::compile_time_assert_sync::<agreement::EphemeralPrivateKey>();
 
         assert_eq!(
-            format!("{:?}", &ephemeral_private_key),
+            format!("{ephemeral_private_key:?}"),
             "EphemeralPrivateKey { algorithm: Algorithm { curve: P256 } }"
         );
     }

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -866,7 +866,7 @@ mod tests {
                 let min_out_len = input_len + ((block_len - (next_total % block_len)) % block_len);
                 if input_len % block_len == 0 && step % block_len == 0 {
                     // When input is provided one block at a time, no additional space should be needed.
-                    assert!(input_len == min_out_len);
+                    assert_eq!(input_len, min_out_len);
                 }
                 let out_end = out_idx + min_out_len;
                 let result = key
@@ -893,7 +893,7 @@ mod tests {
                 let min_out_len = input_len + ((block_len - (next_total % block_len)) % block_len);
                 if input_len % block_len == 0 && step % block_len == 0 {
                     // When input is provided one block at a time, no additional space should be needed.
-                    assert!(input_len == min_out_len);
+                    assert_eq!(input_len, min_out_len);
                 }
                 let out_end = out_idx + min_out_len;
                 let result = key

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -1098,7 +1098,7 @@ mod tests {
     fn test_unparsed_public_key() {
         let random_pubkey: [u8; 32] = generate(&SystemRandom::new()).unwrap().expose();
         let unparsed_pubkey = UnparsedPublicKey::new(&ED25519, random_pubkey);
-        let unparsed_pubkey_debug = format!("{:?}", &unparsed_pubkey);
+        let unparsed_pubkey_debug = format!("{unparsed_pubkey:?}");
 
         #[allow(clippy::clone_on_copy)]
         let unparsed_pubkey_clone = unparsed_pubkey.clone();

--- a/aws-lc-rs/tests/hmac_test.rs
+++ b/aws-lc-rs/tests/hmac_test.rs
@@ -87,10 +87,10 @@ fn hmac_test_case_inner(
 #[test]
 fn hmac_debug() {
     let key = hmac::Key::new(hmac::HMAC_SHA256, &[0; 32]);
-    assert_eq!("Key { algorithm: SHA256 }", format!("{:?}", &key));
+    assert_eq!("Key { algorithm: SHA256 }", format!("{key:?}"));
 
     let ctx = hmac::Context::with_key(&key);
-    assert_eq!("Context { algorithm: SHA256 }", format!("{:?}", &ctx));
+    assert_eq!("Context { algorithm: SHA256 }", format!("{ctx:?}"));
 
     assert_eq!("Algorithm(SHA256)", format!("{:?}", hmac::HMAC_SHA256));
 }

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -807,18 +807,18 @@ round_trip_oaep_algorithm!(
 fn encrypting_keypair_debug() {
     let private_key = PrivateDecryptingKey::generate(KeySize::Rsa2048).expect("generation");
 
-    assert_eq!("PrivateDecryptingKey", format!("{:?}", &private_key));
+    assert_eq!("PrivateDecryptingKey", format!("{private_key:?}"));
 
     let public_key = private_key.public_key();
 
-    assert_eq!("PublicEncryptingKey", format!("{:?}", &public_key));
+    assert_eq!("PublicEncryptingKey", format!("{public_key:?}"));
 
     let oaep_private_key =
         OaepPrivateDecryptingKey::new(private_key.clone()).expect("oaep private key");
 
     assert_eq!(
         "OaepPrivateDecryptingKey { .. }",
-        format!("{:?}", &oaep_private_key)
+        format!("{oaep_private_key:?}")
     );
 
     let oaep_public_key =
@@ -826,7 +826,7 @@ fn encrypting_keypair_debug() {
 
     assert_eq!(
         "OaepPublicEncryptingKey { .. }",
-        format!("{:?}", &oaep_public_key)
+        format!("{oaep_public_key:?}")
     );
 
     let pkcs1_private_key =
@@ -834,7 +834,7 @@ fn encrypting_keypair_debug() {
 
     assert_eq!(
         "Pkcs1PrivateDecryptingKey { .. }",
-        format!("{:?}", &pkcs1_private_key)
+        format!("{pkcs1_private_key:?}")
     );
 
     let pkcs1_public_key =
@@ -842,7 +842,7 @@ fn encrypting_keypair_debug() {
 
     assert_eq!(
         "Pkcs1PublicEncryptingKey { .. }",
-        format!("{:?}", &pkcs1_public_key)
+        format!("{pkcs1_public_key:?}")
     );
 }
 

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -254,13 +254,13 @@ impl CcBuilder {
 
                     let flag = format!("-ffile-prefix-map={path_str}=");
                     if let Ok(true) = cc_build.is_flag_supported(&flag) {
-                        emit_warning(format!("Using flag: {}", &flag));
+                        emit_warning(format!("Using flag: {flag}"));
                         build_options.push(BuildOption::flag(&flag));
                     } else {
                         emit_warning("NOTICE: Build environment source paths might be visible in release binary.");
                         let flag = format!("-fdebug-prefix-map={path_str}=");
                         if let Ok(true) = cc_build.is_flag_supported(&flag) {
-                            emit_warning(format!("Using flag: {}", &flag));
+                            emit_warning(format!("Using flag: {flag}"));
                             build_options.push(BuildOption::flag(&flag));
                         }
                     }
@@ -678,7 +678,7 @@ impl CcBuilder {
         emit_warning(format!(
             "Compilation of '{basename}.c' {} - {:?}.",
             if ret_val { "succeeded" } else { "failed" },
-            &result
+            result
         ));
         ret_val
     }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -193,7 +193,7 @@ fn optional_env<N: AsRef<str>>(name: N) -> Option<String> {
     let name = name.as_ref();
     println!("cargo:rerun-if-env-changed={name}");
     if let Ok(value) = env::var(name) {
-        emit_warning(format!("Environment Variable found '{name}': '{}'", &value));
+        emit_warning(format!("Environment Variable found '{name}': '{value}'"));
         return Some(value);
     }
     None
@@ -252,7 +252,7 @@ fn parse_to_bool(env_var_value: &str) -> Option<bool> {
         || env_var_value.starts_with("off")
         || env_var_value.starts_with('f')
     {
-        emit_warning(format!("Value: {} is false.", &env_var_value));
+        emit_warning(format!("Value: {env_var_value} is false."));
         return Some(false);
     }
     if env_var_value.starts_with(|c: char| c.is_ascii_digit())
@@ -260,7 +260,7 @@ fn parse_to_bool(env_var_value: &str) -> Option<bool> {
         || env_var_value.starts_with("on")
         || env_var_value.starts_with('t')
     {
-        emit_warning(format!("Value: {} is true.", &env_var_value));
+        emit_warning(format!("Value: {env_var_value} is true."));
         return Some(true);
     }
     None
@@ -982,7 +982,7 @@ fn main() {
 
     let builder = get_builder(&prefix, &manifest_dir, &out_dir());
     emit_warning(format!("Building with: {}", builder.name()));
-    emit_warning(format!("Symbol Prefix: {:?}", &prefix));
+    emit_warning(format!("Symbol Prefix: {prefix:?}"));
 
     builder.check_dependencies().unwrap();
 
@@ -1026,7 +1026,7 @@ fn main() {
             emit_warning("###### WARNING: MISSING GIT SUBMODULE ######");
             emit_warning(format!(
                 "  -- Did you initialize the repo's git submodules? Unable to find crypto directory: {}.",
-                &aws_lc_crypto_dir.display()
+                aws_lc_crypto_dir.display()
             ));
             emit_warning("  -- run 'git submodule update --init --recursive' to initialize.");
             emit_warning("######");


### PR DESCRIPTION
### Description of changes:
Cleans up new clippy lints that appeared with recent nightly toolchain updates:
- Inline variables directly in format strings (`format!("{x}")` instead of `format!("{}", x)`)
- Remove redundant `&` borrows in format/assert macro arguments
- Replace `assert!(a == b)` with `assert_eq!(a, b)`

### Testing:
`make clippy` passes cleanly from the `aws-lc-rs` directory.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
