### PR TITLE
ci: replace dtolnay/rust-toolchain with direct rustup invocations

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,13 +31,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: rustfmt
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component rustfmt --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
 
       - name: Run cargo fmt
         run: cargo fmt -- --check --verbose
@@ -58,13 +55,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: clippy
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component clippy --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Run cargo clippy
         working-directory: ${{ matrix.crate_dir }}
         run: cargo clippy ${{ matrix.features }} --all-targets -- -W clippy::all -W clippy::pedantic -D warnings
@@ -84,12 +78,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Install cargo-public-api
         run: cargo install --locked cargo-public-api
       - name: Perform API Diff (Target Branch)
@@ -126,12 +118,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Install cargo-udeps
         run: cargo install cargo-udeps
 
@@ -153,7 +143,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Run cargo tree
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
@@ -185,12 +176,10 @@ jobs:
         with:
           submodules: 'recursive'
           lfs: true
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Setup to use minimal versions
         working-directory: ./${{ matrix.crate }}
         run: cargo update -Z minimal-versions
@@ -221,12 +210,10 @@ jobs:
     if: github.repository_owner == 'aws'
     runs-on: ubuntu-latest
     steps:
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -254,10 +241,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: nightly
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup default nightly
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -271,10 +258,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: nightly
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup default nightly
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -301,10 +288,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: nightly
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup default nightly
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -338,7 +325,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
       - name: Run debug tests under Valgrind
@@ -368,7 +356,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Install readelf
         run: sudo apt-get update && sudo apt-get install -y binutils
       - name: Build project

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -72,10 +72,10 @@ jobs:
           git fetch origin ${{ github.sha }}
           git checkout --recurse-submodules -b ci-job ${{ github.sha }}
           gcc --version
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
@@ -160,10 +160,10 @@ jobs:
           git fetch origin ${{ github.sha }}
           git checkout --recurse-submodules -b ci-job ${{ github.sha }}
           gcc --version
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
@@ -222,10 +222,10 @@ jobs:
           git fetch origin ${{ github.sha }}
           git checkout --recurse-submodules -b ci-job ${{ github.sha }}
           gcc --version
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
@@ -286,10 +286,10 @@ jobs:
           git fetch origin ${{ github.sha }}
           git checkout --recurse-submodules -b ci-job ${{ github.sha }}
           gcc --version
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
@@ -319,10 +319,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         env:

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -69,19 +69,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "stable"
+      - name: Install stable Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ (matrix.target[2] == '0' && 'stable') || 'nightly' }}
-          target: ${{ (matrix.target[2] == '0' && matrix.target[0]) || '' }}
-          components: ${{ (matrix.target[2] == '0' && '') || 'rust-src' }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain for ${{ matrix.target[0] }}
+        run: |
+          if [[ '${{ matrix.target[2] }}' == '0' ]]; then
+            rustup toolchain install stable --profile minimal --target ${{ matrix.target[0] }} --no-self-update
+            rustup default stable
+          else
+            rustup toolchain install nightly --profile minimal --component rust-src --no-self-update
+            rustup default nightly
+          fi
       - if: ${{ !startsWith(matrix.target[0], 'x86_64') }}
         run: |
           echo 'AWS_LC_RS_DISABLE_SLOW_TESTS=1' >> "$GITHUB_ENV"
@@ -149,9 +151,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          target: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
       - name: Install Android NDK
         uses: nttld/setup-ndk@v1
         id: setup-ndk
@@ -215,18 +218,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "stable"
+      - name: Install stable Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: "stable"
-          target: ${{ matrix.target[0] }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain for ${{ matrix.target[0] }}
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target[0] }} --no-self-update
+          rustup default stable
       - if: ${{ !startsWith(matrix.target[0], 'x86_64') }}
         run: |
           echo 'AWS_LC_RS_DISABLE_SLOW_TESTS=1' >> "$GITHUB_ENV"
