### PR TITLE
fix(clippy): fix truncate warnings

### DIFF
--- a/aws-lc-rs/src/test.rs
+++ b/aws-lc-rs/src/test.rs
@@ -396,7 +396,7 @@ fn parse_test_case(
             Some(line) if line.starts_with('[') => {
                 assert!(is_first_line);
                 assert!(line.ends_with(']'));
-                current_section.truncate(0);
+                current_section.clear();
                 current_section.push_str(line);
                 let _: Option<char> = current_section.pop();
                 let _: char = current_section.remove(0);

--- a/aws-lc-rs/tests/aead_test.rs
+++ b/aws-lc-rs/tests/aead_test.rs
@@ -198,7 +198,7 @@ fn test_aead<Seal, Open>(
         let mut o_in_out = vec![123u8; 4096];
 
         for &in_prefix_len in in_prefix_lengths {
-            o_in_out.truncate(0);
+            o_in_out.clear();
             o_in_out.resize(in_prefix_len, 123);
             o_in_out.extend_from_slice(&ct[..]);
 

--- a/aws-lc-rs/tests/digest_test.rs
+++ b/aws-lc-rs/tests/digest_test.rs
@@ -58,7 +58,7 @@ mod digest_shavs {
             // length is zero.
             if len_bits == 0 {
                 assert_eq!(msg, &[0u8]);
-                msg.truncate(0);
+                msg.clear();
             }
             assert_eq!(msg.len().checked_mul(8).unwrap(), len_bits);
             let expected = test_case.consume_bytes("MD");


### PR DESCRIPTION
### Description of changes: 
Fix clippy warning about use of `truncate`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
