### PR TITLE
Add single DES support and rename legacy-3des feature to legacy-des

### DIFF
--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -37,8 +37,8 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
         args:
           - --release --all-targets --features fips,unstable
-          - --release --all-targets --features fips,unstable,legacy-3des
-          - --release --all-targets --features fips,legacy-3des
+          - --release --all-targets --features fips,unstable,legacy-des
+          - --release --all-targets --features fips,legacy-des
           - --profile release-lto --all-targets --features fips,unstable
           - --no-default-features --features fips,unstable
           - --no-default-features --features fips,ring-io,unstable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest, ubuntu-24.04-arm ]
         args:
           - --all-targets --features unstable
-          - --all-targets --features unstable,legacy-3des
-          - --all-targets --features legacy-3des
+          - --all-targets --features unstable,legacy-des
+          - --all-targets --features legacy-des
           - --release --all-targets --features unstable
           - --no-default-features --features non-fips,unstable
           - --no-default-features --features non-fips,ring-io,unstable

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "aws_lc_rs_docsrs"]
-features = ["unstable", "legacy-3des"]
+features = ["unstable", "legacy-des"]
 
 [features]
 alloc = []
@@ -39,7 +39,7 @@ test_logging = []
 unstable = []
 prebuilt-nasm = ["aws-lc-sys?/prebuilt-nasm"]
 dev-tests-only = []
-legacy-3des = ["aws-lc-sys?/all-bindings"]
+legacy-des = ["aws-lc-sys?/all-bindings"]
 
 # require non-FIPS
 non-fips = ["aws-lc-sys"]

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -124,7 +124,7 @@ It can be enabled in two ways:
 used in production builds. The `rand::unsealed` module and `mut_fill` method are not part of the
 stable public API and may change without notice.
 
-##### legacy-3des
+##### legacy-des
 
 Enables Triple DES as an opt-in symmetric cipher under the `cipher` module, exposing
 both `DES_EDE_FOR_LEGACY_USE_ONLY` (2-key Triple DES / DES-EDE) and

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -126,25 +126,35 @@ stable public API and may change without notice.
 
 ##### legacy-des
 
-Enables Triple DES as an opt-in symmetric cipher under the `cipher` module, exposing
-both `DES_EDE_FOR_LEGACY_USE_ONLY` (2-key Triple DES / DES-EDE) and
+Enables single DES and Triple DES as opt-in symmetric ciphers under the `cipher`
+module, exposing `DES_FOR_LEGACY_USE_ONLY` (single DES),
+`DES_EDE_FOR_LEGACY_USE_ONLY` (2-key Triple DES / DES-EDE) and
 `DES_EDE3_FOR_LEGACY_USE_ONLY` (3-key Triple DES / DES-EDE3), together with the
 supporting key-length and IV-length constants. Only CBC and ECB operating modes are
 supported.
 
-**⚠️ Warning:** Triple DES is a legacy algorithm. It has been disallowed for
-encryption by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
+**⚠️ Warning:** Single DES and Triple DES are legacy algorithms. Single DES
+provides only 56 bits of effective security and has been considered insecure for
+decades. Triple DES has been disallowed for encryption by
+[NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
 2-key Triple DES after 2015, and 3-key Triple DES after 2023. This feature exists
 solely to support interoperability. All exposed items are marked `#[deprecated]`
-so that any use site produces a compiler warning. **Do not use Triple DES in new
-designs.** If you only need confidentiality, prefer AES-GCM or another AEAD from
-the `aead` module; if you specifically need a block cipher, prefer one of the AES
-algorithms in `cipher`.
+so that any use site produces a compiler warning. **Do not use single DES or Triple
+DES in new designs.** If you only need confidentiality, prefer AES-GCM or another
+AEAD from the `aead` module; if you specifically need a block cipher, prefer one
+of the AES algorithms in `cipher`.
 
-The universal bindings used by default from `aws-lc-sys` do not expose the `DES_*` symbols. Thus,
-this feature enables `aws-lc-sys?/all-bindings` so that bindings are available for all AWS-LC
-libcrypto functions. On platforms where pre-generated bindings are unavailable, `bindgen` is
-invoked at build time and the generated bindings will include the full symbol set.
+**Build-time impact:** The default `aws-lc-sys` bindings do not expose the low-level `DES_*`
+symbols this feature relies on, so enabling `legacy-des` also enables `aws-lc-sys?/all-bindings`.
+Concretely:
+
+* On platforms with pre-generated per-target bindings, the build switches from the universal
+  bindings to the per-target bindings (no extra tooling required).
+* On platforms *without* pre-generated bindings for the selected target, `bindgen` is invoked at
+  build time, which requires `libclang` to be installed in the build environment.
+
+Because [features are additive](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification),
+enabling `legacy-des` anywhere in your dependency graph applies the above to the entire build.
 
 ## Use of prebuilt NASM objects
 

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -163,10 +163,15 @@ fn cipher_new_mask(
             let counter = u32::from_ne_bytes(*counter_bytes).to_le();
             encrypt_block_chacha20(raw_key, input, nonce, counter)?
         }
+        // DES variants cannot reach this branch: `Algorithm::init` is private
+        // and only the AES_128/AES_256/CHACHA20 consts populate it, so a
+        // `HeaderProtectionKey` can never be constructed with a DES
+        // `SymmetricCipherKey`. The arm exists only to satisfy match
+        // exhaustiveness when the `legacy-des` feature is enabled.
         #[cfg(feature = "legacy-des")]
         SymmetricCipherKey::Des { .. }
         | SymmetricCipherKey::DesEde { .. }
-        | SymmetricCipherKey::DesEde3 { .. } => return Err(error::Unspecified),
+        | SymmetricCipherKey::DesEde3 { .. } => unreachable!(),
     };
 
     let mut out: [u8; 5] = [0; 5];

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -171,7 +171,9 @@ fn cipher_new_mask(
         #[cfg(feature = "legacy-des")]
         SymmetricCipherKey::Des { .. }
         | SymmetricCipherKey::DesEde { .. }
-        | SymmetricCipherKey::DesEde3 { .. } => unreachable!(),
+        | SymmetricCipherKey::DesEde3 { .. } => {
+            unreachable!("DES cipher keys cannot be used with QUIC header protection")
+        }
     };
 
     let mut out: [u8; 5] = [0; 5];

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -164,9 +164,9 @@ fn cipher_new_mask(
             encrypt_block_chacha20(raw_key, input, nonce, counter)?
         }
         #[cfg(feature = "legacy-3des")]
-        SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
-            return Err(error::Unspecified)
-        }
+        SymmetricCipherKey::Des { .. }
+        | SymmetricCipherKey::DesEde { .. }
+        | SymmetricCipherKey::DesEde3 { .. } => return Err(error::Unspecified),
     };
 
     let mut out: [u8; 5] = [0; 5];

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -163,7 +163,7 @@ fn cipher_new_mask(
             let counter = u32::from_ne_bytes(*counter_bytes).to_le();
             encrypt_block_chacha20(raw_key, input, nonce, counter)?
         }
-        #[cfg(feature = "legacy-3des")]
+        #[cfg(feature = "legacy-des")]
         SymmetricCipherKey::Des { .. }
         | SymmetricCipherKey::DesEde { .. }
         | SymmetricCipherKey::DesEde3 { .. } => return Err(error::Unspecified),

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -198,6 +198,16 @@
 //! # }
 //! ```
 //!
+//! ## Feature flags
+//!
+//! ### `legacy-des`
+//!
+//! Enables single DES and Triple DES (`DES_FOR_LEGACY_USE_ONLY`,
+//! `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`) for legacy
+//! interoperability. Only CBC and ECB modes are supported. All exposed items
+//! are `#[deprecated]`. See the crate-level [feature flag
+//! documentation](crate#legacy-des) for details and security caveats.
+//!
 //! ## Getting an immutable reference to the IV slice.
 //!
 //! `TryFrom<&DecryptionContext>` is implemented for `&[u8]` allowing immutable references
@@ -303,14 +313,14 @@ pub use crate::cipher::aes::AES_CTR_IV_LEN;
 /// The number of bytes for an AES-CFB initialization vector (IV)
 pub use crate::cipher::aes::AES_CFB_IV_LEN;
 
-/// The number of bytes for a DES-CBC initialization vector (IV).
+/// The number of bytes for a DES/3DES-CBC initialization vector (IV).
 ///
-/// DES is a legacy algorithm and has been disallowed for encryption by
-/// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
+/// DES and 3DES are legacy algorithms and have been disallowed for encryption by
+/// NIST SP 800-131A Rev. 2 after 2023. They are retained for interoperability only.
 #[cfg(feature = "legacy-des")]
 #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[deprecated(
-    note = "DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+    note = "DES/3DES are legacy algorithms retained for interoperability only; NIST SP 800-131A Rev. 2 disallows their use for encryption. Prefer an AES-based algorithm."
 )]
 pub use crate::cipher::des::DES_CBC_IV_LEN;
 
@@ -401,7 +411,11 @@ macro_rules! define_cipher_context {
             /// A 128-bit Initialization Vector.
             Iv128(FixedLength<IV_LEN_128_BIT>),
 
-            /// A 64-bit Initialization Vector (used by 3DES).
+            /// A 64-bit Initialization Vector.
+            ///
+            /// Used by DES and 3DES in CBC mode only. ECB mode uses
+            /// [`Self::None`] regardless of the cipher's block size, and
+            /// no other cipher in this crate produces or consumes a 64-bit IV.
             #[cfg(feature = "legacy-des")]
             #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
             Iv64(FixedLength<IV_LEN_64_BIT>),
@@ -594,6 +608,36 @@ pub const DES_EDE_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 /// Callers who specifically need 2-key Triple DES (2TDEA) must use
 /// [`DES_EDE_FOR_LEGACY_USE_ONLY`] (16-byte key) rather than encoding 2TDEA
 /// as a 24-byte `K1 ‖ K2 ‖ K1` key here.
+///
+/// # Example: 3DES-CBC interop round-trip
+///
+/// ```rust
+/// # #[cfg(feature = "legacy-des")]
+/// # #[allow(deprecated)]
+/// # fn main() -> Result<(), aws_lc_rs::error::Unspecified> {
+/// use aws_lc_rs::cipher::{
+///     DecryptingKey, EncryptingKey, UnboundCipherKey, DES_EDE3_FOR_LEGACY_USE_ONLY,
+/// };
+///
+/// let key_bytes: [u8; 24] = [
+///     0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+///     0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01,
+///     0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23,
+/// ];
+/// let plaintext = *b"8-byte..16-byte.";
+///
+/// let key = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes)?;
+/// let mut buf = plaintext.to_vec();
+/// let ctx = EncryptingKey::cbc(key)?.encrypt(&mut buf)?;
+///
+/// let key = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes)?;
+/// let recovered = DecryptingKey::cbc(key)?.decrypt(&mut buf, ctx)?;
+/// assert_eq!(&plaintext[..], recovered);
+/// # Ok(())
+/// # }
+/// # #[cfg(not(feature = "legacy-des"))]
+/// # fn main() {}
+/// ```
 #[cfg(feature = "legacy-des")]
 #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[allow(deprecated)]
@@ -843,8 +887,8 @@ impl EncryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
-    ///   support CTR mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
-    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    ///   support CTR mode (e.g. `DES_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CTR)
     }
@@ -859,8 +903,8 @@ impl EncryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
-    ///   support CFB128 mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
-    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    ///   support CFB128 mode (e.g. `DES_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128)
     }
@@ -876,16 +920,17 @@ impl EncryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
-    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
-    // FIPS-approved.
+    // `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` and
+    // `DES_EDE3_FOR_LEGACY_USE_ONLY` are never FIPS-approved.
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn cbc(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC)
     }
@@ -901,16 +946,17 @@ impl EncryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
-    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
-    // FIPS-approved.
+    // `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` and
+    // `DES_EDE3_FOR_LEGACY_USE_ONLY` are never FIPS-approved.
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB)
     }
@@ -1009,8 +1055,8 @@ impl DecryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
     ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
-    ///   support CTR mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
-    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    ///   support CTR mode (e.g. `DES_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
         Self::new(key, OperatingMode::CTR)
     }