@@ -249,18 +250,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "stable"
+      - name: Install stable Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install cross
         run: cargo install cross --locked --version 0.2.5
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: "stable"
-          target: ${{ matrix.target }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain for ${{ matrix.target }}
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
       - if: ${{ !startsWith(matrix.target[0], 'x86_64') }}
         run: |
           echo 'AWS_LC_RS_DISABLE_SLOW_TESTS=1' >> "$GITHUB_ENV"
@@ -282,11 +281,10 @@ jobs:
           go-version: '>=1.18'
       - run: |
           brew install llvm
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
-          target: aarch64-apple-ios-sim
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target aarch64-apple-ios-sim --no-self-update
+          rustup default stable
       - name: Install bash
         run: brew install bash
       - name: iOS Simulator Runner
@@ -304,10 +302,10 @@ jobs:
           submodules: "recursive"
       - run: |
           brew install llvm
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: rust-src
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --component rust-src --no-self-update
+          rustup default nightly
       - name: Install bash, coreutils
         run: brew install bash coreutils
       - name: tvOS Simulator Runner
@@ -323,11 +321,10 @@ jobs:
           submodules: "recursive"
       - run: |
           brew install llvm
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
-          target: x86_64-apple-ios
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-apple-ios --no-self-update
+          rustup default stable
       - name: Debug build for `x86_64-apple-ios`
         run: cargo build -p aws-lc-rs --target x86_64-apple-ios --features bindgen
       - name: Release build for `x86_64-apple-ios`
@@ -363,10 +360,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
       - name: Install cargo-xwin
         run: cargo install --locked cargo-xwin
       - name: Set RUSTFLAGS
@@ -433,11 +430,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
       - name: Set ACTION_CARGO
         run: |
           if ('${{ matrix.target }}' -like '*aarch64*') {
@@ -529,11 +525,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-        with:
-          toolchain: "stable"
-          target: x86_64-pc-windows-gnu
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-gnu --no-self-update
+          rustup default stable
       - name: Install mingw
         run: sudo apt-get update && sudo apt-get install --assume-yes mingw-w64
       - name: Run cargo test

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,12 +26,9 @@ jobs:
           persist-credentials: false
           submodules: 'recursive'
       - name: Install Nightly Rust Toolchain
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'

--- a/.github/workflows/fips-bindings-generator.yml
+++ b/.github/workflows/fips-bindings-generator.yml
@@ -37,9 +37,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.18'
@@ -68,9 +69,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.18'
@@ -95,12 +97,11 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchains
+        run: |
+          rustup toolchain install ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.18'
@@ -123,9 +124,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.18'
@@ -152,9 +154,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install cross
         run: cargo install cross --locked --git https://github.com/cross-rs/cross
       - name: Generate bindings for ${{ matrix.target }}

--- a/.github/workflows/fips.yml
+++ b/.github/workflows/fips.yml
@@ -48,12 +48,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -90,12 +88,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install ninja-build tool
         uses: seanmiddleditch/gha-setup-ninja@v6
       - name: Run cargo test
@@ -111,10 +107,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: nightly
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup default nightly
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,10 +37,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Run s2n-quic integration
         working-directory: ./aws-lc-rs
         run: |
@@ -59,10 +59,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install cargo-download
         run: cargo install cargo-download cargo-show
       - name: Run rustls integration
@@ -84,10 +84,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: run-windows-debug-crt-static-test
         working-directory: ./aws-lc-rs
         shell: bash
@@ -106,10 +106,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: install bindgen-cli
         run: cargo install --force --locked bindgen-cli
       - uses: ilammy/setup-nasm@v1
@@ -138,10 +138,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        id: toolchain
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install NASM on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
@@ -224,12 +224,10 @@ jobs:
       - name: Install ninja-build tool
         if: ${{ matrix.os == 'windows-latest' }}
         uses: seanmiddleditch/gha-setup-ninja@v6
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
       - name: ${{ matrix.crate }}
         working-directory: ./${{ matrix.crate }}
         run: cargo ${{ matrix.args }}
@@ -267,12 +265,10 @@ jobs:
       - name: Install ninja-build tool
         if: ${{ matrix.os == 'windows-latest' }}
         uses: seanmiddleditch/gha-setup-ninja@v6
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
       - name: aws-lc-rs
         working-directory: ./aws-lc-rs
         run: cargo ${{ matrix.args }}
@@ -299,12 +295,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Remove NASM
         shell: bash
         run: |
@@ -351,12 +345,10 @@ jobs:
       # all editions and its MSRV-aware resolver automatically prefers dependency
       # versions compatible with our declared rust-version.
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Install MSRV Rust version
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.71.0
+        run: rustup toolchain install 1.71.0 --profile minimal --no-self-update
 
       # Use stable Cargo with MSRV-aware resolver to generate a lockfile that
       # respects our rust-version. The "fallback" policy tells Cargo to prefer

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -81,9 +81,9 @@ jobs:
           submodules: 'recursive'
 
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+        run: |
+          rustup toolchain install nightly --profile minimal --no-self-update
+          rustup default nightly
 
       - name: Install cargo-docs-rs
         run: cargo install cargo-docs-rs
@@ -103,7 +103,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Run unsealed_rand_test with env var
         env:

--- a/.github/workflows/pregen-bindings.yml
+++ b/.github/workflows/pregen-bindings.yml
@@ -32,11 +32,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          # Our aws-lc-sys generation scripts require nightly.
-          toolchain: ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
-      - run: rustup override set $RUST_NIGHTLY_TOOLCHAIN
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
       - name: Install rust-script
         run: cargo install rust-script
       - name: Install OS Dependencies
@@ -78,11 +77,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          # Our aws-lc-fips-sys generation scripts require nightly.
-          toolchain: ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
-      - run: rustup override set $RUST_NIGHTLY_TOOLCHAIN
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
       - name: Install rust-script
         run: cargo install rust-script
       - name: Install OS Dependencies

--- a/.github/workflows/sys-bindings-generator.yml
+++ b/.github/workflows/sys-bindings-generator.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.20'
@@ -75,12 +75,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        id: toolchain
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --component rustfmt --no-self-update
+          rustup default stable
       - if: contains(matrix.target, 'x86') || contains(matrix.target, 'i686')
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -119,10 +117,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.20'
@@ -147,14 +145,11 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          components: 'rustfmt'
-          toolchain: ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchains
+        run: |
+          rustup toolchain install ${{ env.RUST_SCRIPT_NIGHTLY_TOOLCHAIN }} --profile minimal --component rustfmt --no-self-update
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.20'
@@ -177,10 +172,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - name: Install current Bash on macOS
         if: runner.os == 'macOS'
         run: brew install bash coreutils
@@ -208,12 +203,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        id: toolchain
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --component rustfmt --no-self-update
+          rustup default stable
       - if: contains(matrix.target, 'x86') || contains(matrix.target, 'i686')
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -246,10 +239,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - name: Install cross
         run: cargo install cross --locked --git https://github.com/cross-rs/cross
       - name: Generate bindings for ${{ matrix.target }}
@@ -272,10 +265,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - name: Install current Bash on macOS
         if: runner.os == 'macOS'
         run: brew install bash coreutils
@@ -307,10 +300,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
       - name: Install ripgrep
         run: cargo install --force --locked ripgrep --features pcre2
       - name: Collect source
@@ -329,12 +322,10 @@ jobs:
         with:
           submodules: 'recursive'
           ref: ${{ github.ref_name }}
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        id: toolchain
-        with:
-          toolchain: stable
-          targets: "x86_64-pc-windows-msvc,x86_64-pc-windows-gnu"
-          components: 'rustfmt'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-msvc --target x86_64-pc-windows-gnu --component rustfmt --no-self-update
+          rustup default stable
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - name: Build aws-lc-sys
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,12 +46,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
@@ -80,12 +78,10 @@ jobs:
           brew install llvm
           echo 'LIBCLANG_PATH=${{ (matrix.os == 'macos-15-intel' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/lib' >> $GITHUB_ENV
           echo 'LLVM_CONFIG_PATH=${{ (matrix.os == 'macos-15-intel' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
@@ -113,12 +109,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ matrix.rust }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --no-self-update
+          rustup default ${{ matrix.rust }}
       - name: Run cargo test
         working-directory: ./aws-lc-rs
         run: cargo test ${{ matrix.args }}
@@ -133,13 +127,10 @@ jobs:
           submodules: 'recursive'
           lfs: true
 
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: llvm-tools-preview
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component llvm-tools-preview --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
@@ -173,12 +164,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Run address sanitizers
         env:
           ASAN_OPTIONS: detect_leaks=1
@@ -203,13 +192,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: rust-src
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component rust-src --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Run memory sanitizers
         env:
           AWS_LC_SYS_SANITIZER: msan
@@ -237,13 +223,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: rust-src
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component rust-src --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Run thread sanitizers
         env:
           AWS_LC_SYS_SANITIZER: tsan
@@ -268,7 +251,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Run cargo test
         # Doc-tests fail to link with dynamic build
         # See: https://github.com/rust-lang/cargo/issues/8531
@@ -288,7 +274,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Remove NASM
         shell: bash
         run: |
@@ -323,7 +312,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Remove NASM
         shell: bash
         run: |
@@ -362,7 +354,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install NASM
         uses: ilammy/setup-nasm@v1
       - name: Remove NASM artifacts
@@ -390,7 +385,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Build with clang-cl hidden from PATH
         shell: pwsh
         run: |
@@ -431,7 +429,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Install bindgen-cli
         run: cargo install --locked bindgen-cli
       - name: Remove bindings
@@ -455,9 +456,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          target: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
       - uses: ilammy/setup-nasm@v1
       - name: Install bindgen-cli
         run: cargo install --locked bindgen-cli
@@ -495,7 +497,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -516,7 +521,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Run cargo test
         run: cargo test -p aws-lc-rs
       - name: Release build
@@ -551,7 +559,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -594,7 +605,10 @@ jobs:
         uses: ilammy/setup-nasm@v1
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: seanmiddleditch/gha-setup-ninja@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -625,18 +639,15 @@ jobs:
           lfs: true
       - name: Install cargo-careful
         run: cargo install cargo-careful
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: 'rust-src'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component rust-src --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install llvm
           echo 'LIBCLANG_PATH=${{ (matrix.os == 'macos-15-intel' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/lib' >> $GITHUB_ENV
           echo 'LLVM_CONFIG_PATH=${{ (matrix.os == 'macos-15-intel' && '/usr/local') || '/opt/homebrew' }}/opt/llvm/bin/llvm-config' >> $GITHUB_ENV
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -662,10 +673,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - run: |
           brew update
           brew uninstall --force llvm
@@ -699,7 +710,10 @@ jobs:
           path: "path has spaces/aws-lc-rs"
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/setup-nasm@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: seanmiddleditch/gha-setup-ninja@v6
       - uses: actions/setup-go@v6
         with:
@@ -735,7 +749,10 @@ jobs:
           rm -rf ./aws-lc-sys/aws-lc/generated-src/*
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/setup-nasm@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: seanmiddleditch/gha-setup-ninja@v6
       - uses: actions/setup-go@v6
         with:
@@ -776,7 +793,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - uses: actions/setup-go@v6
         with:
           go-version: '>=1.18'
@@ -810,7 +830,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Run tests
         run: cargo test -p aws-lc-rs --all-targets
 
@@ -822,7 +845,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Replace include files with symlinks
         run: |
           # Simulate build environments (Bazel, Nix) where source files in
@@ -858,7 +884,10 @@ jobs:
           submodules: 'recursive'
       - if: ${{ matrix.os == 'windows-latest' }}
         uses: ilammy/setup-nasm@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Remove other universal bindings
         shell: bash
         run: |
@@ -889,13 +918,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-          components: rustc-codegen-cranelift-preview
-      - name: Set Rust toolchain override
-        run: rustup override set ${{ steps.toolchain.outputs.name }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component rustc-codegen-cranelift-preview --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       - name: Remove other universal bindings
         shell: bash
         run: |

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -51,9 +51,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
       - uses: mlugg/setup-zig@v2
         with:
           version: "0.15.2"


### PR DESCRIPTION

### Description of changes:
All CI jobs started failing because the `dtolnay/rust-toolchain` GitHub Action can no longer be fetched (`An action could not be found at the URI ...`). Per the [GitHub Actions Rust documentation](https://docs.github.com/en/actions/tutorials/build-and-test-code/rust), the recommended approach is to drive `rustup` directly — it's already installed on GitHub-hosted runners.

Every `dtolnay/rust-toolchain@*` invocation across 12 workflow files is replaced with the equivalent `rustup toolchain install ... --profile minimal --no-self-update` + `rustup default` pair. The redundant `rustup override set ${{ steps.toolchain.outputs.name }}` follow-ups are dropped since `rustup default` covers the same need.

For the container-based jobs in `compilers.yml` (bare `ubuntu:18.04` / `ubuntu:20.04` / `arm64v8/ubuntu:*` images that don't have rustup pre-installed), we bootstrap rustup via `rustup-init` from `sh.rustup.rs` — replicating what the dtolnay action was doing internally.

### Call-outs:
- The matrix-driven conditional toolchain in `cross.yml`'s `aws-lc-rs-cross-test` job (stable+target vs. nightly+rust-src, keyed on `matrix.target[2]`) became an `if`/`else` shell block since rustup arguments aren't trivially expressible as a single matrix-templated command.
- `pregen-bindings.yml` had a latent issue: both jobs installed `RUST_SCRIPT_NIGHTLY_TOOLCHAIN` and then ran `rustup override set $RUST_NIGHTLY_TOOLCHAIN` — overriding to a variable that wasn't used for the install. It happened to work because both env vars resolve to `nightly`. The replacement uses `RUST_SCRIPT_NIGHTLY_TOOLCHAIN` consistently.
- The bindings-generator workflows previously SHA-pinned `dtolnay/rust-toolchain@e97e2d8...`. SHA pinning no longer applies since we're invoking the runner-installed `rustup` binary directly.

### Testing:
CI itself is the test. All 13 workflow YAML files parse cleanly via `ruby -ryaml`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
