### PR TITLE
ci(compilers): retry-tolerant curl, latest Go, drop unused PowerShell

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -18,6 +18,19 @@ env:
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly
   DEBIAN_FRONTEND: noninteractive
+  # Pinned versions of tools we install via curl in container jobs.
+  # Hoisted here so updates are a single edit instead of four.
+  GO_VERSION: 1.26.3
+  # Standard curl flags for fetching tool tarballs/scripts in container jobs.
+  # -f: fail (non-zero exit) on HTTP errors instead of writing an HTML error
+  #     page to disk and confusingly failing the next tar/sh step.
+  # --retry / --retry-delay: ride out transient blips on go.dev, github.com
+  #     releases, and sh.rustup.rs. curl's default --retry behavior already
+  #     covers timeouts and HTTP 408/429/5xx, which is the failure mode we
+  #     actually see. (Note: --retry-all-errors would be nice-to-have but
+  #     was added in curl 7.71.0 and is unavailable on the ubuntu:18.04 and
+  #     ubuntu:20.04 containers used here.)
+  CURL_RETRY_FLAGS: "-fL --retry 5 --retry-delay 5"
 
 permissions:
   contents: read
@@ -51,17 +64,12 @@ jobs:
           apt-get install -y gpg-agent software-properties-common dirmngr
           apt-get install -y gcc-${CI_GCC_VERSION} g++-${CI_GCC_VERSION}
           apt-get install -y build-essential
-          GO_VERSION=1.23.8
-          curl -LO "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+          curl ${CURL_RETRY_FLAGS} -O "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
           tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
           rm "go${GO_VERSION}.linux-amd64.tar.gz"
           echo "/usr/local/go/bin" >> $GITHUB_PATH
-          curl -L -O -J https://github.com/PowerShell/PowerShell/releases/download/v7.2.23/powershell_7.2.23-1.deb_amd64.deb
-          dpkg -i powershell_7.2.23-1.deb_amd64.deb
-          apt-get install -f
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CI_GCC_VERSION} 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${CI_GCC_VERSION} 100
-          rm powershell_7.2.23-1.deb_amd64.deb
       - name: Checkout
         run: |
           set -x
@@ -74,7 +82,9 @@ jobs:
           gcc --version
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          curl --proto '=https' --tlsv1.2 ${CURL_RETRY_FLAGS} -sS https://sh.rustup.rs -o /tmp/rustup-init.sh
+          sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal
+          rm /tmp/rustup-init.sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
@@ -136,20 +146,12 @@ jobs:
           apt-get install -y gpg-agent software-properties-common dirmngr
           apt-get install -y gcc-${CI_GCC_VERSION} g++-${CI_GCC_VERSION}
           apt-get install -y build-essential
-          GO_VERSION=1.23.8
-          curl -LO "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz"
+          curl ${CURL_RETRY_FLAGS} -O "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz"
           tar -C /usr/local -xzf "go${GO_VERSION}.linux-arm64.tar.gz"
           rm "go${GO_VERSION}.linux-arm64.tar.gz"
           echo "/usr/local/go/bin" >> $GITHUB_PATH
-          curl -L -O -J https://github.com/PowerShell/PowerShell/releases/download/v7.2.23/powershell-7.2.23-linux-arm64.tar.gz
-          mkdir -p /opt/microsoft/powershell/7
-          tar zxf powershell-7.2.23-linux-arm64.tar.gz -C /opt/microsoft/powershell/7
-          chmod +x /opt/microsoft/powershell/7/pwsh
-          ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
-          apt-get install -f
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CI_GCC_VERSION} 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${CI_GCC_VERSION} 100
-          rm powershell-7.2.23-linux-arm64.tar.gz
       - name: Checkout
         run: |
           set -x
@@ -162,7 +164,9 @@ jobs:
           gcc --version
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          curl --proto '=https' --tlsv1.2 ${CURL_RETRY_FLAGS} -sS https://sh.rustup.rs -o /tmp/rustup-init.sh
+          sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal
+          rm /tmp/rustup-init.sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
@@ -201,17 +205,12 @@ jobs:
           apt-get install -y gpg-agent software-properties-common dirmngr
           apt-get install -y gcc-${CI_GCC_VERSION} g++-${CI_GCC_VERSION}
           apt-get install -y build-essential
