### PR TITLE
fix: Apply -ffile-prefix-map to jitterentropy builder

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -118,6 +118,25 @@ jobs:
           else
             exit 0; # SUCCESS
           fi
+      # Verify the same path stripping in a release build that keeps DWARF.
+      # This catches sub-builders that miss the shared prefix-map flags and
+      # exercises the assembler-specific `-Wa,--debug-prefix-map` path.
+      - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
+        working-directory: /tmp/aws-lc-rs/
+        name: Verify paths not found in release build with debug info
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: 'true'
+          CARGO_TARGET_DIR: /tmp/aws-lc-rs-target-debuginfo
+        run: |
+          cargo build -p aws-lc-sys --release
+          RELEASE_LIBCRYPTO=$(find ${CARGO_TARGET_DIR}/release -name "libaws_lc_*_crypto.a")
+          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+            echo "FAIL: build paths leaked into archive (DWARF source paths):"
+            strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/' | sort -u | head -20
+            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+          else
+            exit 0; # SUCCESS
+          fi
 
   aws-lc-rs-2004-arm-gcc:
     if: github.repository_owner == 'aws'
@@ -174,6 +193,51 @@ jobs:
       - name: Run cargo test (release)
         working-directory: /tmp/aws-lc-rs/
         run: cargo test -p aws-lc-rs --release --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
