### PR TITLE
fix: Fix missing `poly_Rq_mul` symbol in Linux x86_64 build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,49 @@ jobs:
         working-directory: ./aws-lc-rs-testing
         run: cargo test --all-targets
 
+  # Exercises the `aws-lc-sys` crate's own integration tests under both build
+  # paths with `+whole-archive` linkage **and** dead-code preservation. The
+  # standard `aws-lc-rs-test` job above only links symbols that are reachable
+  # from `aws-lc-rs`'s test code; because of static-archive linker semantics,
+  # missing assembly source files in the cc_builder source lists go undetected
+  # when nothing in `aws-lc-rs` references the affected object file.
+  #
+  # `AWS_LC_SYS_LINK_WHOLE_ARCHIVE=1` forces every member of `libcrypto.a`
+  # into the link (`-l static:+whole-archive=...`), but that alone is not
+  # enough: rustc enables section GC by default (`--gc-sections` on Linux,
+  # `-dead_strip` on Apple), and section GC runs before final symbol
+  # resolution, silently dropping unreferenced objects together with their
+  # unresolved internal references. `RUSTFLAGS=-C link-dead-code=yes` tells
+  # rustc not to enable section GC, so any unresolved symbol inside the
+  # archive becomes a link error. The two settings together provide a
+  # generic guarantee that every internal symbol reference resolves.
+  aws-lc-sys-link-test:
+    if: github.repository_owner == 'aws'
+    name: aws-lc-sys link tests (${{ matrix.os }} / cmake=${{ matrix.cmake }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ stable ]
+        os: [ ubuntu-latest, macos-15-intel, macos-latest, ubuntu-24.04-arm ]
+        cmake: [ '0', '1' ]
+    env:
+      AWS_LC_SYS_CMAKE_BUILDER: ${{ matrix.cmake }}
+      AWS_LC_SYS_LINK_WHOLE_ARCHIVE: '1'
+      RUSTFLAGS: '-C link-dead-code=yes'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Set Rust toolchain override
+        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Run aws-lc-sys sanity tests
+        run: cargo test -p aws-lc-sys --tests
+
   bindgen-test:
     if: github.repository_owner == 'aws'
     name: aws-lc-rs bindgen-tests

--- a/aws-lc-sys/scripts/cc_builder/linux_x86_64.sh
+++ b/aws-lc-sys/scripts/cc_builder/linux_x86_64.sh
@@ -16,6 +16,11 @@ mapfile -O 0 -t SOURCE_FILES < <(find crypto/fipsmodule/ml_kem/mlkem/native/x86_
 echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src -name "*.S" -type f | sort -f)
 echo "${SOURCE_FILES[@]}"
+# HRSS provides an AVX2 polynomial multiplication routine in hand-written
+# assembly. CMake includes this via crypto/CMakeLists.txt's CRYPTO_ARCH_SOURCES;
+# we mirror it here so the cc_builder produces an equivalent libcrypto.
+mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find crypto/hrss/asm -name "*.S" -type f | sort -f)
+echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(find generated-src/linux-x86_64/crypto -name "*.S" -type f  | sort -f)
 echo "${SOURCE_FILES[@]}"
 mapfile -O ${#SOURCE_FILES[@]} -t SOURCE_FILES < <(s2n_bignum_x86_64)

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -20,9 +20,9 @@ mod win_x86_64;
 use crate::nasm_builder::NasmBuilder;
 use crate::{
     cargo_env, emit_warning, env_var_to_bool, execute_command, find_clang_cl, get_crate_cc,
-    get_crate_cflags, get_crate_cxx, is_no_asm, out_dir, requested_c_std, set_env_for_target,
-    should_build_jitter_entropy, target, target_arch, target_env, target_os, target_vendor,
-    CStdRequested, EnvGuard, OutputLibType,
+    get_crate_cflags, get_crate_cxx, is_link_whole_archive, is_no_asm, out_dir, requested_c_std,
+    set_env_for_target, should_build_jitter_entropy, target, target_arch, target_env, target_os,
+    target_vendor, CStdRequested, EnvGuard, OutputLibType,
 };
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -629,10 +629,31 @@ impl CcBuilder {
         self.run_compiler_checks(&mut cc_build);
 
         self.add_all_files(sources, &mut cc_build);
-        if let Some(prefix) = &self.build_prefix {
-            cc_build.compile(format!("{}_crypto", prefix.as_str()).as_str());
+
+        let lib_name = if let Some(prefix) = &self.build_prefix {
+            format!("{}_crypto", prefix.as_str())
         } else {
-            cc_build.compile("crypto");
+            "crypto".to_string()
+        };
+
+        // When whole-archive linking is requested, suppress cc-rs's automatic
+        // emission of `cargo:rustc-link-{lib,search}=` so we can emit our own
+        // directives with the `+whole-archive` modifier (which cc-rs has no
+        // way to express). cc still performs the actual compilation and
+        // archive creation; only the metadata output is silenced.
+        if is_link_whole_archive() {
+            cc_build.cargo_metadata(false);
+        }
+        cc_build.compile(&lib_name);
+        if is_link_whole_archive() {
+            emit_warning(format!(
+                "AWS_LC_SYS_LINK_WHOLE_ARCHIVE set: linking '{lib_name}' with +whole-archive"
+            ));
+            println!("cargo:rustc-link-search=native={}", self.out_dir.display());
+            println!(
+                "cargo:rustc-link-lib={}={lib_name}",
+                self.output_lib_type.rust_link_lib_kind()
+            );
         }
     }
 

--- a/builder/cc_builder/linux_x86_64.rs
+++ b/builder/cc_builder/linux_x86_64.rs
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-// Fri May  8 22:13:15 UTC 2026
+// Thu May 21 19:28:12 UTC 2026
 
 pub(super) const CRYPTO_LIBRARY: &[&str] = &[
-    "crypto/hrss/asm/poly_rq_mul.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/intt.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/mulcache_compute.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/ntt.S",
@@ -24,6 +23,7 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/reduce.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/rej_uniform_asm.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/tomont.S",
+    "crypto/hrss/asm/poly_rq_mul.S",
     "generated-src/linux-x86_64/crypto/chacha/chacha-x86_64.S",
     "generated-src/linux-x86_64/crypto/cipher_extra/aes128gcmsiv-x86_64.S",
     "generated-src/linux-x86_64/crypto/cipher_extra/aesni-sha1-x86_64.S",

--- a/builder/cc_builder/linux_x86_64.rs
+++ b/builder/cc_builder/linux_x86_64.rs
@@ -3,6 +3,7 @@
 // Fri May  8 22:13:15 UTC 2026
 
 pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+    "crypto/hrss/asm/poly_rq_mul.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/intt.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/mulcache_compute.S",
     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/ntt.S",

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -684,14 +684,14 @@ impl crate::Builder for CmakeBuilder {
 
         println!(
             "cargo:rustc-link-lib={}={}",
-            self.output_lib_type.rust_lib_type(),
+            self.output_lib_type.rust_link_lib_kind(),
             Crypto.libname(&self.build_prefix)
         );
 
         if cfg!(feature = "ssl") {
             println!(
                 "cargo:rustc-link-lib={}={}",
-                self.output_lib_type.rust_lib_type(),
+                self.output_lib_type.rust_link_lib_kind(),
                 Ssl.libname(&self.build_prefix)
             );
         }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -293,6 +293,22 @@ impl OutputLibType {
             OutputLibType::Dynamic => "dylib",
         }
     }
+
+    /// Returns the `kind` portion of a `cargo:rustc-link-lib=<kind>=<name>`
+    /// directive, including the `+whole-archive` modifier when whole-archive
+    /// linking has been requested for a static library.
+    ///
+    /// Whole-archive linking forces the linker to include every object file
+    /// from the static archive, which surfaces unresolved symbol references
+    /// inside object files that no consumer happens to call. We use it in CI
+    /// to catch missing assembly source files in the `cc_builder` source lists.
+    fn rust_link_lib_kind(self) -> String {
+        if matches!(self, OutputLibType::Static) && is_link_whole_archive() {
+            format!("{}:+whole-archive", self.rust_lib_type())
+        } else {
+            self.rust_lib_type().to_string()
+        }
+    }
 }
 
 impl OutputLib {
@@ -617,6 +633,7 @@ static mut SYS_NO_JITTER_ENTROPY: Option<bool> = None;
 static mut SYS_NO_U1_BINDINGS: Option<bool> = None;
 static mut SYS_INCLUDES: Option<Vec<PathBuf>> = None;
 static mut SYS_SANITIZER: Option<String> = None;
+static mut SYS_LINK_WHOLE_ARCHIVE: bool = false;
 
 static mut SYS_C_STD: CStdRequested = CStdRequested::None;
 
@@ -637,6 +654,7 @@ fn initialize() {
         SYS_INCLUDES =
             optional_env_crate_target("INCLUDES").map(|v| std::env::split_paths(&v).collect());
         SYS_SANITIZER = optional_env_crate_target("SANITIZER").map(|v| v.to_lowercase());
+        SYS_LINK_WHOLE_ARCHIVE = env_crate_var_to_bool("LINK_WHOLE_ARCHIVE").unwrap_or(false);
     }
 
     assert!(
@@ -754,6 +772,22 @@ fn is_cmake_builder() -> Option<bool> {
 
 fn is_no_pregenerated_src() -> bool {
     unsafe { SYS_NO_PREGENERATED_SRC }
+}
+
+/// Returns true when the build script should ask rustc to link the produced
+/// `libcrypto` archive with the `+whole-archive` modifier. This is intended
+/// for CI use only and is enabled via `AWS_LC_SYS_LINK_WHOLE_ARCHIVE=1`.
+///
+/// `+whole-archive` on its own is necessary but not sufficient to catch
+/// missing internal symbol references: the linker may still strip
+/// unreferenced sections (Linux/LLD: `--gc-sections`; Apple ld:
+/// `-dead_strip`) before final symbol resolution, so unresolved references
+/// inside dead-stripped objects never produce link errors. To make this
+/// flag effective, callers should also set `RUSTFLAGS="-C link-dead-code=yes"`
+/// to tell rustc not to enable section GC. The CI job that exercises this
+/// flag does both.
+fn is_link_whole_archive() -> bool {
+    unsafe { SYS_LINK_WHOLE_ARCHIVE }
 }
 
 fn disable_jitter_entropy() -> Option<bool> {


### PR DESCRIPTION
### Summary

This PR fixes a linking error where the symbol `aws_lc_*_poly_Rq_mul` was undefined when building aws-lc-sys on Linux x86_64 with AVX2 support.

### Root Cause

The `poly_Rq_mul` function is called from `crypto/hrss/hrss.c`, which is included in the build via `universal.rs`. However, the AVX2-optimized assembly implementation in `crypto/hrss/asm/poly_rq_mul.S` was **not included** in the `linux_x86_64::CRYPTO_LIBRARY` source list, causing the linker to fail with:

```
ld: error: undefined symbol: aws_lc_0_40_0_poly_Rq_mul
>>> referenced by hrss.c
```

### Changes Made

| File | Change |
|------|--------|
| [builder/cc_builder/linux_x86_64.rs](file:///home/lebei/dev/perryts/aws-lc-rs/builder/cc_builder/linux_x86_64.rs) | Added `"crypto/hrss/asm/poly_rq_mul.S"` to `CRYPTO_LIBRARY` |

### Testing

1. Verified the fix resolves the linking error in Perry projects using aws-lc-sys
2. The assembly file exists in the aws-lc submodule at `aws-lc/crypto/hrss/asm/poly_rq_mul.S`
3. Symbol is properly exported in `symbols/x86_64-unknown-linux-gnu.txt`

### Impact

This fix is backwards-compatible and only affects Linux x86_64 builds. The assembly file provides AVX2-optimized polynomial multiplication for the HRSS signature scheme.