@@ -1025,8 +1071,8 @@ impl DecryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
     ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
-    ///   support CFB128 mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
-    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    ///   support CFB128 mode (e.g. `DES_FOR_LEGACY_USE_ONLY`,
+    ///   `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128)
     }
@@ -1042,16 +1088,17 @@ impl DecryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
-    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
-    // FIPS-approved.
+    // `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` and
+    // `DES_EDE3_FOR_LEGACY_USE_ONLY` are never FIPS-approved.
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn cbc(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
         Self::new(key, OperatingMode::CBC)
     }
@@ -1067,16 +1114,17 @@ impl DecryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
-    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
-    // FIPS-approved.
+    // `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` and
+    // `DES_EDE3_FOR_LEGACY_USE_ONLY` are never FIPS-approved.
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `DecryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB)
     }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -221,7 +221,7 @@
 pub(crate) mod aes;
 pub(crate) mod block;
 pub(crate) mod chacha;
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 pub(crate) mod des;
 pub(crate) mod key;
 mod padded;
@@ -235,7 +235,7 @@ use crate::aws_lc::{
     EVP_aes_192_cfb128, EVP_aes_192_ctr, EVP_aes_192_ecb, EVP_aes_256_cbc, EVP_aes_256_cfb128,
     EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
 };
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 use crate::aws_lc::{
     EVP_des_cbc, EVP_des_ecb, EVP_des_ede, EVP_des_ede3_cbc, EVP_des_ede3_ecb, EVP_des_ede_cbc,
 };
@@ -243,7 +243,7 @@ use crate::buffer::Buffer;
 use crate::error::{KeyRejected, Unspecified};
 use crate::hkdf;
 use crate::hkdf::KeyType;
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 use crate::iv::IV_LEN_64_BIT;
 use crate::iv::{FixedLength, IV_LEN_128_BIT};
 use crate::ptr::ConstPointer;
@@ -263,8 +263,8 @@ pub use crate::cipher::aes::AES_256_KEY_LEN;
 ///
 /// Single DES provides only 56 bits of effective security and is retained
 /// for interoperability only.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[deprecated(
     note = "Single DES is a legacy algorithm retained for interoperability only. Prefer an AES-based algorithm."
 )]
@@ -274,8 +274,8 @@ pub use crate::cipher::des::DES_KEY_LEN;
 ///
 /// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
 /// by NIST SP 800-131A Rev. 2 since 2015. It is retained for interoperability only.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[deprecated(
     note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
@@ -285,8 +285,8 @@ pub use crate::cipher::des::DES_EDE_KEY_LEN;
 ///
 /// 3DES is a legacy algorithm and has been disallowed for encryption by
 /// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[deprecated(
     note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
@@ -307,15 +307,15 @@ pub use crate::cipher::aes::AES_CFB_IV_LEN;
 ///
 /// DES is a legacy algorithm and has been disallowed for encryption by
 /// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[deprecated(
     note = "DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
 pub use crate::cipher::des::DES_CBC_IV_LEN;
 
 use crate::cipher::aes::AES_BLOCK_LEN;
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 use crate::cipher::des::DES_BLOCK_LEN;
 
 const MAX_CIPHER_BLOCK_LEN: usize = AES_BLOCK_LEN;
@@ -352,31 +352,31 @@ impl OperatingMode {
             (OperatingMode::CTR, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ctr() },
             (OperatingMode::CFB128, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cfb128() },
             (OperatingMode::ECB, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ecb() },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::CBC, AlgorithmId::DesForLegacyUseOnly) => unsafe { EVP_des_cbc() },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::ECB, AlgorithmId::DesForLegacyUseOnly) => unsafe { EVP_des_ecb() },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::CBC, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe {
                 EVP_des_ede_cbc()
             },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::ECB, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe { EVP_des_ede() },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::CBC, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
                 EVP_des_ede3_cbc()
             },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::ECB, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
                 EVP_des_ede3_ecb()
             },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             (OperatingMode::CTR, AlgorithmId::DesForLegacyUseOnly)
             | (OperatingMode::CTR, AlgorithmId::DesEdeForLegacyUseOnly)
@@ -402,8 +402,8 @@ macro_rules! define_cipher_context {
             Iv128(FixedLength<IV_LEN_128_BIT>),
 
             /// A 64-bit Initialization Vector (used by 3DES).
-            #[cfg(feature = "legacy-3des")]
-            #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+            #[cfg(feature = "legacy-des")]
+            #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
             Iv64(FixedLength<IV_LEN_64_BIT>),
 
             /// No Cipher Context
@@ -416,7 +416,7 @@ macro_rules! define_cipher_context {
             fn try_from(value: &'a $name) -> Result<Self, Unspecified> {
                 match value {
                     $name::Iv128(iv) => Ok(iv.as_ref()),
-                    #[cfg(feature = "legacy-3des")]
+                    #[cfg(feature = "legacy-des")]
                     $name::Iv64(iv) => Ok(iv.as_ref()),
                     _ => Err(Unspecified),
                 }
@@ -427,7 +427,7 @@ macro_rules! define_cipher_context {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
                     Self::Iv128(_) => write!(f, "Iv128"),
-                    #[cfg(feature = "legacy-3des")]
+                    #[cfg(feature = "legacy-des")]
                     Self::Iv64(_) => write!(f, "Iv64"),
                     Self::None => write!(f, "None"),
                 }
@@ -438,7 +438,7 @@ macro_rules! define_cipher_context {
             fn from(value: $other) -> Self {
                 match value {
                     $other::Iv128(iv) => $name::Iv128(iv),
-                    #[cfg(feature = "legacy-3des")]
+                    #[cfg(feature = "legacy-des")]
                     $other::Iv64(iv) => $name::Iv64(iv),
                     $other::None => $name::None,
                 }
@@ -467,8 +467,8 @@ pub enum AlgorithmId {
     ///
     /// Single DES provides only 56 bits of effective security and has been
     /// considered insecure for decades.
-    #[cfg(feature = "legacy-3des")]
-    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+    #[cfg(feature = "legacy-des")]
+    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
     #[deprecated(
         note = "Single DES is a legacy algorithm retained for interoperability only. Prefer an AES-based algorithm."
     )]
@@ -478,8 +478,8 @@ pub enum AlgorithmId {
     ///
     /// 2-key Triple DES has been disallowed for encryption by
     /// NIST SP 800-131A Rev. 2 since 2015.
-    #[cfg(feature = "legacy-3des")]
-    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+    #[cfg(feature = "legacy-des")]
+    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
     #[deprecated(
         note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
     )]
@@ -489,8 +489,8 @@ pub enum AlgorithmId {
     ///
     /// 3DES has been disallowed for encryption by NIST SP 800-131A Rev. 2
     /// after 2023.
-    #[cfg(feature = "legacy-3des")]
-    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+    #[cfg(feature = "legacy-des")]
+    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
     #[deprecated(
         note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
     )]
@@ -535,8 +535,8 @@ pub const AES_256: Algorithm = Algorithm {
 ///
 /// Only CBC and ECB operating modes are supported. Weak and semi-weak DES
 /// keys are rejected.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[allow(deprecated)]
 #[deprecated(
     note = "Single DES is a legacy algorithm retained for interoperability only. Prefer an AES-based algorithm."
@@ -562,8 +562,8 @@ pub const DES_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 /// [`UnboundCipherKey`] is passed to an [`EncryptingKey`], [`DecryptingKey`],
 /// [`PaddedBlockEncryptingKey`], [`PaddedBlockDecryptingKey`],
 /// [`StreamingEncryptingKey`], or [`StreamingDecryptingKey`] constructor.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[allow(deprecated)]
 #[deprecated(
     note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
@@ -594,8 +594,8 @@ pub const DES_EDE_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
 /// Callers who specifically need 2-key Triple DES (2TDEA) must use
 /// [`DES_EDE_FOR_LEGACY_USE_ONLY`] (16-byte key) rather than encoding 2TDEA
 /// as a 24-byte `K1 ‖ K2 ‖ K1` key here.
-#[cfg(feature = "legacy-3des")]
-#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[cfg(feature = "legacy-des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-des")))]
 #[allow(deprecated)]
 #[deprecated(
     note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
@@ -629,7 +629,7 @@ impl Algorithm {
                 }
                 OperatingMode::ECB => Ok(EncryptionContext::None),
             },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -652,7 +652,7 @@ impl Algorithm {
                     matches!(input, EncryptionContext::None)
                 }
             },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -675,7 +675,7 @@ impl Algorithm {
                     matches!(input, DecryptionContext::None)
                 }
             },
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -701,7 +701,7 @@ impl Algorithm {
                     | OperatingMode::CFB128
                     | OperatingMode::ECB
             ),
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -770,7 +770,7 @@ impl UnboundCipherKey {
     /// Validates the key material against algorithm-specific constraints beyond
     /// the length check performed by [`UnboundCipherKey::new`].
     ///
-    /// For DES algorithms (behind `legacy-3des`), this rejects weak DES subkeys
+    /// For DES algorithms (behind `legacy-des`), this rejects weak DES subkeys
     /// and degenerate key configurations (e.g. K1 == K2 for 2TDEA). For other
     /// algorithms this is a no-op since the only constraint is key length.
     ///
@@ -782,7 +782,7 @@ impl UnboundCipherKey {
     #[allow(clippy::unused_self)]
     #[allow(clippy::unnecessary_wraps)]
     fn validate_key_material(&self) -> Result<(), KeyRejected> {
-        #[cfg(feature = "legacy-3des")]
+        #[cfg(feature = "legacy-des")]
         #[allow(deprecated)]
         match self.algorithm.id() {
             AlgorithmId::DesForLegacyUseOnly => {
@@ -808,15 +808,15 @@ impl TryInto<SymmetricCipherKey> for UnboundCipherKey {
             AlgorithmId::Aes128 => SymmetricCipherKey::aes128(self.key_bytes.as_ref()),
             AlgorithmId::Aes192 => SymmetricCipherKey::aes192(self.key_bytes.as_ref()),
             AlgorithmId::Aes256 => SymmetricCipherKey::aes256(self.key_bytes.as_ref()),
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly => SymmetricCipherKey::des(self.key_bytes.as_ref()),
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly => {
                 SymmetricCipherKey::des_ede(self.key_bytes.as_ref())
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesEde3ForLegacyUseOnly => {
                 SymmetricCipherKey::des_ede3(self.key_bytes.as_ref())
@@ -842,7 +842,7 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
     ///   support CTR mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
     ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -858,7 +858,7 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
     ///   support CFB128 mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
     ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -881,7 +881,7 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -906,7 +906,7 @@ impl EncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -1008,7 +1008,7 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
-    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
     ///   support CTR mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
     ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
@@ -1024,7 +1024,7 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
-    ///   With `legacy-3des` enabled, also returned if `key`'s algorithm does not
+    ///   With `legacy-des` enabled, also returned if `key`'s algorithm does not
     ///   support CFB128 mode (e.g. `DES_EDE_FOR_LEGACY_USE_ONLY`,
     ///   `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -1047,7 +1047,7 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -1072,7 +1072,7 @@ impl DecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `DecryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -1155,7 +1155,7 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cbc_mode(key, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1165,7 +1165,7 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ctr_mode(key, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1178,7 +1178,7 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cfb_mode(key, mode, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1190,7 +1190,7 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ecb_mode(key, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1220,7 +1220,7 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cbc_mode(key, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1230,7 +1230,7 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ctr_mode(key, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1243,7 +1243,7 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cfb_mode(key, mode, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1255,7 +1255,7 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ecb_mode(key, context, in_out)
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             #[allow(deprecated)]
             AlgorithmId::DesForLegacyUseOnly
             | AlgorithmId::DesEdeForLegacyUseOnly
@@ -1597,7 +1597,7 @@ mod tests {
         "f58c4c04d6e5f1ba779eabfb5f7bfbd69cfc4e967edb808d679f777bc6702c7d39f23369a9d9bacfa530e26304231461b2eb05e2c39be9fcda6c19078c6a9d1b"
     );
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_rejects_weak_key() {
@@ -1618,7 +1618,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_rejects_semi_weak_key() {
@@ -1647,7 +1647,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede_rejects_k1_equal_k2() {
@@ -1665,7 +1665,7 @@ mod tests {
             .expect("valid 2TDEA key should be accepted");
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede_rejects_weak_subkey() {
@@ -1700,7 +1700,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_rejects_degenerate_keys() {
@@ -1739,7 +1739,7 @@ mod tests {
             .expect("valid 3TDEA key should be accepted");
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_rejects_weak_subkey() {
@@ -1776,7 +1776,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede_rejects_semi_weak_subkey() {
@@ -1823,7 +1823,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_rejects_semi_weak_subkey() {
@@ -1862,7 +1862,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_rejects_unsupported_modes() {
@@ -1947,7 +1947,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_cbc() {
@@ -1963,7 +1963,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ecb() {
@@ -1979,7 +1979,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede_cbc() {
@@ -1995,7 +1995,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede_ecb() {
@@ -2011,7 +2011,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_cbc() {
@@ -2027,7 +2027,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_ecb() {
@@ -2043,7 +2043,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     macro_rules! des_cipher_kat {
         ($name:ident, $alg:expr, $mode:expr, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
             #[test]
@@ -2074,7 +2074,7 @@ mod tests {
         };
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     des_cipher_kat!(
         test_des_cbc_kat,
         &DES_FOR_LEGACY_USE_ONLY,
@@ -2085,7 +2085,7 @@ mod tests {
         "2d121f90fcf68631ed788fcfe31a62dffa784891fa512ef928ea856d934257c6"
     );
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     des_cipher_kat!(
         test_des_ecb_kat,
         &DES_FOR_LEGACY_USE_ONLY,
@@ -2096,7 +2096,7 @@ mod tests {
         "7277a00dc1c1c36b2256338b7a9f36ef6e511022cfebec489a4a53a1c7d22e5b"
     );
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     des_cipher_kat!(
         test_sp800_67_des_ede_cbc,
         &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -2107,7 +2107,7 @@ mod tests {
         "7401CE1EAB6D003CAFF84BF47B36CC2154F0238F9FFECD8F6ACF118392B45581"
     );
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     des_cipher_kat!(
         test_sp800_67_des_ede_ecb,
         &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -2118,7 +2118,7 @@ mod tests {
         "06EDE3D82884090AFF322C19F0518486730576972A666E58B6C88CF107340D3D"
     );
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     des_cipher_kat!(
         test_sp800_67_des_ede3_cbc,
         &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -2129,7 +2129,7 @@ mod tests {
         "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
     );
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     des_cipher_kat!(
         test_sp800_67_des_ede3_ecb,
         &DES_EDE3_FOR_LEGACY_USE_ONLY,

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -236,7 +236,9 @@ use crate::aws_lc::{
     EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
 };
 #[cfg(feature = "legacy-3des")]
-use crate::aws_lc::{EVP_des_ede, EVP_des_ede3_cbc, EVP_des_ede3_ecb, EVP_des_ede_cbc};
+use crate::aws_lc::{
+    EVP_des_cbc, EVP_des_ecb, EVP_des_ede, EVP_des_ede3_cbc, EVP_des_ede3_ecb, EVP_des_ede_cbc,
+};
 use crate::buffer::Buffer;
 use crate::error::{KeyRejected, Unspecified};
 use crate::hkdf;
@@ -256,6 +258,17 @@ pub use crate::cipher::aes::AES_192_KEY_LEN;
 
 /// The number of bytes in an AES 256-bit key
 pub use crate::cipher::aes::AES_256_KEY_LEN;
+
+/// The number of bytes in a single DES key.
+///
+/// Single DES provides only 56 bits of effective security and is retained
+/// for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[deprecated(
+    note = "Single DES is a legacy algorithm retained for interoperability only. Prefer an AES-based algorithm."
+)]
+pub use crate::cipher::des::DES_KEY_LEN;
 
 /// The number of bytes in a 2TDEA (DES-EDE, 2-key Triple DES) key.
 ///
@@ -290,14 +303,14 @@ pub use crate::cipher::aes::AES_CTR_IV_LEN;
 /// The number of bytes for an AES-CFB initialization vector (IV)
 pub use crate::cipher::aes::AES_CFB_IV_LEN;
 
-/// The number of bytes for a 3DES-CBC initialization vector (IV).
+/// The number of bytes for a DES-CBC initialization vector (IV).
 ///
-/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// DES is a legacy algorithm and has been disallowed for encryption by
 /// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
 #[cfg(feature = "legacy-3des")]
 #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
 #[deprecated(
-    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+    note = "DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
 )]
 pub use crate::cipher::des::DES_CBC_IV_LEN;
 
@@ -341,6 +354,12 @@ impl OperatingMode {
             (OperatingMode::ECB, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ecb() },
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
+            (OperatingMode::CBC, AlgorithmId::DesForLegacyUseOnly) => unsafe { EVP_des_cbc() },
+            #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
+            (OperatingMode::ECB, AlgorithmId::DesForLegacyUseOnly) => unsafe { EVP_des_ecb() },
+            #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
             (OperatingMode::CBC, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe {
                 EVP_des_ede_cbc()
             },
@@ -359,8 +378,10 @@ impl OperatingMode {
             },
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            (OperatingMode::CTR, AlgorithmId::DesEdeForLegacyUseOnly)
+            (OperatingMode::CTR, AlgorithmId::DesForLegacyUseOnly)
+            | (OperatingMode::CTR, AlgorithmId::DesEdeForLegacyUseOnly)
             | (OperatingMode::CTR, AlgorithmId::DesEde3ForLegacyUseOnly)
+            | (OperatingMode::CFB128, AlgorithmId::DesForLegacyUseOnly)
             | (OperatingMode::CFB128, AlgorithmId::DesEdeForLegacyUseOnly)
             | (OperatingMode::CFB128, AlgorithmId::DesEde3ForLegacyUseOnly) => {
                 // `supports_mode()` rejects these combinations at key-construction
@@ -442,6 +463,17 @@ pub enum AlgorithmId {
     /// AES 192-bit
     Aes192,
 
+    /// Single DES (for legacy use only).
+    ///
+    /// Single DES provides only 56 bits of effective security and has been
+    /// considered insecure for decades.
+    #[cfg(feature = "legacy-3des")]
+    #[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+    #[deprecated(
+        note = "Single DES is a legacy algorithm retained for interoperability only. Prefer an AES-based algorithm."
+    )]
+    DesForLegacyUseOnly,
+
     /// 2TDEA (for legacy use only).
     ///
     /// 2-key Triple DES has been disallowed for encryption by
@@ -492,6 +524,27 @@ pub const AES_256: Algorithm = Algorithm {
     id: AlgorithmId::Aes256,
     key_len: AES_256_KEY_LEN,
     block_len: AES_BLOCK_LEN,
+};
+
+/// Single DES cipher, for legacy interoperability only.
+///
+/// Single DES provides only 56 bits of effective security and has been
+/// considered insecure for decades. It is retained here solely for
+/// interoperability with legacy systems. New designs must use an AES-based
+/// algorithm.
+///
+/// Only CBC and ECB operating modes are supported. Weak and semi-weak DES
+/// keys are rejected.
+#[cfg(feature = "legacy-3des")]
+#[cfg_attr(aws_lc_rs_docsrs, doc(cfg(feature = "legacy-3des")))]
+#[allow(deprecated)]
+#[deprecated(
+    note = "Single DES is a legacy algorithm retained for interoperability only. Prefer an AES-based algorithm."
+)]
+pub const DES_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+    id: AlgorithmId::DesForLegacyUseOnly,
+    key_len: DES_KEY_LEN,
+    block_len: DES_BLOCK_LEN,
 };
 
 /// 2TDEA (DES-EDE, 2-key Triple DES) cipher, for legacy interoperability only.
@@ -578,13 +631,13 @@ impl Algorithm {
             },
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                match mode {
-                    OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
-                    OperatingMode::ECB => Ok(EncryptionContext::None),
-                    _ => Err(Unspecified),
-                }
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => match mode {
+                OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
+                OperatingMode::ECB => Ok(EncryptionContext::None),
+                _ => Err(Unspecified),
+            },
         }
     }
 
@@ -601,13 +654,13 @@ impl Algorithm {
             },
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                match mode {
-                    OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
-                    OperatingMode::ECB => matches!(input, EncryptionContext::None),
-                    _ => false,
-                }
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => match mode {
+                OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
+                OperatingMode::ECB => matches!(input, EncryptionContext::None),
+                _ => false,
+            },
         }
     }
 
@@ -624,13 +677,13 @@ impl Algorithm {
             },
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                match mode {
-                    OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
-                    OperatingMode::ECB => matches!(input, DecryptionContext::None),
-                    _ => false,
-                }
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => match mode {
+                OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
+                OperatingMode::ECB => matches!(input, DecryptionContext::None),
+                _ => false,
+            },
         }
     }
 
@@ -650,7 +703,9 @@ impl Algorithm {
             ),
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 matches!(mode, OperatingMode::CBC | OperatingMode::ECB)
             }
         }
@@ -730,6 +785,9 @@ impl UnboundCipherKey {
         #[cfg(feature = "legacy-3des")]
         #[allow(deprecated)]
         match self.algorithm.id() {
+            AlgorithmId::DesForLegacyUseOnly => {
+                let _ = SymmetricCipherKey::prepare_des(self.key_bytes.as_ref())?;
+            }
             AlgorithmId::DesEdeForLegacyUseOnly => {
                 let _ = SymmetricCipherKey::prepare_des_ede(self.key_bytes.as_ref())?;
             }
@@ -750,6 +808,9 @@ impl TryInto<SymmetricCipherKey> for UnboundCipherKey {
             AlgorithmId::Aes128 => SymmetricCipherKey::aes128(self.key_bytes.as_ref()),
             AlgorithmId::Aes192 => SymmetricCipherKey::aes192(self.key_bytes.as_ref()),
             AlgorithmId::Aes256 => SymmetricCipherKey::aes256(self.key_bytes.as_ref()),
+            #[cfg(feature = "legacy-3des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesForLegacyUseOnly => SymmetricCipherKey::des(self.key_bytes.as_ref()),
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
             AlgorithmId::DesEdeForLegacyUseOnly => {
@@ -1096,9 +1157,9 @@ fn encrypt(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                des::encrypt_cbc_mode(key, context, in_out)
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => des::encrypt_cbc_mode(key, context, in_out),
         },
         OperatingMode::CTR => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
@@ -1106,7 +1167,9 @@ fn encrypt(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 unreachable!("DES does not support CTR mode.")
             }
         },
@@ -1117,7 +1180,9 @@ fn encrypt(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 unreachable!("DES does not support CFB128 mode.")
             }
         },
@@ -1127,9 +1192,9 @@ fn encrypt(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                des::encrypt_ecb_mode(key, context, in_out)
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => des::encrypt_ecb_mode(key, context, in_out),
         },
     }
 }
@@ -1157,9 +1222,9 @@ fn decrypt<'in_out>(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                des::decrypt_cbc_mode(key, context, in_out)
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => des::decrypt_cbc_mode(key, context, in_out),
         },
         OperatingMode::CTR => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
@@ -1167,7 +1232,9 @@ fn decrypt<'in_out>(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 unreachable!("DES does not support CTR mode.")
             }
         },
@@ -1178,7 +1245,9 @@ fn decrypt<'in_out>(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 unreachable!("DES does not support CFB128 mode.")
             }
         },
@@ -1188,9 +1257,9 @@ fn decrypt<'in_out>(
             }
             #[cfg(feature = "legacy-3des")]
             #[allow(deprecated)]
-            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
-                des::decrypt_ecb_mode(key, context, in_out)
-            }
+            AlgorithmId::DesForLegacyUseOnly
+            | AlgorithmId::DesEdeForLegacyUseOnly
+            | AlgorithmId::DesEde3ForLegacyUseOnly => des::decrypt_ecb_mode(key, context, in_out),
         },
     }
 }
@@ -1531,6 +1600,56 @@ mod tests {
     #[cfg(feature = "legacy-3des")]
     #[test]
     #[allow(deprecated)]
+    fn test_des_rejects_weak_key() {
+        let weak_keys: [&str; 4] = [
+            "0101010101010101",
+            "fefefefefefefefe",
+            "e0e0e0e0f1f1f1f1",
+            "1f1f1f1f0e0e0e0e",
+        ];
+        for weak in &weak_keys {
+            let key = from_hex(weak).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected weak DES key {weak} to be rejected"
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_rejects_semi_weak_key() {
+        let semi_weak_keys: [&str; 12] = [
+            "01fe01fe01fe01fe",
+            "fe01fe01fe01fe01",
+            "1fe01fe00ef10ef1",
+            "e01fe01ff10ef10e",
+            "01e001e001f101f1",
+            "e001e001f101f101",
+            "1ffe1ffe0efe0efe",
+            "fe1ffe1ffe0efe0e",
+            "011f011f010e010e",
+            "1f011f010e010e01",
+            "e0fee0fef1fef1fe",
+            "fee0fee0fef1fef1",
+        ];
+        for semi_weak in &semi_weak_keys {
+            let key = from_hex(semi_weak).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected semi-weak DES key {semi_weak} to be rejected"
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
     fn test_des_ede_rejects_k1_equal_k2() {
         // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA. If K1 == K2 then
         // 2TDEA collapses to single-DES (56-bit effective security).
@@ -1747,8 +1866,34 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn test_des_rejects_unsupported_modes() {
-        // 2TDEA/3TDEA only support CBC and ECB in this crate; CTR and CFB128
+        // DES/2TDEA/3TDEA only support CBC and ECB in this crate; CTR and CFB128
         // must be rejected at construction time rather than at encrypt time.
+        let key1 = from_hex("0123456789abcdef").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(EncryptingKey::ctr)
+                .is_err(),
+            "DES + CTR (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(EncryptingKey::cfb128)
+                .is_err(),
+            "DES + CFB128 (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(DecryptingKey::ctr)
+                .is_err(),
+            "DES + CTR (decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(DecryptingKey::cfb128)
+                .is_err(),
+            "DES + CFB128 (decrypt) should be rejected"
+        );
+
         let key2 = from_hex("0123456789abcdef23456789abcdef01").unwrap();
         assert!(
             UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
@@ -1800,6 +1945,38 @@ mod tests {
                 .is_err(),
             "3TDEA + CFB128 (decrypt) should be rejected"
         );
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_cbc() {
+        let key = from_hex("0123456789abcdef").unwrap();
+        for i in 0..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_FOR_LEGACY_USE_ONLY,
+                OperatingMode::CBC,
+                size,
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ecb() {
+        let key = from_hex("0123456789abcdef").unwrap();
+        for i in 0..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_FOR_LEGACY_USE_ONLY,
+                OperatingMode::ECB,
+                size,
+            );
+        }
     }
 
     #[cfg(feature = "legacy-3des")]
@@ -1896,6 +2073,28 @@ mod tests {
             }
         };
     }
+
+    #[cfg(feature = "legacy-3des")]
+    des_cipher_kat!(
+        test_des_cbc_kat,
+        &DES_FOR_LEGACY_USE_ONLY,
+        OperatingMode::CBC,
+        "0123456789abcdef",
+        "f69f2445df4f9b17",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "2d121f90fcf68631ed788fcfe31a62dffa784891fa512ef928ea856d934257c6"
+    );
+
+    #[cfg(feature = "legacy-3des")]
+    des_cipher_kat!(
+        test_des_ecb_kat,
+        &DES_FOR_LEGACY_USE_ONLY,
+        OperatingMode::ECB,
+        "0123456789abcdef",
+        "",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "7277a00dc1c1c36b2256338b7a9f36ef6e511022cfebec489a4a53a1c7d22e5b"
+    );
 
     #[cfg(feature = "legacy-3des")]
     des_cipher_kat!(

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -1993,6 +1993,82 @@ mod tests {
                 .is_err(),
             "3TDEA + CFB128 (decrypt) should be rejected"
         );
+
+        // Streaming constructors must also reject unsupported modes.
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(StreamingEncryptingKey::ctr)
+                .is_err(),
+            "DES + CTR (streaming encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(StreamingEncryptingKey::cfb128)
+                .is_err(),
+            "DES + CFB128 (streaming encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(|k| StreamingDecryptingKey::ctr(k, DecryptionContext::None))
+                .is_err(),
+            "DES + CTR (streaming decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key1)
+                .and_then(|k| StreamingDecryptingKey::cfb128(k, DecryptionContext::None))
+                .is_err(),
+            "DES + CFB128 (streaming decrypt) should be rejected"
+        );
+
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(StreamingEncryptingKey::ctr)
+                .is_err(),
+            "2TDEA + CTR (streaming encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(StreamingEncryptingKey::cfb128)
+                .is_err(),
+            "2TDEA + CFB128 (streaming encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(|k| StreamingDecryptingKey::ctr(k, DecryptionContext::None))
+                .is_err(),
+            "2TDEA + CTR (streaming decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(|k| StreamingDecryptingKey::cfb128(k, DecryptionContext::None))
+                .is_err(),
+            "2TDEA + CFB128 (streaming decrypt) should be rejected"
+        );
+
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(StreamingEncryptingKey::ctr)
+                .is_err(),
+            "3TDEA + CTR (streaming encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(StreamingEncryptingKey::cfb128)
+                .is_err(),
+            "3TDEA + CFB128 (streaming encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(|k| StreamingDecryptingKey::ctr(k, DecryptionContext::None))
+                .is_err(),
+            "3TDEA + CTR (streaming decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(|k| StreamingDecryptingKey::cfb128(k, DecryptionContext::None))
+                .is_err(),
+            "3TDEA + CFB128 (streaming decrypt) should be rejected"
+        );
     }
 
     #[cfg(feature = "legacy-des")]

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{
-    DES_cblock, DES_ecb3_encrypt, DES_ede3_cbc_encrypt, DES_key_schedule, DES_DECRYPT, DES_ENCRYPT,
+    DES_cblock, DES_ecb3_encrypt, DES_ecb_encrypt, DES_ede3_cbc_encrypt, DES_key_schedule,
+    DES_ncbc_encrypt, DES_DECRYPT, DES_ENCRYPT,
 };
 use crate::error::Unspecified;
 use crate::fips::indicator_check;
@@ -10,13 +11,16 @@ use zeroize::Zeroize;
 
 use super::{DecryptionContext, EncryptionContext, SymmetricCipherKey};
 
+/// Length of a single DES key in bytes.
+pub const DES_KEY_LEN: usize = 8;
+
 /// Length of a 2TDEA (DES-EDE) key in bytes.
 pub const DES_EDE_KEY_LEN: usize = 16;
 
 /// Length of a 3TDEA (DES-EDE3) key in bytes.
 pub const DES_EDE3_KEY_LEN: usize = 24;
 
-/// The number of bytes for a 3DES-CBC initialization vector (IV).
+/// The number of bytes for a DES-CBC initialization vector (IV).
 pub const DES_CBC_IV_LEN: usize = 8;
 
 pub(crate) const DES_BLOCK_LEN: usize = 8;
@@ -32,22 +36,26 @@ pub(super) fn encrypt_cbc_mode(
     context: EncryptionContext,
     in_out: &mut [u8],
 ) -> Result<DecryptionContext, Unspecified> {
-    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
-        unreachable!()
-    };
-
     let iv_bytes: &[u8] = (&context).try_into()?;
     let mut iv = [0u8; DES_CBC_IV_LEN];
     iv.copy_from_slice(iv_bytes);
 
-    des_cbc_encrypt(
-        &key.0[0],
-        &key.0[1],
-        &key.0[2],
-        &mut iv,
-        in_out,
-        DES_ENCRYPT,
-    );
+    match key {
+        SymmetricCipherKey::Des { key } => {
+            des_cbc_encrypt(&key.0[0], &mut iv, in_out, DES_ENCRYPT);
+        }
+        SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => {
+            des3_cbc_encrypt(
+                &key.0[0],
+                &key.0[1],
+                &key.0[2],
+                &mut iv,
+                in_out,
+                DES_ENCRYPT,
+            );
+        }
+        _ => unreachable!(),
+    }
 
     iv.zeroize();
     Ok(context.into())
@@ -58,22 +66,26 @@ pub(super) fn decrypt_cbc_mode<'in_out>(
     context: DecryptionContext,
     in_out: &'in_out mut [u8],
 ) -> Result<&'in_out mut [u8], Unspecified> {
-    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
-        unreachable!()
-    };
-
     let iv_bytes: &[u8] = (&context).try_into()?;
     let mut iv = [0u8; DES_CBC_IV_LEN];
     iv.copy_from_slice(iv_bytes);
 
-    des_cbc_encrypt(
-        &key.0[0],
-        &key.0[1],
-        &key.0[2],
-        &mut iv,
-        in_out,
-        DES_DECRYPT,
-    );
+    match key {
+        SymmetricCipherKey::Des { key } => {
+            des_cbc_encrypt(&key.0[0], &mut iv, in_out, DES_DECRYPT);
+        }
+        SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => {
+            des3_cbc_encrypt(
+                &key.0[0],
+                &key.0[1],
+                &key.0[2],
+                &mut iv,
+                in_out,
+                DES_DECRYPT,
+            );
+        }
+        _ => unreachable!(),
+    }
 
     iv.zeroize();
     Ok(in_out)
@@ -88,13 +100,19 @@ pub(super) fn encrypt_ecb_mode(
         unreachable!();
     }
 
-    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
-        unreachable!()
-    };
-
     let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
-    for block in in_out_iter.by_ref() {
-        des_ecb_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
+    match key {
+        SymmetricCipherKey::Des { key } => {
+            for block in in_out_iter.by_ref() {
+                des_ecb_encrypt(&key.0[0], block, DES_ENCRYPT);
+            }
+        }
+        SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => {
+            for block in in_out_iter.by_ref() {
+                des3_ecb_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
+            }
+        }
+        _ => unreachable!(),
     }
     // Sanity check: `encrypt` validates that `in_out.len() % block_len == 0`
     // for ECB mode before dispatching here.
@@ -112,10 +130,6 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
         unreachable!();
     }
 
-    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
-        unreachable!()
-    };
-
     // The inner scope ends the mutable borrow of `in_out` held by
     // `in_out_iter` before we return `Ok(in_out)` below. `into_remainder()`
     // would also consume the iterator and release the borrow, but it's inside
@@ -124,8 +138,18 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
     // scope because it doesn't return `in_out`.
     {
         let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
-        for block in in_out_iter.by_ref() {
-            des_ecb_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+        match key {
+            SymmetricCipherKey::Des { key } => {
+                for block in in_out_iter.by_ref() {
+                    des_ecb_encrypt(&key.0[0], block, DES_DECRYPT);
+                }
+            }
+            SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => {
+                for block in in_out_iter.by_ref() {
+                    des3_ecb_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+                }
+            }
+            _ => unreachable!(),
         }
         // Sanity check: `decrypt` validates that `in_out.len() % block_len == 0`
         // for ECB mode before dispatching here.
@@ -135,7 +159,7 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
     Ok(in_out)
 }
 
-fn des_cbc_encrypt(
+fn des3_cbc_encrypt(
     ks1: &DES_key_schedule,
     ks2: &DES_key_schedule,
     ks3: &DES_key_schedule,
@@ -166,7 +190,7 @@ fn des_cbc_encrypt(
     });
 }
 
-fn des_ecb_encrypt(
+fn des3_ecb_encrypt(
     ks1: &DES_key_schedule,
     ks2: &DES_key_schedule,
     ks3: &DES_key_schedule,
@@ -183,5 +207,46 @@ fn des_ecb_encrypt(
     // `DES_ecb3_encrypt` supports in-place operation.
     indicator_check!(unsafe {
         DES_ecb3_encrypt(input_block, output_block, ks1, ks2, ks3, enc);
+    });
+}
+
+fn des_cbc_encrypt(
+    ks: &DES_key_schedule,
+    iv: &mut [u8; DES_CBC_IV_LEN],
+    in_out: &mut [u8],
+    enc: i32,
+) {
+    // The caller (`encrypt`/`decrypt` in cipher.rs) validates block alignment
+    // for CBC mode; assert here as a safety net.
+    debug_assert_eq!(in_out.len() % DES_BLOCK_LEN, 0);
+
+    // DES is not FIPS-approved; `indicator_check!` will observe that the
+    // underlying call does not increment the approved-operation counter and
+    // correctly mark the service indicator as unapproved in FIPS builds.
+    //
+    // SAFETY: `DES_ncbc_encrypt` supports in-place operation (in == out).
+    indicator_check!(unsafe {
+        DES_ncbc_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            ks,
+            iv.as_mut_ptr() as *mut DES_cblock,
+            enc,
+        );
+    });
+}
+
+fn des_ecb_encrypt(ks: &DES_key_schedule, block: &mut [u8], enc: i32) {
+    let input_block = block.as_ptr() as *const DES_cblock;
+    let output_block = block.as_mut_ptr() as *mut DES_cblock;
+    // DES is not FIPS-approved; `indicator_check!` will observe that the
+    // underlying call does not increment the approved-operation counter and
+    // correctly mark the service indicator as unapproved in FIPS builds.
+    //
+    // SAFETY: `input_block` and `output_block` point to the same allocation;
+    // `DES_ecb_encrypt` supports in-place operation.
+    indicator_check!(unsafe {
+        DES_ecb_encrypt(input_block, output_block, ks, enc);
     });
 }

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -20,7 +20,7 @@ pub const DES_EDE_KEY_LEN: usize = 16;
 /// Length of a 3TDEA (DES-EDE3) key in bytes.
 pub const DES_EDE3_KEY_LEN: usize = 24;
 
-/// The number of bytes for a DES-CBC initialization vector (IV).
+/// The number of bytes for a DES/3DES-CBC initialization vector (IV).
 pub const DES_CBC_IV_LEN: usize = 8;
 
 pub(crate) const DES_BLOCK_LEN: usize = 8;
@@ -28,6 +28,11 @@ pub(crate) const DES_BLOCK_LEN: usize = 8;
 // `#[repr(transparent)]` documents that `DesKey` has the same layout as the
 // wrapped array, which the `Drop` impl in `key.rs` relies on when it zeroizes
 // the key schedule bytes through a byte-slice view.