+      # The steps below verify that we're successfully using `-ffile-prefix-map`
+      # to remove build environment paths from the resulting library.
+      - if: ${{ matrix.gcc_version == '8' }}
+        working-directory: /tmp/aws-lc-rs/
+        name: Verify paths found in debug build
+        run: |
+          DEBUG_LIBCRYPTO=$(find ./target/debug -name "libaws_lc_*_crypto.a")
+          if strings ${DEBUG_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+            exit 0; # SUCCESS
+          else
+            strings ${DEBUG_LIBCRYPTO}
+            exit 1; # FAIL - we expected to find "/tmp/aws-lc-rs/"  (i.e., a path)
+          fi
+      # TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
+      # assembly files and its custom compilation commands within CMake), not all
+      # source paths are stripped from the resulting binary.
+      - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
+        working-directory: /tmp/aws-lc-rs/
+        name: Verify paths not found in release build
+        run: |
+          RELEASE_LIBCRYPTO=$(find ./target/release -name "libaws_lc_*_crypto.a")
+          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+          else
+            exit 0; # SUCCESS
+          fi
+      # Verify the same path stripping in a release build that keeps DWARF.
+      # This catches sub-builders that miss the shared prefix-map flags and
+      # exercises the assembler-specific `-Wa,--debug-prefix-map` path.
+      - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
+        working-directory: /tmp/aws-lc-rs/
+        name: Verify paths not found in release build with debug info
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: 'true'
+          CARGO_TARGET_DIR: /tmp/aws-lc-rs-target-debuginfo
+        run: |
+          cargo build -p aws-lc-sys --release
+          RELEASE_LIBCRYPTO=$(find ${CARGO_TARGET_DIR}/release -name "libaws_lc_*_crypto.a")
+          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+            echo "FAIL: build paths leaked into archive (DWARF source paths):"
+            strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/' | sort -u | head -20
+            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+          else
+            exit 0; # SUCCESS
+          fi
 
   aws-lc-rs-1804-gcc:
     if: github.repository_owner == 'aws'

--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -94,33 +94,37 @@ jobs:
         run: cargo test -p aws-lc-rs --release --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       # The steps below verify that we're successfully using `-ffile-prefix-map`
       # to remove build environment paths from the resulting library.
-      - if: ${{ matrix.gcc_version == '8' }}
+      # `${PWD}` is the `working-directory` (the checkout root), which is the
+      # prefix that would leak into the archive if path stripping regressed.
+      - if: ${{ fromJSON(matrix.gcc_version) >= 8 }}
         working-directory: /tmp/aws-lc-rs/
         name: Verify paths found in debug build
         run: |
           DEBUG_LIBCRYPTO=$(find ./target/debug -name "libaws_lc_*_crypto.a")
-          if strings ${DEBUG_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+          if strings ${DEBUG_LIBCRYPTO} | grep "${PWD}/"; then
             exit 0; # SUCCESS
           else
             strings ${DEBUG_LIBCRYPTO}
-            exit 1; # FAIL - we expected to find "/tmp/aws-lc-rs/"  (i.e., a path)
+            exit 1; # FAIL - we expected to find "${PWD}" (i.e., a path)
           fi
       # TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
       # assembly files and its custom compilation commands within CMake), not all
       # source paths are stripped from the resulting binary.
-      - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
+      - if: ${{ fromJSON(matrix.gcc_version) >= 8 && matrix.fips == '0' }}
         working-directory: /tmp/aws-lc-rs/
         name: Verify paths not found in release build
         run: |
           RELEASE_LIBCRYPTO=$(find ./target/release -name "libaws_lc_*_crypto.a")
-          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
-            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+          if strings ${RELEASE_LIBCRYPTO} | grep "${PWD}/"; then
+            exit 1; # FAIL - we did not expect to find "${PWD}" (i.e., a path)
           else
             exit 0; # SUCCESS
           fi
       # Verify the same path stripping in a release build that keeps DWARF.
       # This catches sub-builders that miss the shared prefix-map flags and
       # exercises the assembler-specific `-Wa,--debug-prefix-map` path.
+      # Pinned to a single GCC version (not `>=`): each run adds a full
+      # `cargo build`, so we avoid fanning it out across the matrix.
       - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
         working-directory: /tmp/aws-lc-rs/
         name: Verify paths not found in release build with debug info
@@ -130,10 +134,10 @@ jobs:
         run: |
           cargo build -p aws-lc-sys --release
           RELEASE_LIBCRYPTO=$(find ${CARGO_TARGET_DIR}/release -name "libaws_lc_*_crypto.a")
-          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+          if strings ${RELEASE_LIBCRYPTO} | grep "${PWD}/"; then
             echo "FAIL: build paths leaked into archive (DWARF source paths):"
-            strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/' | sort -u | head -20
-            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+            strings ${RELEASE_LIBCRYPTO} | grep "${PWD}/" | sort -u | head -20
+            exit 1; # FAIL - we did not expect to find "${PWD}" (i.e., a path)
           else
             exit 0; # SUCCESS
           fi
@@ -195,33 +199,37 @@ jobs:
         run: cargo test -p aws-lc-rs --release --all-targets --no-default-features --features ${{ (matrix.fips == '0' && 'unstable,aws-lc-sys') || 'unstable,fips' }}
       # The steps below verify that we're successfully using `-ffile-prefix-map`
       # to remove build environment paths from the resulting library.
-      - if: ${{ matrix.gcc_version == '8' }}
+      # `${PWD}` is the `working-directory` (the checkout root), which is the
+      # prefix that would leak into the archive if path stripping regressed.
+      - if: ${{ fromJSON(matrix.gcc_version) >= 8 }}
         working-directory: /tmp/aws-lc-rs/
         name: Verify paths found in debug build
         run: |
           DEBUG_LIBCRYPTO=$(find ./target/debug -name "libaws_lc_*_crypto.a")
-          if strings ${DEBUG_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+          if strings ${DEBUG_LIBCRYPTO} | grep "${PWD}/"; then
             exit 0; # SUCCESS
           else
             strings ${DEBUG_LIBCRYPTO}
-            exit 1; # FAIL - we expected to find "/tmp/aws-lc-rs/"  (i.e., a path)
+            exit 1; # FAIL - we expected to find "${PWD}" (i.e., a path)
           fi
       # TODO: Due to the nature of the FIPS build (e.g., its dynamic generation of
       # assembly files and its custom compilation commands within CMake), not all
       # source paths are stripped from the resulting binary.
-      - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
+      - if: ${{ fromJSON(matrix.gcc_version) >= 8 && matrix.fips == '0' }}
         working-directory: /tmp/aws-lc-rs/
         name: Verify paths not found in release build
         run: |
           RELEASE_LIBCRYPTO=$(find ./target/release -name "libaws_lc_*_crypto.a")
-          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
-            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+          if strings ${RELEASE_LIBCRYPTO} | grep "${PWD}/"; then
+            exit 1; # FAIL - we did not expect to find "${PWD}" (i.e., a path)
           else
             exit 0; # SUCCESS
           fi
       # Verify the same path stripping in a release build that keeps DWARF.
       # This catches sub-builders that miss the shared prefix-map flags and
       # exercises the assembler-specific `-Wa,--debug-prefix-map` path.
+      # Pinned to a single GCC version (not `>=`): each run adds a full
+      # `cargo build`, so we avoid fanning it out across the matrix.
       - if: ${{ matrix.gcc_version == '8' && matrix.fips == '0' }}
         working-directory: /tmp/aws-lc-rs/
         name: Verify paths not found in release build with debug info
@@ -231,10 +239,10 @@ jobs:
         run: |
           cargo build -p aws-lc-sys --release
           RELEASE_LIBCRYPTO=$(find ${CARGO_TARGET_DIR}/release -name "libaws_lc_*_crypto.a")
-          if strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/'; then
+          if strings ${RELEASE_LIBCRYPTO} | grep "${PWD}/"; then
             echo "FAIL: build paths leaked into archive (DWARF source paths):"
-            strings ${RELEASE_LIBCRYPTO} | grep '/tmp/aws-lc-rs/' | sort -u | head -20
-            exit 1; # FAIL - we did not expect to find "/tmp/aws-lc-rs/" (i.e., a path)
+            strings ${RELEASE_LIBCRYPTO} | grep "${PWD}/" | sort -u | head -20
+            exit 1; # FAIL - we did not expect to find "${PWD}" (i.e., a path)
           else
             exit 0; # SUCCESS
           fi

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -368,7 +368,8 @@ impl CcBuilder {
         }
 
         let mut cc_build = self.create_builder();
-        let (_, build_options) = self.collect_universal_build_options(&cc_build, false);
+        let (compiler_is_msvc, build_options) =
+            self.collect_universal_build_options(&cc_build, false);
         for option in build_options {
             option.apply_cc(&mut cc_build);
         }
@@ -378,6 +379,23 @@ impl CcBuilder {
         // See: https://github.com/aws/aws-lc/blob/main/crypto/CMakeLists.txt#L77
         if target_os() == "linux" || target_os().ends_with("bsd") {
             cc_build.asm_flag("-Wa,--noexecstack");
+        }
+
+        // `-ffile-prefix-map` does not reach GNU `as` for `.S` sources, so in
+        // release-style builds mirror it with `-Wa,--debug-prefix-map=...`.
+        // Probe first because clang's integrated assembler rejects the flag,
+        // and skip paths with spaces because `-Wa,...` must stay a bare token.
+        let opt_level = cargo_env("OPT_LEVEL");
+        if (target_os() == "linux" || target_os().ends_with("bsd"))
+            && !compiler_is_msvc
+            && !matches!(opt_level.as_str(), "0" | "1" | "2")
+            && !self.manifest_dir.to_string_lossy().contains(' ')
+        {
+            let path_str = self.manifest_dir.display().to_string();
+            let asm_flag = format!("-Wa,--debug-prefix-map={path_str}=");
+            if cc_build.is_flag_supported(&asm_flag).unwrap_or(false) {
+                cc_build.asm_flag(asm_flag);
+            }
         }
 
         cc_build
@@ -481,28 +499,18 @@ impl CcBuilder {
                 .flag("-Wconversion");
         }
 
-        // The jitter-entropy `cc::Build` is constructed fresh and does not
-        // inherit `collect_universal_build_options`, so the path-stripping
-        // flags applied to the main builder don't reach jitter object files.
-        // Apply them directly here so absolute build-time paths don't leak
-        // into jitter `.o` files via DWARF source paths (and, defensively,
-        // `__FILE__` expansions and clang `UBSan` type-descriptor records).
-        // Applied unconditionally because jitter is always compiled at `-O0`
-        // regardless of `OPT_LEVEL`.
+        // Jitter uses a separate `cc::Build`, so it needs its own path-mapping
+        // flags even when the main builder already has them. Apply them here
+        // unconditionally because jitter is always compiled at `-O0`.
         for option in self.collect_path_reproducibility_options(&je_builder, is_like_msvc) {
             option.apply_cc(&mut je_builder);
         }
         je_builder
     }
 
-    /// Returns flags that prevent absolute build-time paths from being
-    /// embedded in compiled object files via DWARF source paths,
-    /// `__FILE__` expansions, or clang `UBSan` type-descriptor records.
-    /// Returns an empty `Vec` on MSVC, which has no equivalent flags.
-    ///
-    /// Probing is performed against the supplied `cc_build` so the actual
-    /// configured compiler is consulted (important when the jitter builder
-    /// has a different compiler invocation than the main one).
+    /// Returns path-reproducibility flags for the configured compiler.
+    /// These rewrite DWARF source paths and `__FILE__`; clang may also need
+    /// extra stripping for UBSan metadata. Returns an empty `Vec` on MSVC.
     fn collect_path_reproducibility_options(
         &self,
         cc_build: &cc::Build,
@@ -515,9 +523,8 @@ impl CcBuilder {
 
         let path_str = self.manifest_dir.display().to_string();
 
-        // Strip absolute paths from `__FILE__` expansions and DWARF source
-        // paths. `-ffile-prefix-map` is preferred (covers both); fall back to
-        // `-fdebug-prefix-map` for older GCC (< 8) which only rewrites DWARF.
+        // Prefer the flag that rewrites both `__FILE__` and DWARF; older GCC
+        // may only support `-fdebug-prefix-map`.
         let file_flag = format!("-ffile-prefix-map={path_str}=");
         if cc_build.is_flag_supported(&file_flag).unwrap_or(false) {
             opts.push(BuildOption::flag(&file_flag));
@@ -528,12 +535,7 @@ impl CcBuilder {
             }
         }
 
-        // Clang's `UBSan` emits `SourceLocation` records in `.rodata`
-        // containing the absolute source-file path. `-ffile-prefix-map` does
-        // NOT rewrite those, and at `-O0` they aren't dead-code eliminated.
-        // Strip to basename. No-op on compilers that don't recognize the
-        // flag (GCC, older clang) and on builds without
-        // `-fsanitize=undefined`.
+        // Clang UBSan metadata can still carry the full source path at `-O0`.
         if let Some(opt) = BuildOption::flag_if_supported(
             cc_build,
             "-fsanitize-undefined-strip-path-components=-1",

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -510,7 +510,7 @@ impl CcBuilder {
 
     /// Returns path-reproducibility flags for the configured compiler.
     /// These rewrite DWARF source paths and `__FILE__`; clang may also need
-    /// extra stripping for UBSan metadata. Returns an empty `Vec` on MSVC.
+    /// extra stripping for `UBSan` metadata. Returns an empty `Vec` on MSVC.
     fn collect_path_reproducibility_options(
         &self,
         cc_build: &cc::Build,

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -480,7 +480,68 @@ impl CcBuilder {
                 .flag("-fwrapv")
                 .flag("-Wconversion");
         }
+
+        // The jitter-entropy `cc::Build` is constructed fresh and does not
+        // inherit `collect_universal_build_options`, so the path-stripping
+        // flags applied to the main builder don't reach jitter object files.
+        // Apply them directly here so absolute build-time paths don't leak
+        // into jitter `.o` files via DWARF source paths (and, defensively,
+        // `__FILE__` expansions and clang `UBSan` type-descriptor records).
+        // Applied unconditionally because jitter is always compiled at `-O0`
+        // regardless of `OPT_LEVEL`.
+        for option in self.collect_path_reproducibility_options(&je_builder, is_like_msvc) {
+            option.apply_cc(&mut je_builder);
+        }
         je_builder
+    }
+
+    /// Returns flags that prevent absolute build-time paths from being
+    /// embedded in compiled object files via DWARF source paths,
+    /// `__FILE__` expansions, or clang `UBSan` type-descriptor records.
+    /// Returns an empty `Vec` on MSVC, which has no equivalent flags.
+    ///
+    /// Probing is performed against the supplied `cc_build` so the actual
+    /// configured compiler is consulted (important when the jitter builder
+    /// has a different compiler invocation than the main one).
+    fn collect_path_reproducibility_options(
+        &self,
+        cc_build: &cc::Build,
+        is_like_msvc: bool,
+    ) -> Vec<BuildOption> {
+        let mut opts: Vec<BuildOption> = Vec::new();
+        if is_like_msvc {
+            return opts;
+        }
+
+        let path_str = self.manifest_dir.display().to_string();
+
+        // Strip absolute paths from `__FILE__` expansions and DWARF source
+        // paths. `-ffile-prefix-map` is preferred (covers both); fall back to
+        // `-fdebug-prefix-map` for older GCC (< 8) which only rewrites DWARF.
+        let file_flag = format!("-ffile-prefix-map={path_str}=");
+        if cc_build.is_flag_supported(&file_flag).unwrap_or(false) {
+            opts.push(BuildOption::flag(&file_flag));
+        } else {
+            let dbg_flag = format!("-fdebug-prefix-map={path_str}=");
+            if cc_build.is_flag_supported(&dbg_flag).unwrap_or(false) {
+                opts.push(BuildOption::flag(&dbg_flag));
+            }
+        }
+
+        // Clang's `UBSan` emits `SourceLocation` records in `.rodata`
+        // containing the absolute source-file path. `-ffile-prefix-map` does
+        // NOT rewrite those, and at `-O0` they aren't dead-code eliminated.
+        // Strip to basename. No-op on compilers that don't recognize the
+        // flag (GCC, older clang) and on builds without
+        // `-fsanitize=undefined`.
+        if let Some(opt) = BuildOption::flag_if_supported(
+            cc_build,
+            "-fsanitize-undefined-strip-path-components=-1",
+        ) {
+            opts.push(opt);
+        }
+
+        opts
     }
 
     /// The cc crate appends CFLAGS at the end of the compiler command line,

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -102,6 +102,25 @@ impl CmakeBuilder {
         for option in &build_options {
             option.apply_cmake(cmake_cfg, is_like_msvc);
         }
+
+        // CMake seeds `CMAKE_C_FLAGS` and `CMAKE_ASM_FLAGS` separately, so the
+        // C-side prefix-map does not cover `.S` sources. In release-style
+        // builds, mirror it with `asmflag()` when the compiler accepts
+        // `-Wa,--debug-prefix-map=...`, and skip paths with spaces because the
+        // flag must survive CMake and the assembler as one bare token.
+        let opt_level = cargo_env("OPT_LEVEL");
+        if !is_like_msvc
+            && (target_os() == "linux" || target_os().ends_with("bsd"))
+            && !matches!(opt_level.as_str(), "0" | "1" | "2")
+            && !self.manifest_dir.to_string_lossy().contains(' ')
+        {
+            let path_str = self.manifest_dir.display().to_string();
+            let asm_flag = format!("-Wa,--debug-prefix-map={path_str}=");
+            if cc_build.is_flag_supported(&asm_flag).unwrap_or(false) {
+                cmake_cfg.asmflag(asm_flag);
+            }
+        }
+
         cmake_cfg
     }
 


### PR DESCRIPTION
### Issues:
Resolves #1137

### Description of changes:
The jitter-entropy builder constructs a fresh `cc::Build` and bypasses `collect_universal_build_options`, so `-ffile-prefix-map` never reaches jitter object files. Stock release builds are unaffected (jitter sources don't use `__FILE__`), but consumers that enable debug info on C compilation — Bazel, Nix, distro packagers — see absolute paths leak into the archive via DWARF.

Commit 1 fixes the builder. Commit 2 adds a CI step that builds with debug info enabled, since the existing release path-check ran without DWARF and couldn't catch this class of regression.

### Call-outs:
Review the commits in order — the CI commit alone would fail without the fix.

Path-stripping is applied to the jitter builder unconditionally (vs. the main builder, which gates it on `OPT_LEVEL`), since jitter is always compiled at `-O0` regardless of profile.

The helper also includes `-fsanitize-undefined-strip-path-components=-1` for defensive coverage; the new CI check deliberately does not exercise UBSan (rationale in the commit message).

### Testing:
Local A/B on `aarch64-apple-darwin` with `CARGO_PROFILE_RELEASE_DEBUG=true`: archive goes from 10 leaked path strings (all six `jitterentropy-*.c` paths) to zero. The new CI step is the codified equivalent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
