### PR TITLE
Fix memcmp_check build failure when CFLAGS contains LTO flags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -809,6 +809,38 @@ jobs:
           export ${{ matrix.env_name }}="${{ matrix.env_value }}"
           cargo test -p aws-lc-rs --all-targets --features fips
 
+  windows-hostile-environment:
+    if: github.repository_owner == 'aws'
+    name: Windows hostile env - CC=${{ matrix.cc }} CFLAGS=${{ matrix.cflags }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cc: clang
+            cxx: clang++
+            cflags: '-flto=thin'
+          - cc: clang
+            cxx: clang++
+            cflags: '-flto=thin -march=native'
+    runs-on: windows-latest
+    env:
+      AWS_LC_SYS_PREBUILT_NASM: 1
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+      - name: Install Rust
+        shell: pwsh
+        run: rustup toolchain install stable --profile minimal
+      - name: Run cargo build
+        shell: pwsh
+        run: |
+          $env:CC='${{ matrix.cc }}'
+          $env:CXX='${{ matrix.cxx }}'
+          $env:AR='llvm-lib'
+          $env:CFLAGS='${{ matrix.cflags }}'
+          cargo build -p aws-lc-rs
+
   hardened-environment:
     if: github.repository_owner == 'aws'
     name: Hardened environment

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -405,9 +405,15 @@ impl CcBuilder {
             build_options.push(BuildOption::define("NOMINMAX", ""));
         }
 
+        // Suppress MSVC CRT deprecation warnings (fopen, getenv, strerror, etc.).
+        // This applies to any compiler targeting the MSVC environment since the
+        // warnings originate from the Windows SDK/CRT headers, not the compiler.
+        if target_env() == "msvc" {
+            build_options.push(BuildOption::define("_CRT_SECURE_NO_WARNINGS", "1"));
+        }
+
         if is_like_msvc {
             build_options.push(BuildOption::define("_HAS_EXCEPTIONS", "0"));
-            build_options.push(BuildOption::define("_CRT_SECURE_NO_WARNINGS", "0"));
             build_options.push(BuildOption::define(
                 "_STL_EXTRA_DISABLED_WARNINGS",
                 "4774 4987",
@@ -715,13 +721,17 @@ impl CcBuilder {
             // The logic below assumes a Clang or GCC compiler is in use
             return;
         }
-        let mut memcmp_compile_args = Vec::from(memcmp_compiler.args());
+        // Only pass -O3 to trigger the optimization bug. We intentionally ignore
+        // CFLAGS here — this check is about compiler behavior at high optimization
+        // levels, not about the user's build configuration. Arbitrary CFLAGS can
+        // cause unrelated compile/link failures (e.g., -flto=thin on Windows
+        // requires -fuse-ld=lld). This matches the CMake build which only passes
+        // CMAKE_C_FLAGS_RELEASE (-O3) to check_run().
+        let mut memcmp_compile_args: Vec<std::ffi::OsString> = vec!["-O3".into()];
 
-        // This check invokes the compiled executable and hence needs to link
-        // it. CMake handles this via LDFLAGS but `cc` doesn't. In setups with
-        // custom linker setups this could lead to a mismatch between the
-        // expected and the actually used linker. Explicitly respecting LDFLAGS
-        // here brings us back to parity with CMake.
+        // Respect LDFLAGS for custom linker configurations. This check produces
+        // an executable, so the linker must be reachable. LDFLAGS may contain
+        // necessary flags like library search paths or linker selection.
         if let Ok(ldflags) = std::env::var("LDFLAGS") {
             for flag in ldflags.split_whitespace() {
                 memcmp_compile_args.push(flag.into());

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -16,6 +16,8 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use crate::is_lto_flag;
+
 /// Strip LTO-related flags from a CFLAGS string. LTO flags interfere with the
 /// FIPS delocator pipeline, which compiles C to assembly (`-S`) and processes it
 /// with a Go tool. The combination of `-S` and `-flto` causes GCC to produce
@@ -26,11 +28,7 @@ use std::str::FromStr;
 fn strip_lto_flags(cflags: &str) -> String {
     cflags
         .split_whitespace()
-        .filter(|flag| {
-            !flag.starts_with("-flto")
-                && *flag != "-ffat-lto-objects"
-                && *flag != "-fno-fat-lto-objects"
-        })
+        .filter(|flag| !is_lto_flag(flag))
         .collect::<Vec<_>>()
         .join(" ")
 }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -359,6 +359,14 @@ pub(crate) struct TestCommandResult {
     status: bool,
 }
 
+/// Returns true if the given flag is an LTO-related compiler flag.
+/// Used to filter out LTO flags from checks/builds where they are unnecessary
+/// or cause toolchain-specific failures (e.g., Clang on Windows requires
+/// `-fuse-ld=lld` for LTO linking).
+pub(crate) fn is_lto_flag(flag: &str) -> bool {
+    flag.starts_with("-flto") || flag == "-ffat-lto-objects" || flag == "-fno-fat-lto-objects"
+}
+
 const MAX_CMD_OUTPUT_SIZE: usize = 1 << 15;
 fn execute_command(executable: &OsStr, args: &[&OsStr]) -> TestCommandResult {
     if let Ok(mut result) = Command::new(executable).args(args).output() {
@@ -1466,5 +1474,26 @@ mod tests {
     #[test]
     fn test_version_constant_exists() {
         assert!(!VERSION.is_empty(), "VERSION should not be empty");
+    }
+
+    // -------------------------------------------------------------------------
+    // is_lto_flag tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_is_lto_flag() {
+        assert!(is_lto_flag("-flto"));
+        assert!(is_lto_flag("-flto=thin"));
+        assert!(is_lto_flag("-flto=full"));
+        assert!(is_lto_flag("-flto=auto"));
+        assert!(is_lto_flag("-flto=4"));
+        assert!(is_lto_flag("-ffat-lto-objects"));
+        assert!(is_lto_flag("-fno-fat-lto-objects"));
+
+        assert!(!is_lto_flag("-O3"));
+        assert!(!is_lto_flag("-march=native"));
+        assert!(!is_lto_flag("-ffunction-sections"));
+        assert!(!is_lto_flag("-fdata-sections"));
+        assert!(!is_lto_flag("-fuse-ld=lld"));
     }
 }


### PR DESCRIPTION
### Issues:
Addresses:
* #1132

### Description of changes:
The `memcmp_check` in the cc-builder path was inheriting all user-supplied `CFLAGS` (via `cc::Build::default().get_compiler().args()`). This causes unrelated compile/link failures when CFLAGS contains flags like `-flto=thin` — Clang on Windows refuses to LTO-link without `-fuse-ld=lld`.

Instead of filtering individual problematic flags, this change ignores CFLAGS entirely and only passes `-O3` — the sole flag needed to trigger the GCC memcmp bug this check detects. This matches the CMake build which only passes `CMAKE_C_FLAGS_RELEASE` (`-O3`) to `check_run()`. LDFLAGS is still respected for environments where the linker needs explicit configuration.

Additionally, `_CRT_SECURE_NO_WARNINGS` was only defined for MSVC-like compilers (`cl.exe`/`clang-cl`). When using `CC=clang` targeting `x86_64-pc-windows-msvc`, the CRT headers still emit deprecation warnings for `fopen`, `getenv`, `strerror`, etc. This is now defined for all compilers targeting the MSVC environment (`target_env() == "msvc"`).

### Call-outs:
The previous `memcmp_check` code used `memcmp_compiler.args()` which included cc-crate-computed flags (`-m64`, `--target=...`, `-ffunction-sections`) in addition to CFLAGS. We're dropping all of these. This is safe because the check already gates on `HOST == TARGET`, so the compiler's default target is correct without explicit flags — matching the CMake behavior.

Also extracts a shared `is_lto_flag()` predicate into `main.rs`, used by `cmake_builder`'s `strip_lto_flags()`.

### Testing:
Unit test added for `is_lto_flag`. Full `builder-test` suite passes (11 tests). Both `aws-lc-sys` and `aws-lc-fips-sys` compile cleanly. New `windows-hostile-environment` CI job added to catch regressions with `CC=clang AR=llvm-lib CFLAGS='-flto=thin'` on Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
