### PR TITLE
CI: support zig cross compile for arm32

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -34,6 +34,7 @@ jobs:
           - x86_64-pc-windows-gnu
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - arm-unknown-linux-gnueabihf
         include:
           - host: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary
- Adds 32-bit ARM (`arm-unknown-linux-gnueabihf`) to the cargo-zigbuild CI matrix, covering builds from all three host platforms (ubuntu, macos, windows).
- Provides CI validation for the fix reported in #931.

## Test plan
- [x] Verify the new matrix entries pass in CI across all three host platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