+//
+// The array is sized for 3TDEA and is used unchanged for single DES (slot 0
+// populated, slots 1 and 2 zeroed) and 2TDEA (slots 0 and 1 populated, slot 2 =
+// slot 0 per K3 == K1). Callers in this module match on `SymmetricCipherKey`
+// and read only the slots that are meaningful for the variant.
 #[repr(transparent)]
 pub(crate) struct DesKey(pub(super) [DES_key_schedule; 3]);
 

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -7,7 +7,7 @@ use crate::aws_lc::{DES_cblock, DES_key_schedule, DES_set_key};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
 #[cfg(feature = "legacy-3des")]
-use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN};
+use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN, DES_KEY_LEN};
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
 #[cfg(feature = "legacy-3des")]
 use crate::constant_time;
@@ -34,6 +34,10 @@ pub(crate) enum SymmetricCipherKey {
     },
     ChaCha20 {
         raw_key: ChaCha20Key,
+    },
+    #[cfg(feature = "legacy-3des")]
+    Des {
+        key: DesKey,
     },
     #[cfg(feature = "legacy-3des")]
     DesEde {
@@ -70,7 +74,9 @@ impl Drop for SymmetricCipherKey {
             },
             SymmetricCipherKey::ChaCha20 { .. } => {}
             #[cfg(feature = "legacy-3des")]
-            SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => unsafe {
+            SymmetricCipherKey::Des { key }
+            | SymmetricCipherKey::DesEde { key }
+            | SymmetricCipherKey::DesEde3 { key } => unsafe {
                 let key_bytes: &mut [u8; size_of::<DesKey>()] = (key as *mut DesKey)
                     .cast::<[u8; size_of::<DesKey>()]>()
                     .as_mut()
@@ -144,6 +150,30 @@ impl SymmetricCipherKey {
                 raw_key: ChaCha20Key(kb.assume_init()),
             })
         }
+    }
+
+    /// Validates single DES key material and computes the key schedule.
+    ///
+    /// Returns the schedule as `[ks, zeroed, zeroed]` (only slot 0 is used).
+    /// This is the shared validation/preparation step used by both
+    /// [`SymmetricCipherKey::des`] and
+    /// [`UnboundCipherKey::validate_key_material`].
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn prepare_des(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
+        if key_bytes.len() != DES_KEY_LEN {
+            return Err(KeyRejected::unspecified());
+        }
+        let k: &[u8; 8] = key_bytes.try_into().expect("length already checked");
+        let ks = Self::des_set_key(k)?;
+        let zero = MaybeUninit::<DES_key_schedule>::zeroed();
+        unsafe { Ok([ks, zero.assume_init(), zero.assume_init()]) }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn des(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
+        Ok(SymmetricCipherKey::Des {
+            key: DesKey(Self::prepare_des(key_bytes)?),
+        })
     }
 
     /// Validates 2TDEA key material and computes the three DES key schedules.
@@ -262,7 +292,9 @@ impl SymmetricCipherKey {
                 panic!("Unsupported algorithm!")
             }
             #[cfg(feature = "legacy-3des")]
-            SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
+            SymmetricCipherKey::Des { .. }
+            | SymmetricCipherKey::DesEde { .. }
+            | SymmetricCipherKey::DesEde3 { .. } => {
                 panic!("Unsupported algorithm!")
             }
         }

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 use crate::aws_lc::{DES_cblock, DES_key_schedule, DES_set_key};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN, DES_KEY_LEN};
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 use crate::constant_time;
 use crate::error::{KeyRejected, Unspecified};
 use core::mem::{size_of, MaybeUninit};