-          GO_VERSION=1.23.8
-          curl -LO "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+          curl ${CURL_RETRY_FLAGS} -O "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
           tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
           rm "go${GO_VERSION}.linux-amd64.tar.gz"
           echo "/usr/local/go/bin" >> $GITHUB_PATH
-          curl -L -O -J https://github.com/PowerShell/PowerShell/releases/download/v7.2.23/powershell_7.2.23-1.deb_amd64.deb
-          dpkg -i powershell_7.2.23-1.deb_amd64.deb
-          apt-get install -f
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CI_GCC_VERSION} 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${CI_GCC_VERSION} 100
-          rm powershell_7.2.23-1.deb_amd64.deb
       - name: Checkout
         run: |
           set -x
@@ -224,7 +223,9 @@ jobs:
           gcc --version
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          curl --proto '=https' --tlsv1.2 ${CURL_RETRY_FLAGS} -sS https://sh.rustup.rs -o /tmp/rustup-init.sh
+          sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal
+          rm /tmp/rustup-init.sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/
@@ -262,20 +263,12 @@ jobs:
           apt-get install -y gpg-agent software-properties-common dirmngr
           apt-get install -y gcc-${CI_GCC_VERSION} g++-${CI_GCC_VERSION}
           apt-get install -y build-essential
-          GO_VERSION=1.23.8
-          curl -LO "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz"
+          curl ${CURL_RETRY_FLAGS} -O "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz"
           tar -C /usr/local -xzf "go${GO_VERSION}.linux-arm64.tar.gz"
           rm "go${GO_VERSION}.linux-arm64.tar.gz"
           echo "/usr/local/go/bin" >> $GITHUB_PATH
-          curl -L -O -J https://github.com/PowerShell/PowerShell/releases/download/v7.2.23/powershell-7.2.23-linux-arm64.tar.gz
-          mkdir -p /opt/microsoft/powershell/7
-          tar zxf powershell-7.2.23-linux-arm64.tar.gz -C /opt/microsoft/powershell/7
-          chmod +x /opt/microsoft/powershell/7/pwsh
-          ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
-          apt-get install -f
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CI_GCC_VERSION} 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${CI_GCC_VERSION} 100
-          rm powershell-7.2.23-linux-arm64.tar.gz
       - name: Checkout
         run: |
           set -x
@@ -288,7 +281,9 @@ jobs:
           gcc --version
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          curl --proto '=https' --tlsv1.2 ${CURL_RETRY_FLAGS} -sS https://sh.rustup.rs -o /tmp/rustup-init.sh
+          sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal
+          rm /tmp/rustup-init.sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Run cargo test (debug)
         working-directory: /tmp/aws-lc-rs/


### PR DESCRIPTION
### Issues:
Resolves #1136

### Description of changes:
The four container-based jobs in `compilers.yml` fetch Go, PowerShell, and rustup over the network with no retries and no `-f`, and the rustup install uses `curl | sh` (which silently executes a truncated script on a dropped connection). Any blip on `go.dev`, `github.com/releases`, or `sh.rustup.rs` fails unrelated PRs.

This PR makes those downloads retry-tolerant, drops the PowerShell install (it isn't invoked anywhere on the Linux build/test path — every `pwsh` reference in the tree is in upstream aws-lc's Windows-only CI), and bumps Go to latest stable while we're touching the file.

### Call-outs:

- I skipped the `actions/setup-go` option from the issue. It requires Node 20 inside the container, which needs glibc ≥ 2.28; the `ubuntu:18.04` rows are on 2.27 and would break. The rest of the repo uses `setup-go` because it doesn't run inside ancient containers — the inconsistency is intentional.
- PowerShell removal is the part most worth a careful look. PS 7.2 is EOL and PS 7.4+ drops 18.04 support, so "drop it" is also the only forward-compatible option if it turned out we did need it — but as best I can tell, we don't.
- `${CURL_RETRY_FLAGS}` is intentionally unquoted at call sites (relies on shell word-splitting). Don't add `set -u` or quote the expansion.

### Testing:
CI on this PR. Behavioral surface of the jobs is unchanged.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
