### PR TITLE
Implement Send/Sync for RSA hazmat encryption key types

### DIFF
--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -247,8 +247,12 @@ impl LcPtr<EVP_PKEY> {
     #[allow(non_snake_case)]
     pub(crate) fn create_EVP_PKEY_CTX(&self) -> Result<LcPtr<EVP_PKEY_CTX>, ()> {
         // The only modification made by EVP_PKEY_CTX_new to `priv_key` is to increment its
-        // refcount. The modification is made while holding a global lock:
-        // https://github.com/aws/aws-lc/blob/61503f7fe72457e12d3446853a5452d175560c49/crypto/refcount_lock.c#L29
+        // refcount. AWS-LC's refcount operations are thread-safe: lock-free `_Atomic` CAS on the
+        // C11-atomic build, `InterlockedIncrement`-style atomics on Windows, and a mutex-protected
+        // fallback otherwise. See:
+        // https://github.com/aws/aws-lc/blob/main/crypto/refcount_c11.c
+        // https://github.com/aws/aws-lc/blob/main/crypto/refcount_win.c
+        // https://github.com/aws/aws-lc/blob/main/crypto/refcount_lock.c
         LcPtr::new(unsafe { EVP_PKEY_CTX_new(self.as_mut_unsafe_ptr(), null_mut()) })
     }
 
@@ -562,8 +566,12 @@ impl LcPtr<EVP_PKEY> {
 
 impl Clone for LcPtr<EVP_PKEY> {
     fn clone(&self) -> Self {
-        // EVP_PKEY_up_ref increments the refcount while holding a global lock:
-        // https://github.com/aws/aws-lc/blob/61503f7fe72457e12d3446853a5452d175560c49/crypto/refcount_lock.c#L29
+        // EVP_PKEY_up_ref increments the refcount using AWS-LC's thread-safe refcount
+        // implementation: lock-free `_Atomic` CAS on the C11-atomic build, `InterlockedIncrement`-
+        // style atomics on Windows, and a mutex-protected fallback otherwise. See:
+        // https://github.com/aws/aws-lc/blob/main/crypto/refcount_c11.c
+        // https://github.com/aws/aws-lc/blob/main/crypto/refcount_win.c
+        // https://github.com/aws/aws-lc/blob/main/crypto/refcount_lock.c
         assert_eq!(
             1,
             unsafe { EVP_PKEY_up_ref(self.as_mut_unsafe_ptr()) },

--- a/aws-lc-rs/src/rsa/encryption.rs
+++ b/aws-lc-rs/src/rsa/encryption.rs
@@ -34,6 +34,15 @@ pub enum EncryptionAlgorithmId {
 /// An RSA private key used for decrypting ciphertext encrypted by a [`PublicEncryptingKey`].
 pub struct PrivateDecryptingKey(LcPtr<EVP_PKEY>);
 
+// https://github.com/aws/aws-lc/blob/ebaa07a207fee02bd68fe8d65f6b624afbf29394/include/openssl/evp.h#L295
+// An |EVP_PKEY| object represents a public or private RSA key. A given object may be
+// used concurrently on multiple threads by non-mutating functions, provided no
+// other thread is concurrently calling a mutating function. Unless otherwise
+// documented, functions which take a |const| pointer are non-mutating and
+// functions which take a non-|const| pointer are mutating.
+unsafe impl Send for PrivateDecryptingKey {}
+unsafe impl Sync for PrivateDecryptingKey {}
+
 impl PrivateDecryptingKey {
     fn new(evp_pkey: LcPtr<EVP_PKEY>) -> Result<Self, Unspecified> {
         Self::validate_key(&evp_pkey)?;
@@ -146,6 +155,10 @@ impl Clone for PrivateDecryptingKey {
 
 /// An RSA public key used for encrypting plaintext that is decrypted by a [`PrivateDecryptingKey`].
 pub struct PublicEncryptingKey(LcPtr<EVP_PKEY>);
+
+// See thread-safety note on `PrivateDecryptingKey`.
+unsafe impl Send for PublicEncryptingKey {}
+unsafe impl Sync for PublicEncryptingKey {}
 
 impl PublicEncryptingKey {
     pub(crate) fn new(evp_pkey: LcPtr<EVP_PKEY>) -> Result<Self, Unspecified> {

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -28,6 +28,20 @@ fn rsa_traits() {
     test::compile_time_assert_sync::<RsaPublicKeyComponents<&[u8]>>();
     test::compile_time_assert_send::<RsaPublicKeyComponents<Vec<u8>>>();
     test::compile_time_assert_sync::<RsaPublicKeyComponents<Vec<u8>>>();
+
+    // Hazmat encryption types
+    test::compile_time_assert_send::<PrivateDecryptingKey>();
+    test::compile_time_assert_sync::<PrivateDecryptingKey>();
+    test::compile_time_assert_send::<PublicEncryptingKey>();
+    test::compile_time_assert_sync::<PublicEncryptingKey>();
+    test::compile_time_assert_send::<OaepPrivateDecryptingKey>();
+    test::compile_time_assert_sync::<OaepPrivateDecryptingKey>();
+    test::compile_time_assert_send::<OaepPublicEncryptingKey>();
+    test::compile_time_assert_sync::<OaepPublicEncryptingKey>();
+    test::compile_time_assert_send::<Pkcs1PrivateDecryptingKey>();
+    test::compile_time_assert_sync::<Pkcs1PrivateDecryptingKey>();
+    test::compile_time_assert_send::<Pkcs1PublicEncryptingKey>();
+    test::compile_time_assert_sync::<Pkcs1PublicEncryptingKey>();
 }
 
 #[test]


### PR DESCRIPTION
### Issues:
Resolves #1125

### Description of changes:
Adds `unsafe impl Send` and `unsafe impl Sync` for `rsa::PrivateDecryptingKey` and `rsa::PublicEncryptingKey`. These are the only `LcPtr<EVP_PKEY>`-bearing public types in the crate that were missing these impls — the equivalent `rsa::KeyPair` (signature side), `agreement::PrivateKey`/`PublicKey`, `kem::DecapsulationKey`/`EncapsulationKey`, `EcdsaKeyPair`, `Ed25519KeyPair`, etc. all already had them. The thread-safety comment on `PrivateDecryptingKey` mirrors the one already on `rsa::KeyPair` and points at the same aws-lc `EVP_PKEY` documentation.

The four wrapper types (`OaepPrivateDecryptingKey`, `OaepPublicEncryptingKey`, `Pkcs1PrivateDecryptingKey`, `Pkcs1PublicEncryptingKey`) only contain those base types, so they pick up `Send + Sync` via auto-trait propagation without explicit impls.

### Call-outs:
The `Sync` impl is the interesting one. The encrypt/decrypt code paths (`oaep.rs`, `pkcs1.rs`) take `&self`, allocate a fresh `EVP_PKEY_CTX` per call via `create_EVP_PKEY_CTX`, and never escape it. The only mutation visible across threads on the shared `EVP_PKEY` is the refcount bump performed by `EVP_PKEY_CTX_new` / `EVP_PKEY_up_ref`, which is thread-safe — lock-free `_Atomic` CAS on the C11-atomic build (`crypto/refcount_c11.c`), `InterlockedIncrement`-style on Windows (`crypto/refcount_win.c`), and a mutex-protected fallback otherwise (`crypto/refcount_lock.c`). RSA private-key blinding state is managed internally by aws-lc with its own `CRYPTO_MUTEX`, so concurrent decrypts from the same key are well-defined.


### Testing:
Extended the existing `rsa_traits` compile-time assertion test in `tests/rsa_test.rs` to cover all six types (`PrivateDecryptingKey`, `PublicEncryptingKey`, and the four `Oaep*`/`Pkcs1*` wrappers) for both `Send` and `Sync`. This guards against future regressions of the auto-trait propagation through the wrappers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.