### PR TITLE
Reduce AEAD and RSA test iterations under DISABLE_SLOW_TESTS

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -239,7 +239,7 @@ jobs:
     name: cross v0.2.5 tests ${{ matrix.target }}
     runs-on: ubuntu-latest
     env:
-      CROSS_CONFIG: "./Cross.toml.x86_64-unknown-linux-gnu"
+      CROSS_CONFIG: "./Cross.toml.passthrough-only"
     strategy:
       fail-fast: false
       matrix:

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -187,17 +187,22 @@ fn test_aead<Seal, Open>(
 
         // In release builds, test all prefix lengths from 0 to 4096 bytes.
         // Debug builds are too slow for this, so for those builds, only
-        // test a smaller subset.
+        // test a smaller subset.  Under `disable_slow_tests` (primarily the
+        // MSan CI job), shrink further to a handful of alignment-sensitive
+        // offsets -- this dominates the inner-loop cost and is the primary
+        // lever for keeping MSan runtime under the CI timeout.
 
         let more_comprehensive_in_prefix_lengths: Box<[usize]> = (1..4096).collect();
-        let in_prefix_lengths = if cfg!(any(debug_assertions, disable_slow_tests)) {
+        let in_prefix_lengths: &[usize] = if cfg!(disable_slow_tests) {
+            &[0, 1, 16, 17]
+        } else if cfg!(debug_assertions) {
             &MINIMAL_IN_PREFIX_LENS[..]
         } else {
             &more_comprehensive_in_prefix_lengths[..]
         };
         let mut o_in_out = vec![123u8; 4096];
 
-        for &in_prefix_len in in_prefix_lengths {
+        for (idx, &in_prefix_len) in in_prefix_lengths.iter().enumerate() {
             o_in_out.clear();
             o_in_out.resize(in_prefix_len, 123);
             o_in_out.extend_from_slice(&ct[..]);
@@ -219,16 +224,23 @@ fn test_aead<Seal, Open>(
                     let result = o_result.unwrap();
                     assert_eq!(&plaintext[..], result);
 
-                    for bad_func in [aead_open_bad_tag, aead_open_bad_nonce, aead_open_bad_aad] {
-                        bad_func(
-                            aead_alg,
-                            &key_bytes,
-                            &nonce_bytes,
-                            aad.as_slice(),
-                            &o_in_out_clone,
-                            in_prefix_len,
-                            &open,
-                        );
+                    // The `bad_func` checks verify that corrupted tag / nonce /
+                    // AAD all cause `open` to fail. That failure path is
+                    // independent of `in_prefix_len`, so running them once per
+                    // test vector is sufficient.
+                    if idx == 0 {
+                        for bad_func in [aead_open_bad_tag, aead_open_bad_nonce, aead_open_bad_aad]
+                        {
+                            bad_func(
+                                aead_alg,
+                                &key_bytes,
+                                &nonce_bytes,
+                                aad.as_slice(),
+                                &o_in_out_clone,
+                                in_prefix_len,
+                                &open,
+                            );
+                        }
                     }
                 }
                 Some(ref error) if error == "WRONG_NONCE_LENGTH" => {

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -17,6 +17,7 @@ use aws_lc_rs::signature::{
 };
 use aws_lc_rs::test::to_hex_upper;
 use aws_lc_rs::{digest, rand, signature, test, test_file};
+use std::collections::HashSet;
 
 #[test]
 fn rsa_traits() {
@@ -60,6 +61,11 @@ fn rsa_from_pkcs8_test() {
 #[test]
 fn test_signature_rsa_pkcs1_sign() {
     let rng = rand::SystemRandom::new();
+    // Under `disable_slow_tests`, one representative vector per digest is
+    // enough to exercise the signing path for MSan.  The `Fail-Invalid-Key`
+    // early-return above still runs on every vector, so input-validation
+    // coverage is preserved.
+    let mut signed_digests = HashSet::new();
     test::run(
         test_file!("data/rsa_pkcs1_sign_tests.txt"),
         |section, test_case| {
@@ -93,6 +99,9 @@ fn test_signature_rsa_pkcs1_sign() {
             let key_pair = RsaKeyPair::from_der(&private_key);
             if result == "Fail-Invalid-Key" {
                 assert!(key_pair.is_err(), "{}", &debug_msg);
+                return Ok(());
+            }
+            if cfg!(disable_slow_tests) && !signed_digests.insert(digest_name) {
                 return Ok(());
             }
             let key_pair = key_pair.expect(&debug_msg);
@@ -146,6 +155,9 @@ fn test_signature_rsa_pkcs1_sign() {
 
 #[test]
 fn test_signature_rsa_pss_sign() {
+    // Under `disable_slow_tests`, one representative vector per digest is
+    // enough to exercise the signing path for MSan.
+    let mut signed_digests = HashSet::new();
     test::run(
         test_file!("data/rsa_pss_sign_tests.txt"),
         |section, test_case| {
@@ -177,10 +189,13 @@ fn test_signature_rsa_pss_sign() {
             if key_pair.is_err() && result == "Fail-Invalid-Key" {
                 return Ok(());
             }
+            let msg = test_case.consume_bytes("Msg");
+            if cfg!(disable_slow_tests) && !signed_digests.insert(digest_name) {
+                return Ok(());
+            }
             let key_pair = key_pair.unwrap();
             let public_key = key_pair.public_key();
             let rng = SystemRandom::new();
-            let msg = test_case.consume_bytes("Msg");
 
             {
                 let upk = UnparsedPublicKey::new(verification_alg, public_key.as_ref());


### PR DESCRIPTION
### Description of changes:

The MSan CI (`aws-lc-rs msan`) and `cross v0.2.5 tests aarch64-unknown-linux-gnu` jobs are regularly exceeding 30 minutes. `AWS_LC_RS_DISABLE_SLOW_TESTS=1` was already wired into the build but wasn't reducing the iteration count enough on its own.

Three changes:

- **AEAD tests** — two reductions. (1) Unconditional: the `bad_tag`/`bad_nonce`/`bad_aad` checks now run once per test vector instead of once per `in_prefix_len`, since those failure paths don't depend on prefix length. (2) Under `disable_slow_tests`: shrink `in_prefix_lengths` from 36 entries to `{0, 1, 16, 17}`. This is by far the fattest axis of the inner loop, and the four offsets cover the alignment cases MSan actually cares about (in-place, byte-misaligned, AES block boundary, and one past).

- **RSA sign tests** — under `disable_slow_tests`, exercise one representative vector per digest via a `HashSet<String>`. DER parsing and the `Fail-Invalid-Key` early-return still run on every vector, so input-validation coverage is preserved; only the expensive signing path is sampled. Stable under test-file reordering.

- **`cross.yml`** — the cross v0.2.5 job referenced `Cross.toml.x86_64-unknown-linux-gnu`, a file that was deleted in #852. Repoint it at `Cross.toml.passthrough-only` (which is what the sibling `aws-lc-rs-cross-prebuilt-nasm` job already uses).

### Call-outs:

The `bad_func` hoist is unconditional, not gated on `disable_slow_tests`. It's a pure redundancy removal — the three failure paths don't read `in_prefix_len`, so running them 36 times per vector was giving us no additional coverage for the same inputs. Faster non-MSan CI jobs as a side benefit.

### Testing:

Covered by the existing CI suite. The MSan job is the primary target; the non-sampling CI jobs continue to exercise every test vector and the full 36-entry prefix-length set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.