@@ -35,15 +35,15 @@ pub(crate) enum SymmetricCipherKey {
     ChaCha20 {
         raw_key: ChaCha20Key,
     },
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     Des {
         key: DesKey,
     },
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     DesEde {
         key: DesKey,
     },
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     DesEde3 {
         key: DesKey,
     },
@@ -73,7 +73,7 @@ impl Drop for SymmetricCipherKey {
                 dec_bytes.zeroize();
             },
             SymmetricCipherKey::ChaCha20 { .. } => {}
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             SymmetricCipherKey::Des { key }
             | SymmetricCipherKey::DesEde { key }
             | SymmetricCipherKey::DesEde3 { key } => unsafe {
@@ -158,7 +158,7 @@ impl SymmetricCipherKey {
     /// This is the shared validation/preparation step used by both
     /// [`SymmetricCipherKey::des`] and
     /// [`UnboundCipherKey::validate_key_material`].
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     pub(crate) fn prepare_des(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
         if key_bytes.len() != DES_KEY_LEN {
             return Err(KeyRejected::unspecified());
@@ -169,7 +169,7 @@ impl SymmetricCipherKey {
         unsafe { Ok([ks, zero.assume_init(), zero.assume_init()]) }
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     pub(crate) fn des(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         Ok(SymmetricCipherKey::Des {
             key: DesKey(Self::prepare_des(key_bytes)?),
@@ -182,7 +182,7 @@ impl SymmetricCipherKey {
     /// This is the shared validation/preparation step used by both
     /// [`SymmetricCipherKey::des_ede`] and
     /// [`UnboundCipherKey::validate_key_material`].
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     pub(crate) fn prepare_des_ede(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
         if key_bytes.len() != DES_EDE_KEY_LEN {
             return Err(KeyRejected::unspecified());
@@ -206,14 +206,14 @@ impl SymmetricCipherKey {
         Ok([ks1, ks2, ks1])
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     pub(crate) fn des_ede(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         Ok(SymmetricCipherKey::DesEde {
             key: DesKey(Self::prepare_des_ede(key_bytes)?),
         })
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     fn des_set_key(key_bytes: &[u8; 8]) -> Result<DES_key_schedule, KeyRejected> {
         let mut ks = MaybeUninit::<DES_key_schedule>::uninit();
         // DES_set_key return values (see openssl/des.h):
@@ -233,7 +233,7 @@ impl SymmetricCipherKey {
     /// This is the shared validation/preparation step used by both
     /// [`SymmetricCipherKey::des_ede3`] and
     /// [`UnboundCipherKey::validate_key_material`].
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     pub(crate) fn prepare_des_ede3(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
         if key_bytes.len() != DES_EDE3_KEY_LEN {
             return Err(KeyRejected::unspecified());
@@ -272,7 +272,7 @@ impl SymmetricCipherKey {
         ])
     }
 
-    #[cfg(feature = "legacy-3des")]
+    #[cfg(feature = "legacy-des")]
     pub(crate) fn des_ede3(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         Ok(SymmetricCipherKey::DesEde3 {
             key: DesKey(Self::prepare_des_ede3(key_bytes)?),
@@ -291,7 +291,7 @@ impl SymmetricCipherKey {
             SymmetricCipherKey::ChaCha20 { .. } => {
                 panic!("Unsupported algorithm!")
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             SymmetricCipherKey::Des { .. }
             | SymmetricCipherKey::DesEde { .. }
             | SymmetricCipherKey::DesEde3 { .. } => {

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -98,10 +98,11 @@ impl PaddedBlockEncryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
     }
@@ -116,10 +117,11 @@ impl PaddedBlockEncryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
@@ -229,10 +231,11 @@ impl PaddedBlockDecryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, PaddingStrategy::PKCS7)
     }
@@ -251,10 +254,11 @@ impl PaddedBlockDecryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn cbc_iso10126(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CBC, PaddingStrategy::ISO10126)
     }
@@ -274,10 +278,11 @@ impl PaddedBlockDecryptingKey {
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
     ///   With `legacy-des` enabled, also returned if `key` was constructed with
-    ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
-    ///   provided key material contains weak or semi-weak DES subkeys, or a
-    ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
-    ///   pairwise equality for 3TDEA).
+    ///   `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY` or
+    ///   `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains
+    ///   weak or semi-weak DES subkeys, or (for Triple DES) a degenerate subkey
+    ///   configuration (e.g. `K1 == K2` for 2TDEA, or any pairwise equality
+    ///   for 3TDEA).
     pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -97,7 +97,7 @@ impl PaddedBlockEncryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -115,7 +115,7 @@ impl PaddedBlockEncryptingKey {
     ///
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing a `PaddedBlockEncryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -228,7 +228,7 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -250,7 +250,7 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any
@@ -273,7 +273,7 @@ impl PaddedBlockDecryptingKey {
     //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `PaddedBlockDecryptingKey`.
-    ///   With `legacy-3des` enabled, also returned if `key` was constructed with
+    ///   With `legacy-des` enabled, also returned if `key` was constructed with
     ///   `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
     ///   provided key material contains weak or semi-weak DES subkeys, or a
     ///   degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA, or any

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -152,7 +152,7 @@ impl StreamingEncryptingKey {
                 );
                 evp_encrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             ctx @ EncryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(
@@ -319,7 +319,7 @@ impl StreamingEncryptingKey {
     /// The resulting ciphertext will be the same length as the plaintext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CTR mode (e.g.
     /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -334,7 +334,7 @@ impl StreamingEncryptingKey {
     /// an `EncryptionContext` from a previously used initialization vector (IV).
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CTR mode (e.g.
     /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn less_safe_ctr(
@@ -350,7 +350,7 @@ impl StreamingEncryptingKey {
     /// to fill the next block of ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
     /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
     /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
@@ -364,7 +364,7 @@ impl StreamingEncryptingKey {
     /// The resulting ciphertext will be the same length as the plaintext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
     /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -382,7 +382,7 @@ impl StreamingEncryptingKey {
     /// very likely not what you want to use.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
     /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
     /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
@@ -399,7 +399,7 @@ impl StreamingEncryptingKey {
     /// an `EncryptionContext` from a previously used initialization vector (IV).
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
     /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn less_safe_cfb128(
@@ -418,7 +418,7 @@ impl StreamingEncryptingKey {
     /// an `EncryptionContext` from a previously used initialization vector (IV).
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
     /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
     /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
@@ -473,7 +473,7 @@ impl StreamingDecryptingKey {
                 );
                 evp_decrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
             }
-            #[cfg(feature = "legacy-3des")]
+            #[cfg(feature = "legacy-des")]
             ctx @ DecryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(
@@ -635,7 +635,7 @@ impl StreamingDecryptingKey {
     /// The resulting plaintext will be the same length as the ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CTR mode (e.g.
     /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey, context: DecryptionContext) -> Result<Self, Unspecified> {
@@ -646,7 +646,7 @@ impl StreamingDecryptingKey {
     /// The resulting plaintext will be shorter than the ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
     /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
     /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
@@ -662,7 +662,7 @@ impl StreamingDecryptingKey {
     /// The resulting plaintext will be the same length as the ciphertext.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
     /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey, context: DecryptionContext) -> Result<Self, Unspecified> {
@@ -677,7 +677,7 @@ impl StreamingDecryptingKey {
     /// very likely not what you want to use.
     ///
     /// # Errors
-    /// Returns an error on an internal failure. With `legacy-3des` enabled, also
+    /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
     /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
     /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -321,7 +321,8 @@ impl StreamingEncryptingKey {
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CTR mode (e.g.
-    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    /// `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key.algorithm().new_encryption_context(OperatingMode::CTR)?;
         Self::less_safe_ctr(key, context)
@@ -336,7 +337,8 @@ impl StreamingEncryptingKey {
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CTR mode (e.g.
-    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    /// `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn less_safe_ctr(
         key: UnboundCipherKey,
         context: EncryptionContext,
@@ -351,10 +353,11 @@ impl StreamingEncryptingKey {
     ///
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
-    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
-    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
-    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
-    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
+    /// returned if `key` was constructed with `DES_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    /// provided key material contains weak or semi-weak DES subkeys, or (for
+    /// Triple DES) a degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA,
+    /// or any pairwise equality for 3TDEA).
     pub fn cbc_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key.algorithm().new_encryption_context(OperatingMode::CBC)?;
         Self::less_safe_cbc_pkcs7(key, context)
@@ -366,7 +369,8 @@ impl StreamingEncryptingKey {
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
-    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    /// `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key
             .algorithm()
@@ -383,10 +387,11 @@ impl StreamingEncryptingKey {
     ///
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
-    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
-    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
-    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
-    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
+    /// returned if `key` was constructed with `DES_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    /// provided key material contains weak or semi-weak DES subkeys, or (for
+    /// Triple DES) a degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA,
+    /// or any pairwise equality for 3TDEA).
     pub fn ecb_pkcs7(key: UnboundCipherKey) -> Result<Self, Unspecified> {
         let context = key.algorithm().new_encryption_context(OperatingMode::ECB)?;
         Self::new(key, OperatingMode::ECB, context)
@@ -401,7 +406,8 @@ impl StreamingEncryptingKey {
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
-    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    /// `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn less_safe_cfb128(
         key: UnboundCipherKey,
         context: EncryptionContext,
@@ -419,10 +425,11 @@ impl StreamingEncryptingKey {
     ///
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
-    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
-    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
-    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
-    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
+    /// returned if `key` was constructed with `DES_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    /// provided key material contains weak or semi-weak DES subkeys, or (for
+    /// Triple DES) a degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA,
+    /// or any pairwise equality for 3TDEA).
     pub fn less_safe_cbc_pkcs7(
         key: UnboundCipherKey,
         context: EncryptionContext,
@@ -637,7 +644,8 @@ impl StreamingDecryptingKey {
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CTR mode (e.g.
-    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    /// `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn ctr(key: UnboundCipherKey, context: DecryptionContext) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CTR, context)
     }
@@ -647,10 +655,11 @@ impl StreamingDecryptingKey {
     ///
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
-    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
-    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
-    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
-    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
+    /// returned if `key` was constructed with `DES_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    /// provided key material contains weak or semi-weak DES subkeys, or (for
+    /// Triple DES) a degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA,
+    /// or any pairwise equality for 3TDEA).
     pub fn cbc_pkcs7(
         key: UnboundCipherKey,
         context: DecryptionContext,
@@ -664,7 +673,8 @@ impl StreamingDecryptingKey {
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
     /// returned if `key`'s algorithm does not support CFB128 mode (e.g.
-    /// `DES_EDE_FOR_LEGACY_USE_ONLY`, `DES_EDE3_FOR_LEGACY_USE_ONLY`).
+    /// `DES_FOR_LEGACY_USE_ONLY`, `DES_EDE_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE3_FOR_LEGACY_USE_ONLY`).
     pub fn cfb128(key: UnboundCipherKey, context: DecryptionContext) -> Result<Self, Unspecified> {
         Self::new(key, OperatingMode::CFB128, context)
     }
@@ -678,10 +688,11 @@ impl StreamingDecryptingKey {
     ///
     /// # Errors
     /// Returns an error on an internal failure. With `legacy-des` enabled, also
-    /// returned if `key` was constructed with `DES_EDE_FOR_LEGACY_USE_ONLY` or
-    /// `DES_EDE3_FOR_LEGACY_USE_ONLY` and the provided key material contains weak
-    /// or semi-weak DES subkeys, or a degenerate subkey configuration (e.g.
-    /// `K1 == K2` for 2TDEA, or any pairwise equality for 3TDEA).
+    /// returned if `key` was constructed with `DES_FOR_LEGACY_USE_ONLY`,
+    /// `DES_EDE_FOR_LEGACY_USE_ONLY` or `DES_EDE3_FOR_LEGACY_USE_ONLY` and the
+    /// provided key material contains weak or semi-weak DES subkeys, or (for
+    /// Triple DES) a degenerate subkey configuration (e.g. `K1 == K2` for 2TDEA,
+    /// or any pairwise equality for 3TDEA).
     pub fn ecb_pkcs7(
         key: UnboundCipherKey,
         context: DecryptionContext,

--- a/aws-lc-rs/src/cipher/tests/fips.rs
+++ b/aws-lc-rs/src/cipher/tests/fips.rs
@@ -9,7 +9,9 @@ use crate::cipher::{
 };
 #[cfg(feature = "legacy-3des")]
 #[allow(deprecated)]
-use crate::cipher::{DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY};
+use crate::cipher::{
+    DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY, DES_FOR_LEGACY_USE_ONLY,
+};
 use crate::fips::{assert_fips_status_indicator, FipsServiceStatus};
 
 const TEST_KEY_128_BIT: [u8; 16] = [
@@ -25,6 +27,9 @@ const TEST_KEY_256_BIT: [u8; 32] = [
     0xd8, 0x32, 0x58, 0xa9, 0x5a, 0x62, 0x6c, 0x99, 0xc4, 0xe6, 0xb5, 0x3f, 0x97, 0x90, 0x62, 0xbe,
     0x71, 0x0f, 0xd5, 0xe1, 0xd4, 0xfe, 0x95, 0xb3, 0x03, 0x46, 0xa5, 0x8e, 0x36, 0xad, 0x18, 0xe3,
 ];
+
+#[cfg(feature = "legacy-3des")]
+const TEST_KEY_DES: [u8; 8] = [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
 
 #[cfg(feature = "legacy-3des")]
 const TEST_KEY_DES_EDE: [u8; 16] = [
@@ -205,6 +210,46 @@ block_api!(
     DecryptingKey::ctr,
     &TEST_KEY_256_BIT,
     FipsServiceStatus::Approved
+);
+
+#[cfg(feature = "legacy-3des")]
+block_api!(
+    block_des_cbc_pkcs7,
+    &DES_FOR_LEGACY_USE_ONLY,
+    PaddedBlockEncryptingKey::cbc_pkcs7,
+    PaddedBlockDecryptingKey::cbc_pkcs7,
+    &TEST_KEY_DES,
+    FipsServiceStatus::NonApproved
+);
+
+#[cfg(feature = "legacy-3des")]
+block_api!(
+    block_des_ecb_pkcs7,
+    &DES_FOR_LEGACY_USE_ONLY,
+    PaddedBlockEncryptingKey::ecb_pkcs7,
+    PaddedBlockDecryptingKey::ecb_pkcs7,
+    &TEST_KEY_DES,
+    FipsServiceStatus::NonApproved
+);
+
+#[cfg(feature = "legacy-3des")]
+streaming_api!(
+    streaming_des_cbc_pkcs7,
+    &DES_FOR_LEGACY_USE_ONLY,
+    StreamingEncryptingKey::cbc_pkcs7,
+    StreamingDecryptingKey::cbc_pkcs7,
+    &TEST_KEY_DES,
+    FipsServiceStatus::NonApproved
+);
+
+#[cfg(feature = "legacy-3des")]
+streaming_api!(
+    streaming_des_ecb_pkcs7,
+    &DES_FOR_LEGACY_USE_ONLY,
+    StreamingEncryptingKey::ecb_pkcs7,
+    StreamingDecryptingKey::ecb_pkcs7,
+    &TEST_KEY_DES,
+    FipsServiceStatus::NonApproved
 );
 
 #[cfg(feature = "legacy-3des")]

--- a/aws-lc-rs/src/cipher/tests/fips.rs
+++ b/aws-lc-rs/src/cipher/tests/fips.rs
@@ -7,7 +7,7 @@ use crate::cipher::{
     DecryptingKey, EncryptingKey, PaddedBlockDecryptingKey, PaddedBlockEncryptingKey,
     StreamingDecryptingKey, StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 #[allow(deprecated)]
 use crate::cipher::{
     DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY, DES_FOR_LEGACY_USE_ONLY,
@@ -28,15 +28,15 @@ const TEST_KEY_256_BIT: [u8; 32] = [
     0x71, 0x0f, 0xd5, 0xe1, 0xd4, 0xfe, 0x95, 0xb3, 0x03, 0x46, 0xa5, 0x8e, 0x36, 0xad, 0x18, 0xe3,
 ];
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 const TEST_KEY_DES: [u8; 8] = [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef];
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 const TEST_KEY_DES_EDE: [u8; 16] = [
     0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01,
 ];
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 const TEST_KEY_DES_EDE3: [u8; 24] = [
     0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01,
     0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23,
@@ -212,7 +212,7 @@ block_api!(
     FipsServiceStatus::Approved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 block_api!(
     block_des_cbc_pkcs7,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -222,7 +222,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 block_api!(
     block_des_ecb_pkcs7,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -232,7 +232,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 streaming_api!(
     streaming_des_cbc_pkcs7,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -242,7 +242,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 streaming_api!(
     streaming_des_ecb_pkcs7,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -252,7 +252,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 block_api!(
     block_des_ede_cbc_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -262,7 +262,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 block_api!(
     block_des_ede_ecb_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -272,7 +272,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 block_api!(
     block_des_ede3_cbc_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -282,7 +282,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 block_api!(
     block_des_ede3_ecb_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -292,7 +292,7 @@ block_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 streaming_api!(
     streaming_des_ede_cbc_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -302,7 +302,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 streaming_api!(
     streaming_des_ede_ecb_pkcs7,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -312,7 +312,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 streaming_api!(
     streaming_des_ede3_cbc_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -322,7 +322,7 @@ streaming_api!(
     FipsServiceStatus::NonApproved
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 streaming_api!(
     streaming_des_ede3_ecb_pkcs7,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,

--- a/aws-lc-rs/src/cmac.rs
+++ b/aws-lc-rs/src/cmac.rs
@@ -169,12 +169,20 @@ pub const AES_256: Algorithm = Algorithm {
     tag_len: 16,
 };
 
-/// CMAC using 3DES (Triple DES). Obsolete
-pub const TDES_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+/// CMAC using 3-key Triple DES (DES-EDE3). For legacy interoperability only;
+/// new designs must use an AES-based algorithm.
+pub const DES_EDE3_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
     id: AlgorithmId::Tdes,
     key_len: 24,
     tag_len: 8,
 };
+
+/// CMAC using 3-key Triple DES (DES-EDE3). For legacy interoperability only;
+/// new designs must use an AES-based algorithm.
+#[deprecated(
+    note = "Use `DES_EDE3_FOR_LEGACY_USE_ONLY` instead, which aligns with the naming used in the `cipher` module. The two constants are interchangeable."
+)]
+pub const TDES_FOR_LEGACY_USE_ONLY: Algorithm = DES_EDE3_FOR_LEGACY_USE_ONLY;
 
 /// Maximum CMAC tag length (AES block size).
 const MAX_CMAC_TAG_LEN: usize = 16;
@@ -513,7 +521,7 @@ mod tests {
 
     #[test]
     fn cmac_basic_test() {
-        for &algorithm in &[AES_128, AES_192, AES_256, TDES_FOR_LEGACY_USE_ONLY] {
+        for &algorithm in &[AES_128, AES_192, AES_256, DES_EDE3_FOR_LEGACY_USE_ONLY] {
             let key = Key::generate(algorithm).unwrap();
             let data = b"hello, world";
 
@@ -529,7 +537,7 @@ mod tests {
         const HELLO_WORLD_GOOD: &[u8] = b"hello, world";
         const HELLO_WORLD_BAD: &[u8] = b"hello, worle";
 
-        for algorithm in &[AES_128, AES_192, AES_256, TDES_FOR_LEGACY_USE_ONLY] {
+        for algorithm in &[AES_128, AES_192, AES_256, DES_EDE3_FOR_LEGACY_USE_ONLY] {
             let key = Key::generate(*algorithm).unwrap();
             let tag = sign(&key, HELLO_WORLD_GOOD).unwrap();
             println!("{key:?}");
@@ -545,7 +553,7 @@ mod tests {
         assert_ne!(AES_128, AES_256);
         assert_ne!(AES_192, AES_256);
 
-        for &alg in &[AES_128, AES_192, AES_256, TDES_FOR_LEGACY_USE_ONLY] {
+        for &alg in &[AES_128, AES_192, AES_256, DES_EDE3_FOR_LEGACY_USE_ONLY] {
             // Clone after updating context with message, then check if the final Tag is the same.
             let key_bytes = vec![0u8; alg.key_len()];
             let key = Key::new(alg, &key_bytes).unwrap();
@@ -608,7 +616,7 @@ mod tests {
         let k1 = Key::new(AES_128, &key_128).unwrap();
         let k2 = Key::new(AES_192, &key_192).unwrap();
         let k3 = Key::new(AES_256, &key_256).unwrap();
-        let k4 = Key::new(TDES_FOR_LEGACY_USE_ONLY, &key_3des).unwrap();
+        let k4 = Key::new(DES_EDE3_FOR_LEGACY_USE_ONLY, &key_3des).unwrap();
 
         let data = b"test message";
 
@@ -637,8 +645,8 @@ mod tests {
         assert_eq!(AES_256.key_len(), 32);
         assert_eq!(AES_256.tag_len(), 16);
 
-        assert_eq!(TDES_FOR_LEGACY_USE_ONLY.key_len(), 24);
-        assert_eq!(TDES_FOR_LEGACY_USE_ONLY.tag_len(), 8);
+        assert_eq!(DES_EDE3_FOR_LEGACY_USE_ONLY.key_len(), 24);
+        assert_eq!(DES_EDE3_FOR_LEGACY_USE_ONLY.tag_len(), 8);
     }
 
     #[test]
@@ -657,7 +665,7 @@ mod tests {
 
     #[test]
     fn des_ede3_cmac_test() {
-        let key = Key::generate(TDES_FOR_LEGACY_USE_ONLY).unwrap();
+        let key = Key::generate(DES_EDE3_FOR_LEGACY_USE_ONLY).unwrap();
         let data = b"test data for 3DES CMAC";
 
         let tag = sign(&key, data).unwrap();
@@ -667,7 +675,7 @@ mod tests {
 
     #[test]
     fn cmac_sign_to_buffer_test() {
-        for &algorithm in &[AES_128, AES_192, AES_256, TDES_FOR_LEGACY_USE_ONLY] {
+        for &algorithm in &[AES_128, AES_192, AES_256, DES_EDE3_FOR_LEGACY_USE_ONLY] {
             let key = Key::generate(algorithm).unwrap();
             let data = b"hello, world";
 
@@ -704,7 +712,7 @@ mod tests {
 
     #[test]
     fn cmac_context_verify_test() {
-        for &algorithm in &[AES_128, AES_192, AES_256, TDES_FOR_LEGACY_USE_ONLY] {
+        for &algorithm in &[AES_128, AES_192, AES_256, DES_EDE3_FOR_LEGACY_USE_ONLY] {
             let key = Key::generate(algorithm).unwrap();
             let data = b"hello, world";
 

--- a/aws-lc-rs/src/cmac/tests/fips.rs
+++ b/aws-lc-rs/src/cmac/tests/fips.rs
@@ -3,7 +3,7 @@
 
 #![cfg(debug_assertions)]
 
-use crate::cmac::{sign, verify, Key, AES_128, AES_192, AES_256, TDES_FOR_LEGACY_USE_ONLY};
+use crate::cmac::{sign, verify, Key, AES_128, AES_192, AES_256, DES_EDE3_FOR_LEGACY_USE_ONLY};
 use crate::fips::{assert_fips_status_indicator, FipsServiceStatus};
 use crate::rand::{self, SystemRandom};
 
@@ -38,8 +38,8 @@ cmac_api!(aes_128, AES_128, 16, FipsServiceStatus::Approved);
 cmac_api!(aes_192, AES_192, 24, FipsServiceStatus::NonApproved);
 cmac_api!(aes_256, AES_256, 32, FipsServiceStatus::Approved);
 cmac_api!(
-    tdes,
-    TDES_FOR_LEGACY_USE_ONLY,
+    des_ede3,
+    DES_EDE3_FOR_LEGACY_USE_ONLY,
     24,
     FipsServiceStatus::NonApproved
 );

--- a/aws-lc-rs/src/iv.rs
+++ b/aws-lc-rs/src/iv.rs
@@ -11,7 +11,7 @@ use crate::rand;
 use zeroize::Zeroize;
 
 /// Length of a 64-bit IV in bytes (used by DES/3DES).
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 pub(crate) const IV_LEN_64_BIT: usize = 8;
 
 /// Length of a 128-bit IV in bytes.

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -142,6 +142,43 @@
 //! used in production builds. The `rand::unsealed` module and `mut_fill` method are not part of the
 //! stable public API and may change without notice.
 //!
+//! #### legacy-des
+//!
+//! Enables single DES and Triple DES as opt-in symmetric ciphers under the
+//! [`cipher`] module, exposing `DES_FOR_LEGACY_USE_ONLY` (single DES),
+//! `DES_EDE_FOR_LEGACY_USE_ONLY` (2-key Triple DES) and
+//! `DES_EDE3_FOR_LEGACY_USE_ONLY` (3-key Triple DES), together with the
+//! supporting key-length and IV-length constants. Only CBC and ECB operating
+//! modes are supported.
+//!
+//! **⚠️ Warning:** Single DES and Triple DES are legacy algorithms. Single DES
+//! provides only 56 bits of effective security and has been considered insecure
+//! for decades. Triple DES has been disallowed for encryption by
+//! [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
+//! 2-key Triple DES after 2015, and 3-key Triple DES after 2023. This feature
+//! exists solely to support interoperability. All exposed items are marked
+//! `#[deprecated]` so that any use site produces a compiler warning. **Do not
+//! use single DES or Triple DES in new designs.** If you only need
+//! confidentiality, prefer AES-GCM or another AEAD from the [`aead`] module;
+//! if you specifically need a block cipher, prefer one of the AES algorithms
+//! in [`cipher`].
+//!
+//! **Build-time impact:** The default `aws-lc-sys` bindings do not expose the
+//! low-level `DES_*` symbols this feature relies on, so enabling `legacy-des`
+//! also enables `aws-lc-sys?/all-bindings`. Concretely:
+//!
+//! * On platforms with pre-generated per-target bindings, the build switches
+//!   from the universal bindings to the per-target bindings (no extra
+//!   tooling required).
+//! * On platforms *without* pre-generated bindings for the selected target,
+//!   `bindgen` is invoked at build time, which requires `libclang` to be
+//!   installed in the build environment.
+//!
+//! Because [features are
+//! additive](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification),
+//! enabling `legacy-des` anywhere in your dependency graph applies the
+//! above to the entire build.
+//!
 //! # Use of prebuilt NASM objects
 //!
 //! Prebuilt NASM objects are **only** applicable to Windows x86-64 platforms. They are **never** used on any other platform (Linux, macOS, etc.).

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -1413,11 +1413,17 @@ macro_rules! des_padded_cipher_rt {
     };
 }
 
-// The following DES KAT vectors are from the NIST SP 800-38A TDES example values:
+// The following Triple DES (2TDEA/3TDEA) KAT vectors are from the NIST SP 800-38A
+// TDES example values:
 // https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
 // The 2TDEA key is the first 16 bytes of the 3TDEA key.
 // PKCS#7-padded variants are not from NIST; their ciphertexts were computed
 // by applying PKCS#7 padding to the NIST plaintext before encryption.
+//
+// The single-DES KAT vectors below share the same key prefix, IV and plaintext
+// as the TDES vectors for convenience but are not from NIST (SP 800-38A has no
+// single-DES examples). Their ciphertexts were verified against an independent
+// DES implementation.
 #[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_cbc_32_bytes,

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -8,7 +8,9 @@ use aws_lc_rs::cipher::{
 };
 #[cfg(feature = "legacy-3des")]
 #[allow(deprecated)]
-use aws_lc_rs::cipher::{DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY};
+use aws_lc_rs::cipher::{
+    DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY, DES_FOR_LEGACY_USE_ONLY,
+};
 use aws_lc_rs::iv::{FixedLength, IV_LEN_128_BIT};
 use aws_lc_rs::test;
 use aws_lc_rs::test::from_hex;
@@ -1416,6 +1418,68 @@ macro_rules! des_padded_cipher_rt {
 // The 2TDEA key is the first 16 bytes of the 3TDEA key.
 // PKCS#7-padded variants are not from NIST; their ciphertexts were computed
 // by applying PKCS#7 padding to the NIST plaintext before encryption.
+#[cfg(feature = "legacy-3des")]
+des_cipher_rt!(
+    test_rt_des_cbc_32_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_rt!(
+    test_rt_des_ecb_32_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_cbc_31_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_cipher_kat!(
+    test_kat_des_ecb_31_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_rt!(
+    test_rt_des_cbc_pkcs7_31_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
+);
+
+#[cfg(feature = "legacy-3des")]
+des_padded_cipher_rt!(
+    test_rt_des_ecb_pkcs7_31_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
+);
+
 #[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede_cbc_32_bytes,

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -1446,6 +1446,30 @@ des_cipher_rt!(
 
 #[cfg(feature = "legacy-des")]
 des_cipher_kat!(
+    test_kat_des_cbc_32_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "2d121f90fcf68631ed788fcfe31a62dffa784891fa512ef928ea856d934257c6"
+);
+
+#[cfg(feature = "legacy-des")]
+des_cipher_kat!(
+    test_kat_des_ecb_32_bytes,
+    &DES_FOR_LEGACY_USE_ONLY,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "7277a00dc1c1c36b2256338b7a9f36ef6e511022cfebec489a4a53a1c7d22e5b"
+);
+
+#[cfg(feature = "legacy-des")]
+des_cipher_kat!(
     test_kat_des_cbc_31_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
@@ -1485,6 +1509,124 @@ des_padded_cipher_rt!(
     "0123456789abcdef",
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
+
+#[test]
+#[cfg(feature = "legacy-des")]
+#[allow(deprecated)]
+fn test_des_weak_keys_rejected() {
+    // The four DES weak keys (with parity bits set).
+    let weak_keys: &[&str] = &[
+        "0101010101010101",
+        "fefefefefefefefe",
+        "e0e0e0e0f1f1f1f1",
+        "1f1f1f1f0e0e0e0e",
+    ];
+    for hex_key in weak_keys {
+        let key_bytes = from_hex(hex_key).unwrap();
+        let unbound_key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        EncryptingKey::cbc(unbound_key)
+            .expect_err(&format!("weak key {hex_key} should be rejected"));
+    }
+}
+
+#[test]
+#[cfg(feature = "legacy-des")]
+#[allow(deprecated)]
+fn test_des_ede_rejects_k1_equals_k2() {
+    // 2TDEA with K1 == K2 degenerates to single DES; must be rejected.
+    let k1 = "0123456789abcdef";
+    let key_bytes = from_hex(&format!("{k1}{k1}")).unwrap();
+    let unbound = UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    EncryptingKey::cbc(unbound).expect_err("2TDEA K1==K2 should be rejected");
+
+    let unbound = UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    EncryptingKey::ecb(unbound).expect_err("2TDEA K1==K2 should be rejected (ECB)");
+
+    let unbound = UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    assert!(
+        StreamingEncryptingKey::cbc_pkcs7(unbound).is_err(),
+        "2TDEA K1==K2 should be rejected (streaming CBC)"
+    );
+}
+
+#[test]
+#[cfg(feature = "legacy-des")]
+#[allow(deprecated)]
+fn test_des_ede3_rejects_pairwise_equal_keys() {
+    let k1 = "0123456789abcdef";
+    let k2 = "23456789abcdef01";
+    let k3 = "456789abcdef0123";
+
+    // K1 == K2
+    let key_bytes = from_hex(&format!("{k1}{k1}{k3}")).unwrap();
+    let unbound = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    EncryptingKey::cbc(unbound).expect_err("3TDEA K1==K2 should be rejected");
+
+    // K2 == K3
+    let key_bytes = from_hex(&format!("{k1}{k2}{k2}")).unwrap();
+    let unbound = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    EncryptingKey::cbc(unbound).expect_err("3TDEA K2==K3 should be rejected");
+
+    // K1 == K3 (degenerates to 2TDEA)
+    let key_bytes = from_hex(&format!("{k1}{k2}{k1}")).unwrap();
+    let unbound = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    EncryptingKey::cbc(unbound).expect_err("3TDEA K1==K3 should be rejected");
+
+    // All three equal
+    let key_bytes = from_hex(&format!("{k1}{k1}{k1}")).unwrap();
+    let unbound = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    EncryptingKey::ecb(unbound).expect_err("3TDEA K1==K2==K3 should be rejected");
+
+    // Streaming path
+    let key_bytes = from_hex(&format!("{k1}{k1}{k3}")).unwrap();
+    let unbound = UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+    assert!(
+        StreamingEncryptingKey::cbc_pkcs7(unbound).is_err(),
+        "3TDEA K1==K2 should be rejected (streaming)"
+    );
+}
+
+#[test]
+#[cfg(feature = "legacy-des")]
+#[allow(deprecated)]
+fn test_des_unsupported_modes_rejected() {
+    let des_key = from_hex("0123456789abcdef").unwrap();
+    let ede_key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+    let ede3_key =
+        from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+
+    for (alg, key_bytes) in [
+        (&DES_FOR_LEGACY_USE_ONLY, des_key.as_slice()),
+        (&DES_EDE_FOR_LEGACY_USE_ONLY, ede_key.as_slice()),
+        (&DES_EDE3_FOR_LEGACY_USE_ONLY, ede3_key.as_slice()),
+    ] {
+        // CTR must be rejected
+        let unbound = UnboundCipherKey::new(alg, key_bytes).unwrap();
+        EncryptingKey::ctr(unbound).expect_err("DES + CTR should be rejected");
+
+        let unbound = UnboundCipherKey::new(alg, key_bytes).unwrap();
+        DecryptingKey::ctr(unbound).expect_err("DES + CTR should be rejected (decrypt)");
+
+        let unbound = UnboundCipherKey::new(alg, key_bytes).unwrap();
+        assert!(
+            StreamingEncryptingKey::ctr(unbound).is_err(),
+            "DES + CTR should be rejected (streaming encrypt)"
+        );
+
+        // CFB128 must be rejected
+        let unbound = UnboundCipherKey::new(alg, key_bytes).unwrap();
+        EncryptingKey::cfb128(unbound).expect_err("DES + CFB128 should be rejected");
+
+        let unbound = UnboundCipherKey::new(alg, key_bytes).unwrap();
+        DecryptingKey::cfb128(unbound).expect_err("DES + CFB128 should be rejected (decrypt)");
+
+        let unbound = UnboundCipherKey::new(alg, key_bytes).unwrap();
+        assert!(
+            StreamingEncryptingKey::cfb128(unbound).is_err(),
+            "DES + CFB128 should be rejected (streaming encrypt)"
+        );
+    }
+}
 
 #[cfg(feature = "legacy-des")]
 des_cipher_kat!(

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -6,7 +6,7 @@ use aws_lc_rs::cipher::{
     PaddedBlockDecryptingKey, PaddedBlockEncryptingKey, StreamingDecryptingKey,
     StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 #[allow(deprecated)]
 use aws_lc_rs::cipher::{
     DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY, DES_FOR_LEGACY_USE_ONLY,
@@ -1116,7 +1116,7 @@ unpadded_cipher_kat!(
     "00112233445566778899aabbccddee"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 macro_rules! des_streaming_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
         paste! {
@@ -1179,7 +1179,7 @@ macro_rules! des_streaming_cipher_kat {
     };
 }
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 macro_rules! des_streaming_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal, $from_step:literal, $to_step:literal) => {
         paste! {
@@ -1207,7 +1207,7 @@ macro_rules! des_streaming_cipher_rt {
     };
 }
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 macro_rules! des_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
         #[test]
@@ -1269,7 +1269,7 @@ macro_rules! des_cipher_kat {
     };
 }
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 macro_rules! des_padded_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
         #[test]
@@ -1358,7 +1358,7 @@ macro_rules! des_padded_cipher_kat {
     };
 }
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 macro_rules! des_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
         #[test]
@@ -1385,7 +1385,7 @@ macro_rules! des_cipher_rt {
     };
 }
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 macro_rules! des_padded_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
         #[test]
@@ -1418,7 +1418,7 @@ macro_rules! des_padded_cipher_rt {
 // The 2TDEA key is the first 16 bytes of the 3TDEA key.
 // PKCS#7-padded variants are not from NIST; their ciphertexts were computed
 // by applying PKCS#7 padding to the NIST plaintext before encryption.
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_cbc_32_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -1428,7 +1428,7 @@ des_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_ecb_32_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -1438,7 +1438,7 @@ des_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_cbc_31_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -1449,7 +1449,7 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ecb_31_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -1460,7 +1460,7 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_rt!(
     test_rt_des_cbc_pkcs7_31_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -1470,7 +1470,7 @@ des_padded_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_rt!(
     test_rt_des_ecb_pkcs7_31_bytes,
     &DES_FOR_LEGACY_USE_ONLY,
@@ -1480,7 +1480,7 @@ des_padded_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede_cbc_32_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1492,7 +1492,7 @@ des_cipher_kat!(
     "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede3_cbc_32_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1504,7 +1504,7 @@ des_cipher_kat!(
     "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede_ecb_32_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1516,7 +1516,7 @@ des_cipher_kat!(
     "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede3_ecb_32_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1528,7 +1528,7 @@ des_cipher_kat!(
     "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede_cbc_31_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1539,7 +1539,7 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede3_cbc_31_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1550,7 +1550,7 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede_ecb_31_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1561,7 +1561,7 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_kat!(
     test_kat_des_ede3_ecb_31_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1572,7 +1572,7 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_ede_cbc_32_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1582,7 +1582,7 @@ des_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_ede3_cbc_32_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1592,7 +1592,7 @@ des_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_ede_ecb_32_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1602,7 +1602,7 @@ des_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_cipher_rt!(
     test_rt_des_ede3_ecb_32_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1612,7 +1612,7 @@ des_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_kat!(
     test_kat_des_ede_cbc_pkcs7_32_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1624,7 +1624,7 @@ des_padded_cipher_kat!(
     "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581dcb0d2607c9dd8a3"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_kat!(
     test_kat_des_ede3_cbc_pkcs7_32_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1636,7 +1636,7 @@ des_padded_cipher_kat!(
     "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da733830d1a78387028"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_kat!(
     test_kat_des_ede_ecb_pkcs7_32_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1648,7 +1648,7 @@ des_padded_cipher_kat!(
     "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d5db28100613ac225"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_kat!(
     test_kat_des_ede3_ecb_pkcs7_32_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1660,7 +1660,7 @@ des_padded_cipher_kat!(
     "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87832846b52f9e213d"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_rt!(
     test_rt_des_ede_cbc_pkcs7_31_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1670,7 +1670,7 @@ des_padded_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_rt!(
     test_rt_des_ede3_cbc_pkcs7_31_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,
@@ -1680,7 +1680,7 @@ des_padded_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_rt!(
     test_rt_des_ede_ecb_pkcs7_31_bytes,
     &DES_EDE_FOR_LEGACY_USE_ONLY,
@@ -1690,7 +1690,7 @@ des_padded_cipher_rt!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51"
 );
 
-#[cfg(feature = "legacy-3des")]
+#[cfg(feature = "legacy-des")]
 des_padded_cipher_rt!(
     test_rt_des_ede3_ecb_pkcs7_31_bytes,
     &DES_EDE3_FOR_LEGACY_USE_ONLY,

--- a/aws-lc-rs/tests/cmac_tests.rs
+++ b/aws-lc-rs/tests/cmac_tests.rs
@@ -140,7 +140,7 @@ fn cavp_cmac_3des_tests() {
             let input = if mlen == 0 { Vec::new() } else { msg };
             let should_pass = result.starts_with('P');
 
-            let cmac_key = cmac::Key::new(cmac::TDES_FOR_LEGACY_USE_ONLY, &combined_key).unwrap();
+            let cmac_key = cmac::Key::new(cmac::DES_EDE3_FOR_LEGACY_USE_ONLY, &combined_key).unwrap();
             let signature = cmac::sign(&cmac_key, &input).unwrap();
 
             // Truncate to tlen
@@ -164,7 +164,7 @@ fn test_sign_to_buffer_basic() {
         cmac::AES_128,
         cmac::AES_192,
         cmac::AES_256,
-        cmac::TDES_FOR_LEGACY_USE_ONLY,
+        cmac::DES_EDE3_FOR_LEGACY_USE_ONLY,
     ] {
         let key = cmac::Key::generate(*algorithm).unwrap();
         let data = b"test data for sign_to_buffer";
@@ -231,7 +231,7 @@ fn test_context_verify_basic() {
         cmac::AES_128,
         cmac::AES_192,
         cmac::AES_256,
-        cmac::TDES_FOR_LEGACY_USE_ONLY,
+        cmac::DES_EDE3_FOR_LEGACY_USE_ONLY,
     ] {
         let key = cmac::Key::generate(*algorithm).unwrap();
         let data = b"data to verify";


### PR DESCRIPTION
  ## Summary

  Extends the existing Triple DES support (from #1109) to include single DES (`DES_FOR_LEGACY_USE_ONLY`) and renames the feature flag from `legacy-3des` to `legacy-des` to reflect the broader scope. Only CBC and
  ECB operating modes are supported.

  ## Changes

  - **Add single DES cipher** (`DES_FOR_LEGACY_USE_ONLY`) with CBC and ECB modes, gated behind the `legacy-des` feature flag
  - **Rename feature flag** from `legacy-3des` to `legacy-des`
  - **Rename CMAC constant** to `DES_EDE3_FOR_LEGACY_USE_ONLY` (old name retained as deprecated alias)
  - **Improve documentation**: crate-level and module-level feature flag docs, expanded doc-comments on cipher constructors, doctest examples, clarified `Iv64` usage
  - **Add test coverage**: weak-key/semi-weak-key rejection, degenerate key configurations, unsupported mode rejection, single DES CBC/ECB KAT vectors, streaming constructor rejection tests

  ## Motivation

  Single DES and Triple DES are legacy algorithms but are still needed for interoperability with older systems. This PR consolidates all DES-family cipher support under a single `legacy-des` feature flag. All
  exposed items are marked `#[deprecated]` to produce compiler warnings at use sites.

  ## Testing

  - Added integration tests for single DES CBC and ECB (32-byte plaintext KAT vectors)
  - Added tests for weak-key and semi-weak-key rejection
  - Added tests for degenerate Triple DES key configurations (K1==K2, etc.)
  - Added tests for unsupported mode rejection (CTR, CFB128)
  - Extended streaming constructor rejection tests

  ---

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0/ISC license.