### PR TITLE
fix: support building with MinGW on Windows 7

### DIFF
--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -412,14 +412,24 @@ impl CcBuilder {
                 "_STL_EXTRA_DISABLED_WARNINGS",
                 "4774 4987",
             ));
+        }
 
-            if target().ends_with("-win7-windows-msvc") {
-                // 0x0601 is the value of `_WIN32_WINNT_WIN7`
-                build_options.push(BuildOption::define("_WIN32_WINNT", "0x0601"));
-                emit_warning(format!(
-                    "Setting _WIN32_WINNT to _WIN32_WINNT_WIN7 for {} target",
-                    target()
-                ));
+        // Target Windows 7 (0x0601 == _WIN32_WINNT_WIN7) for any win7 target triple.
+        if target().contains("-win7-windows-") {
+            build_options.push(BuildOption::define("_WIN32_WINNT", "0x0601"));
+            emit_warning(format!(
+                "Setting _WIN32_WINNT to _WIN32_WINNT_WIN7 for {} target",
+                target()
+            ));
+
+            // Additional workaround for MinGW: the upstream C source
+            // (crypto/rand_extra/windows.c) gates the Win7 compat path
+            // (BCryptGenRandom) with `!defined(__MINGW32__)`, which prevents MinGW
+            // from using it even when `_WIN32_WINNT` targets Win7. We define
+            // AWSLC_WINDOWS_7_COMPAT directly to bypass that guard until the
+            // upstream fix lands: https://github.com/aws/aws-lc/pull/3239
+            if !is_like_msvc {
+                build_options.push(BuildOption::define("AWSLC_WINDOWS_7_COMPAT", ""));
             }
         }
     }

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -7,7 +7,7 @@ use crate::{
     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
     get_crate_cflags, is_crt_static, is_fips_build, is_no_asm, is_no_pregenerated_src,
     optional_env, optional_env_optional_crate_target, sanitizer, set_env, set_env_for_target,
-    should_build_jitter_entropy, target_arch, target_env, target_os, test_clang_cl_command,
+    should_build_jitter_entropy, target, target_arch, target_env, target_os, test_clang_cl_command,
     test_nasm_command, use_prebuilt_nasm, OutputLibType,
 };
 use std::collections::HashMap;
@@ -402,6 +402,14 @@ impl CmakeBuilder {
                 cmake_cfg.define("CMAKE_SYSTEM_NAME", "Windows");
                 cmake_cfg.define("CMAKE_SYSTEM_PROCESSOR", arch);
             }
+        }
+
+        // Workaround for win7-windows-gnu targets: the upstream C source gates the
+        // Win7 compat path with `!defined(__MINGW32__)`. CMakeLists.txt already sets
+        // _WIN32_WINNT for MinGW, but we must force AWSLC_WINDOWS_7_COMPAT until the
+        // upstream fix lands: https://github.com/aws/aws-lc/pull/3239
+        if target().contains("-win7-windows-gnu") {
+            cmake_cfg.cflag("-DAWSLC_WINDOWS_7_COMPAT");
         }
     }
 

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -1066,6 +1066,14 @@ fn main() {
     );
     builder.build().unwrap();
 
+    // MinGW win7 targets use the BCryptGenRandom path (AWSLC_WINDOWS_7_COMPAT),
+    // which requires linking against bcrypt. MinGW ignores the MSVC
+    // `#pragma comment(lib, "bcrypt.lib")` in the source, so we link explicitly.
+    // See: https://github.com/aws/aws-lc/pull/3239
+    if target().contains("-win7-windows-gnu") {
+        println!("cargo:rustc-link-lib=bcrypt");
+    }
+
     println!(
         "cargo:include={}",
         setup_include_paths(&out_dir(), &manifest_dir).display()


### PR DESCRIPTION
### Issues:
Addresses: 
* #1111

### Description of changes:

Enable `x86_64-win7-windows-gnu` (and similar win7 MinGW triples) to build and run on Windows 7 by routing `CRYPTO_sysrand` through `BCryptGenRandom` instead of `ProcessPrng`.

The upstream C source (`crypto/rand_extra/windows.c`) guards the Win7-compatible code path with `!defined(__MINGW32__)`, so MinGW builds always take the `ProcessPrng` path — which aborts on Windows 7 because that API only exists on Windows 8+. This change works around the guard by defining `AWSLC_WINDOWS_7_COMPAT` directly from the build script for win7-gnu targets, and explicitly links `bcrypt` (since MinGW ignores the MSVC `#pragma comment(lib, ...)` in the source).

### Call-outs:

This is a temporary workaround. The proper fix is https://github.com/aws/aws-lc/pull/3239, which drops the `!defined(__MINGW32__)` guard upstream. Once that merges and we bump the submodule, the `AWSLC_WINDOWS_7_COMPAT` define can be removed. The `_WIN32_WINNT` and `bcrypt` link will still be needed for the CC builder path.

The existing win7-msvc handling was refactored into the same `if target().contains("-win7-windows-")` block so both toolchains share the `_WIN32_WINNT=0x0601` define in one place.

### Testing:

Build-tested with `cargo check -p aws-lc-sys`. Full validation requires a MinGW cross-compile targeting `x86_64-win7-windows-gnu`, which will be exercised once the upstream fix and a CI job are in place.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
