### PR TITLE
Adds `LessSafeKey::open_in_place_separate_tag`

### DIFF
--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -740,7 +740,9 @@ impl LessSafeKey {
     /// passed separately.
     ///
     /// `nonce` must be unique for every use of the key to open data.
-    ///
+    // # FIPS
+    // This method must not be used.
+    //
     /// # Errors
     /// `error::Unspecified` when ciphertext is invalid.
     #[inline]

--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -739,13 +739,19 @@ impl LessSafeKey {
     /// Like [`OpeningKey::open_in_place()`], except the authentication tag is
     /// passed separately.
     ///
+    /// `in_out` contains the ciphertext on input and is overwritten with the
+    /// plaintext on success. `tag` is the authentication tag, e.g. as produced
+    /// by [`Self::seal_in_place_separate_tag()`].
+    ///
     /// `nonce` must be unique for every use of the key to open data.
     // # FIPS
     // This method must not be used.
     //
     /// # Errors
-    /// `error::Unspecified` when ciphertext is invalid.
+    /// `error::Unspecified` when ciphertext is invalid. In this case, `in_out` may
+    /// have been overwritten in an unspecified way.
     #[inline]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn open_in_place_separate_tag<'in_out, A>(
         &self,
         nonce: Nonce,
@@ -757,7 +763,7 @@ impl LessSafeKey {
         A: AsRef<[u8]>,
     {
         self.key
-            .open_in_place_separate_tag(&nonce, aad.as_ref(), in_out, tag)?;
+            .open_in_place_separate_tag(&nonce, aad.as_ref(), tag, in_out)?;
         Ok(in_out)
     }
 
@@ -789,7 +795,7 @@ impl LessSafeKey {
             .open_within(nonce, aad.as_ref(), in_out, ciphertext_and_tag)
     }
 
-    /// Authenticates and decrypts (“opens”) data into another provided slice.
+    /// Authenticates and decrypts ("opens") data into another provided slice.
     ///
     /// `aad` is the additional authenticated data (AAD), if any.
     ///

--- a/aws-lc-rs/src/aead.rs
+++ b/aws-lc-rs/src/aead.rs
@@ -736,6 +736,29 @@ impl LessSafeKey {
         self.open_within(nonce, aad, in_out, 0..)
     }
 
+    /// Like [`OpeningKey::open_in_place()`], except the authentication tag is
+    /// passed separately.
+    ///
+    /// `nonce` must be unique for every use of the key to open data.
+    ///
+    /// # Errors
+    /// `error::Unspecified` when ciphertext is invalid.
+    #[inline]
+    pub fn open_in_place_separate_tag<'in_out, A>(
+        &self,
+        nonce: Nonce,
+        aad: Aad<A>,
+        tag: &[u8],
+        in_out: &'in_out mut [u8],
+    ) -> Result<&'in_out mut [u8], Unspecified>
+    where
+        A: AsRef<[u8]>,
+    {
+        self.key
+            .open_in_place_separate_tag(&nonce, aad.as_ref(), in_out, tag)?;
+        Ok(in_out)
+    }
+
     /// Like [`OpeningKey::open_within()`], except it accepts an arbitrary nonce.
     ///
     /// `nonce` must be unique for every use of the key to open data.

--- a/aws-lc-rs/src/aead/unbound_key.rs
+++ b/aws-lc-rs/src/aead/unbound_key.rs
@@ -88,16 +88,52 @@ impl UnboundKey {
         in_tag: &[u8],
         out_plaintext: &mut [u8],
     ) -> Result<(), Unspecified> {
-        self.check_per_nonce_max_bytes(in_ciphertext.len())?;
+        self.open_separate_gather_impl(
+            nonce,
+            aad,
+            in_ciphertext.as_ptr(),
+            in_ciphertext.len(),
+            in_tag,
+            out_plaintext.as_mut_ptr(),
+            out_plaintext.len(),
+        )
+    }
+
+    #[inline]
+    pub(crate) fn open_in_place_separate_tag(
+        &self,
+        nonce: &Nonce,
+        aad: &[u8],
+        in_out: &mut [u8],
+        in_tag: &[u8],
+    ) -> Result<(), Unspecified> {
+        self.open_separate_gather_impl(
+            nonce,
+            aad,
+            in_out.as_ptr(),
+            in_out.len(),
+            in_tag,
+            in_out.as_mut_ptr(),
+            in_out.len(),
+        )
+    }
+
+    #[inline]
+    fn open_separate_gather_impl(
+        &self,
+        nonce: &Nonce,
+        aad: &[u8],
+        in_ciphertext: *const u8,
+        in_ciphertext_len: usize,
+        in_tag: &[u8],
+        out_plaintext: *mut u8,
+        out_plaintext_len: usize,
+    ) -> Result<(), Unspecified> {
+        self.check_per_nonce_max_bytes(in_ciphertext_len)?;
 
         // ensure that the lengths match
-        {
-            let actual = in_ciphertext.len();
-            let expected = out_plaintext.len();
-
-            if actual != expected {
-                return Err(Unspecified);
-            }
+        if in_ciphertext_len != out_plaintext_len {
+            return Err(Unspecified);
         }
 
         unsafe {
@@ -106,11 +142,11 @@ impl UnboundKey {
 
             if 1 != EVP_AEAD_CTX_open_gather(
                 aead_ctx.as_const_ptr(),
-                out_plaintext.as_mut_ptr(),
+                out_plaintext,
                 nonce.as_ptr(),
                 nonce.len(),
-                in_ciphertext.as_ptr(),
-                in_ciphertext.len(),
+                in_ciphertext,
+                in_ciphertext_len,
                 in_tag.as_ptr(),
                 in_tag.len(),
                 aad.as_ptr(),

--- a/aws-lc-rs/src/aead/unbound_key.rs
+++ b/aws-lc-rs/src/aead/unbound_key.rs
@@ -104,21 +104,26 @@ impl UnboundKey {
         &self,
         nonce: &Nonce,
         aad: &[u8],
-        in_out: &mut [u8],
         in_tag: &[u8],
+        in_out: &mut [u8],
     ) -> Result<(), Unspecified> {
-        self.open_separate_gather_impl(
-            nonce,
-            aad,
-            in_out.as_ptr(),
-            in_out.len(),
-            in_tag,
-            in_out.as_mut_ptr(),
-            in_out.len(),
-        )
+        let ptr = in_out.as_mut_ptr();
+        let len = in_out.len();
+        self.open_separate_gather_impl(nonce, aad, ptr.cast_const(), len, in_tag, ptr, len)
     }
 
+    /// Common FFI path for `EVP_AEAD_CTX_open_gather`-based opening.
+    ///
+    /// `in_ciphertext` / `out_plaintext` may alias (exactly, i.e. same base
+    /// pointer and length). `EVP_AEAD_CTX_open_gather` explicitly permits
+    /// `out == in`, which is how `open_in_place_separate_tag` works.
+    ///
+    /// Callers must ensure:
+    /// * `in_ciphertext` is valid for reads of `in_ciphertext_len` bytes.
+    /// * `out_plaintext` is valid for writes of `out_plaintext_len` bytes.
+    /// * If the two pointers alias, they must alias exactly (same base, same length).
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn open_separate_gather_impl(
         &self,
         nonce: &Nonce,

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -606,16 +606,17 @@ fn test_aead_thread_safeness() {
     }
 }
 
-#[test]
-fn test_less_safe_key_open_in_place_separate_tag() {
-    let key_bytes = [0x42; 16];
+fn test_open_in_place_separate_tag_for(
+    algorithm: &'static aead::Algorithm,
+    key_bytes: &[u8],
+    plaintext: &[u8],
+) {
     let nonce_bytes = [0x24; NONCE_LEN];
     let aad = b"detached-tag";
-    let expected_plaintext = b"open detached tags in place";
 
-    let sealing_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
-    let opening_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
-    let mut in_out = expected_plaintext.to_vec();
+    let sealing_key = make_less_safe_key(algorithm, key_bytes);
+    let opening_key = make_less_safe_key(algorithm, key_bytes);
+    let mut in_out = plaintext.to_vec();
 
     let tag = sealing_key
         .seal_in_place_separate_tag(
@@ -625,7 +626,7 @@ fn test_less_safe_key_open_in_place_separate_tag() {
         )
         .unwrap();
 
-    let plaintext = opening_key
+    let result = opening_key
         .open_in_place_separate_tag(
             Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
             Aad::from(aad.as_slice()),
@@ -634,7 +635,55 @@ fn test_less_safe_key_open_in_place_separate_tag() {
         )
         .unwrap();
 
-    assert_eq!(expected_plaintext, plaintext);
+    assert_eq!(plaintext, result);
+}
+
+#[test]
+fn test_less_safe_key_open_in_place_separate_tag() {
+    let plaintext = b"open detached tags in place";
+
+    test_open_in_place_separate_tag_for(&aead::AES_128_GCM, &[0x42; 16], plaintext);
+    test_open_in_place_separate_tag_for(&aead::AES_256_GCM, &[0x42; 32], plaintext);
+    test_open_in_place_separate_tag_for(&aead::CHACHA20_POLY1305, &[0x42; 32], plaintext);
+}
+
+#[test]
+fn test_less_safe_key_open_in_place_separate_tag_empty_plaintext() {
+    test_open_in_place_separate_tag_for(&aead::AES_128_GCM, &[0x42; 16], b"");
+    test_open_in_place_separate_tag_for(&aead::AES_256_GCM, &[0x42; 32], b"");
+    test_open_in_place_separate_tag_for(&aead::CHACHA20_POLY1305, &[0x42; 32], b"");
+}
+
+#[test]
+fn test_less_safe_key_open_in_place_separate_tag_wrong_tag() {
+    let key_bytes = [0x42; 16];
+    let nonce_bytes = [0x24; NONCE_LEN];
+    let aad = b"detached-tag";
+    let plaintext = b"open detached tags in place";
+
+    let sealing_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
+    let opening_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
+    let mut in_out = plaintext.to_vec();
+
+    let tag = sealing_key
+        .seal_in_place_separate_tag(
+            Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
+            Aad::from(aad.as_slice()),
+            &mut in_out,
+        )
+        .unwrap();
+
+    let mut bad_tag = tag.as_ref().to_vec();
+    bad_tag[0] ^= 0xff;
+
+    let result = opening_key.open_in_place_separate_tag(
+        Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
+        Aad::from(aad.as_slice()),
+        &bad_tag,
+        &mut in_out,
+    );
+
+    assert!(result.is_err());
 }
 
 #[test]

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -607,6 +607,37 @@ fn test_aead_thread_safeness() {
 }
 
 #[test]
+fn test_less_safe_key_open_in_place_separate_tag() {
+    let key_bytes = [0x42; 16];
+    let nonce_bytes = [0x24; NONCE_LEN];
+    let aad = b"detached-tag";
+    let expected_plaintext = b"open detached tags in place";
+
+    let sealing_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
+    let opening_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
+    let mut in_out = expected_plaintext.to_vec();
+
+    let tag = sealing_key
+        .seal_in_place_separate_tag(
+            Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
+            Aad::from(aad.as_slice()),
+            &mut in_out,
+        )
+        .unwrap();
+
+    let plaintext = opening_key
+        .open_in_place_separate_tag(
+            Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
+            Aad::from(aad.as_slice()),
+            tag.as_ref(),
+            &mut in_out,
+        )
+        .unwrap();
+
+    assert_eq!(expected_plaintext, plaintext);
+}
+
+#[test]
 fn test_aead_key_debug() {
     let key_bytes = [0; 32];
     let nonce = [0; NONCE_LEN];

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -687,6 +687,35 @@ fn test_less_safe_key_open_in_place_separate_tag_wrong_tag() {
 }
 
 #[test]
+fn test_less_safe_key_open_in_place_separate_tag_wrong_aad() {
+    let key_bytes = [0x42; 16];
+    let nonce_bytes = [0x24; NONCE_LEN];
+    let aad = b"detached-tag";
+    let plaintext = b"open detached tags in place";
+
+    let sealing_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
+    let opening_key = make_less_safe_key(&aead::AES_128_GCM, &key_bytes);
+    let mut in_out = plaintext.to_vec();
+
+    let tag = sealing_key
+        .seal_in_place_separate_tag(
+            Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
+            Aad::from(aad.as_slice()),
+            &mut in_out,
+        )
+        .unwrap();
+
+    let result = opening_key.open_in_place_separate_tag(
+        Nonce::try_assume_unique_for_key(&nonce_bytes).unwrap(),
+        Aad::from(b"wrong-aad".as_slice()),
+        tag.as_ref(),
+        &mut in_out,
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_aead_key_debug() {
     let key_bytes = [0; 32];
     let nonce = [0; NONCE_LEN];


### PR DESCRIPTION
### Issues:
Resolves #1115

### Description of changes:
* impl `open_in_place_separate_tag` to allow for in-place + separate tags, limited to just `LessSafeKey` for now.

### Call-outs:

### Testing:
* passed `cargo check` and `cargo test -p aws-lc-rs --test aead_test` + `cargo clippy`
* benchmark details:

Sample results using a M4 Mac + a thrown together benchmark harness. But I am happy to incorperate this change into a larger bench suite if needed for the PR.
```
open_separate_gather + copy back   17.488ms     3659.6 MiB/s
open_in_place_separate_tag        10.870ms     5887.8 MiB/s
```

```rust
const PLAINTEXT_LEN: usize = 128 * 1024;

// <snip>

fn benchmark_separate_output(key: &LessSafeKey, samples: &[Sample]) -> Duration {
    let mut in_out = vec![0u8; PLAINTEXT_LEN];
    let mut temporary_plaintext = vec![0u8; PLAINTEXT_LEN];
    let start = Instant::now();

    for sample in samples {
        in_out.copy_from_slice(&sample.ciphertext);
        key.open_separate_gather(
            Nonce::try_assume_unique_for_key(&sample.nonce).unwrap(),
            Aad::from(AAD),
            &in_out,
            &sample.tag,
            &mut temporary_plaintext,
        )
        .unwrap();
        in_out.copy_from_slice(&temporary_plaintext);
        black_box(in_out[0]);
    }

    start.elapsed()
}

fn benchmark_in_place(key: &LessSafeKey, samples: &[Sample]) -> Duration {
    let mut in_out = vec![0u8; PLAINTEXT_LEN];
    let start = Instant::now();

    for sample in samples {
        in_out.copy_from_slice(&sample.ciphertext);
        key.open_in_place_separate_tag(
            Nonce::try_assume_unique_for_key(&sample.nonce).unwrap(),
            Aad::from(AAD),
            &sample.tag,
            &mut in_out,
        )
        .unwrap();
        black_box(in_out[0]);
    }

    start.elapsed()
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.