### PR TITLE
Support system-installed AWS-LC FIPS library for aws-lc-fips-sys

### DIFF
--- a/.github/workflows/system-lib-tests-fips.yml
+++ b/.github/workflows/system-lib-tests-fips.yml
@@ -1,0 +1,469 @@
+name: System Library Tests (FIPS)
+# Exercises the system-library FIPS path enabled by
+# AWS_LC_FIPS_SYS_SYSTEM_DIR, including the link probe and runtime check.
+#
+# Builds AWS-LC FIPS from the fips-2025-09-12-lts branch, which supports
+# -DGENERATE_RUST_BINDINGS=ON for system-installed bindings.
+#
+# Two AWS-LC FIPS build constraints drive the matrix:
+#   * A *static* FIPS build is supported only on Linux; macOS and Windows FIPS
+#     builds must be shared (BUILD_SHARED_LIBS=ON).
+#   * Windows FIPS requires a Release build (Debug/RelWithDebInfo unsupported).
+#
+# A prefixed-install lane (BORINGSSL_PREFIX) runs only on Linux, where FIPS
+# can produce the required static archives.
+#
+# The negative (non-FIPS) fixture also builds bindings so failures occur at the
+# FIPS probe, not earlier during bindings resolution.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build AWS-LC FIPS (and a non-FIPS negative fixture) from the LTS branch into
+  # install prefixes the test jobs consume via workflow artifacts.
+  # ---------------------------------------------------------------------------
+  build-fips-unix:
+    if: github.repository_owner == 'aws'
+    name: Build AWS-LC FIPS (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: clang
+      CXX: clang++
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cover both Apple architectures.
+        os: [ ubuntu-latest, macos-15-intel, macos-latest ]
+    steps:
+      - name: Checkout AWS-LC (fips-2025-09-12-lts)
+        uses: actions/checkout@v6
+        with:
+          repository: aws/aws-lc
+          ref: fips-2025-09-12-lts
+          submodules: 'recursive'
+          path: aws-lc-fips-src
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.18'
+
+      - name: Update CMake (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          brew update
+          brew install --force cmake
+          cmake --version
+
+      - name: Install bindgen-cli
+        run: cargo install --force --locked bindgen-cli
+
+      - name: Select FIPS library form
+        id: form
+        run: |
+          # Static FIPS is Linux-only.
+          if [ "$(uname -s)" = "Linux" ]; then
+            echo "shared=OFF" >> "$GITHUB_OUTPUT"
+          else
+            echo "shared=ON" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and install AWS-LC FIPS (+ Rust bindings)
+        run: |
+          cmake -S aws-lc-fips-src -B build-fips \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFIPS=1 \
+            -DBUILD_SHARED_LIBS=${{ steps.form.outputs.shared }} \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-fips"
+          cmake --build build-fips --target install -j
+
+      - name: Build and install AWS-LC non-FIPS (+ Rust bindings, negative fixture)
+        run: |
+          cmake -S aws-lc-fips-src -B build-nonfips \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-nonfips"
+          cmake --build build-nonfips --target install -j
+
+      # Linux-only: generate a matching BORINGSSL_PREFIX symbols list from the
+      # unprefixed static archives we just built.
+      - name: Generate prefix symbols list (Linux)
+        if: runner.os == 'Linux'
+        working-directory: aws-lc-fips-src
+        run: |
+          libdir=lib
+          [ -f "${GITHUB_WORKSPACE}/install-fips/lib64/libcrypto.a" ] && libdir=lib64
+          go run util/read_symbols.go \
+            -out "${GITHUB_WORKSPACE}/fips_symbols.txt" \
+            "${GITHUB_WORKSPACE}/install-fips/${libdir}/libcrypto.a" \
+            "${GITHUB_WORKSPACE}/install-fips/${libdir}/libssl.a"
+
+      - name: Build and install AWS-LC FIPS with symbol prefix (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cmake -S aws-lc-fips-src -B build-fips-prefixed \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFIPS=1 \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DBORINGSSL_PREFIX=awslc_fips_sys_test \
+            -DBORINGSSL_PREFIX_SYMBOLS="${PWD}/fips_symbols.txt" \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-fips-prefixed"
+          cmake --build build-fips-prefixed --target install -j
+
+      - name: Upload install artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-lc-fips-install-${{ matrix.os }}
+          path: |
+            install-fips/
+            install-nonfips/
+          retention-days: 1
+
+      - name: Upload prefixed install artifact (Linux)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-lc-fips-install-prefixed
+          path: install-fips-prefixed/
+          retention-days: 1
+
+  build-fips-windows:
+    if: github.repository_owner == 'aws'
+    name: Build AWS-LC FIPS (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout AWS-LC (fips-2025-09-12-lts)
+        uses: actions/checkout@v6
+        with:
+          repository: aws/aws-lc
+          ref: fips-2025-09-12-lts
+          submodules: 'recursive'
+          path: aws-lc-fips-src
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: ilammy/setup-nasm@v1
+      - uses: seanmiddleditch/gha-setup-ninja@v6
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.18'
+
+      - name: Install bindgen-cli
+        run: cargo install --force --locked bindgen-cli
+
+      - name: Build and install AWS-LC FIPS (shared, Release, + Rust bindings)
+        shell: bash
+        run: |
+          # Windows FIPS requires a shared Release build.
+          cmake -S aws-lc-fips-src -B build-fips \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFIPS=1 \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-fips"
+          cmake --build build-fips --target install -j
+
+      - name: Build and install AWS-LC non-FIPS (static, + Rust bindings, negative fixture)
+        shell: bash
+        run: |
+          cmake -S aws-lc-fips-src -B build-nonfips \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-nonfips"
+          cmake --build build-nonfips --target install -j
+
+      - name: Upload install artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-lc-fips-install-windows-latest
+          path: |
+            install-fips/
+            install-nonfips/
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Positive path: link aws-lc-fips-sys / aws-lc-rs against the FIPS install and
+  # assert both the system-library path and FIPS verification ran.
+  # ---------------------------------------------------------------------------
+  test-fips-unix:
+    if: github.repository_owner == 'aws'
+    needs: build-fips-unix
+    name: "Test: ${{ matrix.config.name }} (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-15-intel, macos-latest ]
+        config:
+          - name: "aws-lc-fips-sys"
+            cargo_args: "-p aws-lc-fips-sys"
+            cargo_cmd: "build"
+          - name: "aws-lc-rs, fips"
+            cargo_args: "-p aws-lc-rs --no-default-features --features fips --lib"
+            cargo_cmd: "test"
+    steps:
+      # Do not initialize the aws-lc submodule; that makes fallback-to-source a
+      # hard failure instead of a silent regression. SKIP_VERSION_CHECK is
+      # required because the version check reads submodule headers.
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download AWS-LC FIPS install
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-lc-fips-install-${{ matrix.os }}
+          path: ${{ github.workspace }}/fips-artifacts
+
+      - name: Determine link form
+        id: form
+        run: |
+          # Matches the build job: static on Linux, shared on macOS.
+          if [ "$(uname -s)" = "Linux" ]; then
+            echo "static=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "static=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run cargo ${{ matrix.config.cargo_cmd }}
+        env:
+          AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-fips
+          AWS_LC_FIPS_SYS_STATIC: ${{ steps.form.outputs.static }}
+          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
+          # A shared install (macOS) must be discoverable at runtime.
+          LD_LIBRARY_PATH: ${{ github.workspace }}/fips-artifacts/install-fips/lib
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/fips-artifacts/install-fips/lib
+        run: |
+          # Assert that the system-library path and FIPS verification both ran.
+          set -o pipefail
+          cargo ${{ matrix.config.cargo_cmd }} -vv ${{ matrix.config.cargo_args }} 2>&1 | tee cargo.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo.log; then
+            echo '::error::System-library code path was not entered; aws-lc-fips-sys silently fell back to building from source.'
+            exit 1
+          fi
+          if ! grep -q 'FIPS verification' cargo.log; then
+            echo '::error::FIPS verification did not run on the system-library FIPS path.'
+            exit 1
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Prefixed-install path (Linux): verify that prefix-aware bindings work and
+  # that the FIPS probe resolves the renamed FIPS-only symbol.
+  # ---------------------------------------------------------------------------
+  test-fips-prefixed-linux:
+    if: github.repository_owner == 'aws'
+    needs: build-fips-unix
+    name: "Test: ${{ matrix.config.name }} (ubuntu-latest)"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "aws-lc-fips-sys, prefixed"
+            cargo_args: "-p aws-lc-fips-sys"
+            cargo_cmd: "build"
+          - name: "aws-lc-rs, fips, prefixed"
+            cargo_args: "-p aws-lc-rs --no-default-features --features fips --lib"
+            cargo_cmd: "test"
+    steps:
+      # Do not initialize the aws-lc submodule (see test-fips-unix).
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download prefixed AWS-LC FIPS install
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-lc-fips-install-prefixed
+          path: ${{ github.workspace }}/fips-artifacts/install-fips-prefixed
+
+      - name: Sanity-check that the install is actually prefixed
+        run: |
+          # Make sure prefixing actually changed the exported symbol names.
+          libdir=lib
+          [ -f "${GITHUB_WORKSPACE}/fips-artifacts/install-fips-prefixed/lib64/libcrypto.a" ] && libdir=lib64
+          if ! nm "${GITHUB_WORKSPACE}/fips-artifacts/install-fips-prefixed/${libdir}/libcrypto.a" \
+               | grep -q 'awslc_fips_sys_test_'; then
+            echo '::error::Prefixed install does not contain awslc_fips_sys_test_* symbols; prefixing did not take effect.'
+            exit 1
+          fi
+
+      - name: Run cargo ${{ matrix.config.cargo_cmd }}
+        env:
+          AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-fips-prefixed
+          AWS_LC_FIPS_SYS_STATIC: "1"
+          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
+        run: |
+          set -o pipefail
+          cargo ${{ matrix.config.cargo_cmd }} -vv ${{ matrix.config.cargo_args }} 2>&1 | tee cargo.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo.log; then
+            echo '::error::System-library code path was not entered; aws-lc-fips-sys silently fell back to building from source.'
+            exit 1
+          fi
+          if ! grep -q 'FIPS verification' cargo.log; then
+            echo '::error::FIPS verification did not run on the system-library FIPS path.'
+            exit 1
+          fi
+
+  test-fips-windows:
+    if: github.repository_owner == 'aws'
+    needs: build-fips-windows
+    name: "Test: ${{ matrix.config.name }} (windows-latest)"
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "aws-lc-fips-sys"
+            cargo_args: "-p aws-lc-fips-sys"
+            cargo_cmd: "build"
+          - name: "aws-lc-rs, fips"
+            cargo_args: "-p aws-lc-rs --no-default-features --features fips --lib"
+            cargo_cmd: "test"
+    steps:
+      # Do not initialize the aws-lc submodule (see test-fips-unix).
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Download AWS-LC FIPS install
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-lc-fips-install-windows-latest
+          path: ${{ github.workspace }}/fips-artifacts
+
+      - name: Run cargo ${{ matrix.config.cargo_cmd }}
+        shell: pwsh
+        env:
+          AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-fips
+          # Windows FIPS is a shared build.
+          AWS_LC_FIPS_SYS_STATIC: "0"
+          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
+        run: |
+          # Windows needs the DLL on PATH for both the probe and the test binary.
+          $env:Path = "$env:AWS_LC_FIPS_SYS_SYSTEM_DIR\bin;$env:AWS_LC_FIPS_SYS_SYSTEM_DIR\lib;$env:Path"
+
+          $output = cargo ${{ matrix.config.cargo_cmd }} -vv ${{ matrix.config.cargo_args }} 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Tee-Object -FilePath cargo.log
+          if ($exitCode -ne 0) { exit $exitCode }
+
+          if (-not (Select-String -Path cargo.log -Pattern 'Using system-installed AWS-LC from' -Quiet)) {
+            Write-Error 'System-library code path was not entered; aws-lc-fips-sys silently fell back to building from source.'
+            exit 1
+          }
+          if (-not (Select-String -Path cargo.log -Pattern 'FIPS verification' -Quiet)) {
+            Write-Error 'FIPS verification did not run on the system-library FIPS path.'
+            exit 1
+          }
+
+  # ---------------------------------------------------------------------------
+  # Negative path: building against a non-FIPS install MUST fail at the FIPS
+  # link probe (proving the probe is not trivially satisfied).
+  # ---------------------------------------------------------------------------
+  reject-nonfips-unix:
+    if: github.repository_owner == 'aws'
+    needs: build-fips-unix
+    name: "Reject non-FIPS install (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-15-intel, macos-latest ]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download AWS-LC install
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-lc-fips-install-${{ matrix.os }}
+          path: ${{ github.workspace }}/fips-artifacts
+
+      - name: Assert the FIPS probe rejects a non-FIPS install
+        env:
+          AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-nonfips
+          AWS_LC_FIPS_SYS_STATIC: "1"
+          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
+        run: |
+          set -o pipefail
+          if cargo build -p aws-lc-fips-sys -vv 2>&1 | tee cargo.log; then
+            echo '::error::Build unexpectedly succeeded against a non-FIPS install.'
+            exit 1
+          fi
+          if ! grep -q 'FIPS verification failed' cargo.log; then
+            echo '::error::Build failed, but not at the FIPS probe rejection (check the failure cause).'
+            exit 1
+          fi
+
+  reject-nonfips-windows:
+    if: github.repository_owner == 'aws'
+    needs: build-fips-windows
+    name: "Reject non-FIPS install (windows-latest)"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Download AWS-LC install
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-lc-fips-install-windows-latest
+          path: ${{ github.workspace }}/fips-artifacts
+
+      - name: Assert the FIPS probe rejects a non-FIPS install
+        shell: pwsh
+        env:
+          AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-nonfips
+          AWS_LC_FIPS_SYS_STATIC: "1"
+          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $output = cargo build -p aws-lc-fips-sys -vv 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | Tee-Object -FilePath cargo.log
+
+          if ($exitCode -eq 0) {
+            Write-Error 'Build unexpectedly succeeded against a non-FIPS install.'
+            exit 1
+          }
+          if (-not (Select-String -Path cargo.log -Pattern 'FIPS verification failed' -Quiet)) {
+            Write-Error 'Build failed, but not at the FIPS probe rejection (check the failure cause).'
+            exit 1
+          }
+
+          # The failed cargo build is expected in this negative test. Make the
+          # successful assertion explicit so PowerShell/GitHub Actions does not
+          # propagate cargo's non-zero $LASTEXITCODE as the step result.
+          exit 0

--- a/aws-lc-fips-sys/Cargo.toml
+++ b/aws-lc-fips-sys/Cargo.toml
@@ -47,6 +47,7 @@ include = [
     "/aws-lc/util/godeps.go",
     "/CMakeLists.txt",
     "/builder/**/*.rs",
+    "/builder/**/*.c",
     "/builder/printenv.bat",
     "/Cargo.toml",
     "/generated-include/**",

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -59,6 +59,60 @@ Prebuilt NASM objects are *not* available for this crate.
 `aws-lc-fips-sys` currently relies on the AWS-LC FIPS static build, please see our CI documentation
 at [AWS-LC](https://github.com/aws/aws-lc/tree/main/tests/ci#unit-tests).
 
+## Using a system-installed AWS-LC FIPS module
+
+If you already have an AWS-LC FIPS installation (built and installed with `-DFIPS=1`), you can
+link against it instead of building from the bundled source. Set `AWS_LC_FIPS_SYS_SYSTEM_DIR` to
+the install prefix:
+
+```shell
+AWS_LC_FIPS_SYS_SYSTEM_DIR=/path/to/aws-lc-fips-install cargo build
+```
+
+The install directory must contain `include/openssl/base.h` and a `lib/` (or `lib64/`) directory
+holding `libcrypto` (and `libssl` when the `ssl` feature is enabled). The structure mirrors what
+`aws-lc-sys` accepts — see [aws-lc-sys/README.md](../aws-lc-sys/README.md) for the full layout.
+
+### FIPS verification
+
+The build script links a small C probe against the install's `libcrypto` and calls
+`BORINGSSL_integrity_test()`, which is exported only by FIPS, non-ASAN AWS-LC builds. When the
+build host can run the target binary directly, or through `CARGO_TARGET_<TRIPLE>_RUNNER`, the probe
+also requires `FIPS_mode() != 0`.
+
+A startup check is also linked into dependent binaries. It calls `FIPS_mode()` at process startup
+and aborts if the runtime library is not in FIPS mode, catching issues the build-time probe cannot
+see, such as deployment-host mismatches or shared-library shadowing. If the build-time probe links
+but cannot be launched, the build continues and relies on this startup check.
+
+### Runtime library path (shared installs)
+
+When linking a shared `libcrypto` (the required form for FIPS on macOS and Windows), the install's
+library directory is not embedded in the consumer binary, so the dynamic loader must be able to
+find it at runtime. Otherwise a different `libcrypto` may be loaded — on macOS the build-host's
+`@rpath` install name can resolve to an unrelated library. Make the install discoverable via
+`LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH=<prefix>/lib`, an rpath in your own binary
+(`RUSTFLAGS="-C link-arg=-Wl,-rpath,<prefix>/lib"`), or a standard system library path. Static
+installs (Linux) are unaffected.
+
+### Bindings
+
+This path requires pre-generated bindings; it does not invoke `bindgen` itself. Either:
+
+1. Install AWS-LC with `-DGENERATE_RUST_BINDINGS=ON` (AWS-LC v1.68.0+) so the conventional
+   `share/rust/aws_lc_bindings.rs` is populated; or
+2. Set `AWS_LC_FIPS_SYS_SYSTEM_BINDINGS=/path/to/bindings.rs` to point at a bindings file you
+   produced separately.
+
+The bindings must match the install's `BORINGSSL_PREFIX` setting. Generate bindings for the exact
+install you intend to link; the bindings shipped inside this crate are for the bundled,
+version-stamped prefix and are not suitable for an arbitrary system install.
+
+### Version compatibility
+
+The version embedded in the installed headers must be greater than or equal to the AWS-LC
+version bundled with this crate. Override with `AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
+
 ## Build Prerequisites
 
 Since this crate builds AWS-LC as a native library, all build tools needed to build AWS-LC are applicable to

--- a/aws-lc-sys/Cargo.toml
+++ b/aws-lc-sys/Cargo.toml
@@ -50,6 +50,7 @@ include = [
     "/builder/**/*.bat",
     "/builder/**/*.sh",
     "/builder/**/*.obj",
+    "/builder/**/*.c",
     "/Cargo.toml",
     "/generated-include/**",
     "/include/**",

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -129,10 +129,6 @@ recommended), set `AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
 ### Limitations
 
-System-library FIPS linking (`aws-lc-fips-sys`) is not yet supported.
-When `AWS_LC_FIPS_SYS_SYSTEM_DIR` is set, the build will fail with
-a clear error directing you to build from source instead.
-
 When the `ssl` feature is enabled, the pre-generated bindings file must
 cover both `libcrypto` and `libssl`. AWS-LC's `-DGENERATE_RUST_BINDINGS=ON`
 produces such a combined file by default; if you supply your own bindings

--- a/builder/fips_link_probe.c
+++ b/builder/fips_link_probe.c
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// Build-time FIPS probe for the system-library path.
+//
+// The exit code below must stay in sync with FIPS_MODE_OFF_EXIT_CODE in
+// builder/fips_probe.rs.
+
+#include <openssl/crypto.h>
+
+// Not declared in public headers; exported only by FIPS builds.
+extern int BORINGSSL_integrity_test(void);
+
+int main(void) {
+    (void)BORINGSSL_integrity_test();
+    return FIPS_mode() ? 0 : 42;
+}

--- a/builder/fips_probe.rs
+++ b/builder/fips_probe.rs
@@ -1,0 +1,324 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+use crate::system_library::ResolvedLib;
+use crate::{
+    cargo_env, emit_warning, execute_command, is_lto_flag, out_dir, target, target_os,
+    OutputLibType,
+};
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+/// Joins a literal flag prefix (e.g. `-I`, `-L`, `-Wl,-rpath,`) with a path
+/// without forcing UTF-8.
+fn prefixed_os_arg(prefix: &str, value: &OsStr) -> std::ffi::OsString {
+    let mut s = std::ffi::OsString::from(prefix);
+    s.push(value);
+    s
+}
+
+/// Runs `program` with owned `OsString` args.
+fn execute_os(program: &OsStr, args: &[std::ffi::OsString]) -> crate::CommandResult {
+    let refs: Vec<&OsStr> = args.iter().map(std::ffi::OsString::as_os_str).collect();
+    execute_command(program, &refs)
+}
+
+/// Extra libraries the FIPS link probe must name when linking a *static*
+/// libcrypto. The probe is bare C and so lacks the std-provided pthread/dl/c
+/// linkage a real Rust binary would have. Each entry must be linkable on the
+/// target (Apple has no standalone `-ldl`) and is a no-op where folded into
+/// libc (e.g. glibc >= 2.34).
+fn fips_probe_static_deps() -> &'static [&'static str] {
+    match target_os().as_str() {
+        "linux" | "android" => &["-pthread", "-ldl", "-lm"],
+        // *BSD: threads via `-pthread`; dl/m symbols live in libc.
+        "freebsd" | "openbsd" | "netbsd" | "dragonfly" => &["-pthread"],
+        // Apple (libSystem) and anything else (incl. windows-gnu): nothing
+        // portable to add; a genuine missing dep still surfaces as a link
+        // error whose diagnostic names transitive dependencies.
+        _ => &[],
+    }
+}
+
+/// Returns cc-rs's target compiler flags, minus LTO flags.
+fn inherited_probe_args(compiler: &cc::Tool) -> Vec<std::ffi::OsString> {
+    compiler
+        .args()
+        .iter()
+        .filter(|arg| !arg.to_str().is_some_and(is_lto_flag))
+        .cloned()
+        .collect()
+}
+
+/// Appends the probe source and link arguments to the inherited compiler flags.
+fn append_probe_link_args(
+    args: &mut Vec<std::ffi::OsString>,
+    is_msvc: bool,
+    include_dir: &Path,
+    crypto_lib: &ResolvedLib,
+    lib_dir: &Path,
+    probe_src: &Path,
+    exec_path: &Path,
+) {
+    if is_msvc {
+        let obj_path = out_dir().join("aws_lc_fips_link_probe.obj");
+        args.extend([
+            prefixed_os_arg("/I", include_dir.as_os_str()),
+            probe_src.as_os_str().to_os_string(),
+            prefixed_os_arg("/Fe:", exec_path.as_os_str()),
+            prefixed_os_arg("/Fo:", obj_path.as_os_str()),
+            "/link".into(),
+            crypto_lib.path.as_os_str().to_os_string(),
+        ]);
+    } else {
+        args.extend([
+            prefixed_os_arg("-I", include_dir.as_os_str()),
+            probe_src.as_os_str().to_os_string(),
+            prefixed_os_arg("-L", lib_dir.as_os_str()),
+            prefixed_os_arg("-Wl,-rpath,", lib_dir.as_os_str()),
+        ]);
+        if matches!(crypto_lib.lib_type, OutputLibType::Static) {
+            args.push(crypto_lib.path.as_os_str().to_os_string());
+            args.extend(fips_probe_static_deps().iter().copied().map(Into::into));
+        } else {
+            args.push(format!("-l{}", crypto_lib.name).into());
+        }
+        args.extend(["-o".into(), exec_path.as_os_str().to_os_string()]);
+    }
+}
+
+/// Compiles and links the FIPS probe against the install's `libcrypto`,
+/// returning the linked executable's path on success.
+pub(crate) fn compile_fips_probe(
+    manifest_dir: &Path,
+    include_dir: &Path,
+    crypto_lib: &ResolvedLib,
+    lib_dir: &Path,
+) -> Result<PathBuf, String> {
+    let probe_src = manifest_dir.join("builder").join("fips_link_probe.c");
+    if !probe_src.is_file() {
+        return Err(format!(
+            "FIPS probe source missing: {}",
+            probe_src.display()
+        ));
+    }
+    println!("cargo:rerun-if-changed={}", probe_src.display());
+
+    let exec_path = out_dir().join(if target_os() == "windows" {
+        "aws_lc_fips_link_probe.exe"
+    } else {
+        "aws_lc_fips_link_probe"
+    });
+
+    let cc_build = cc::Build::new();
+    let compiler = cc_build.get_compiler();
+    let is_msvc = compiler.is_like_msvc();
+    if !(compiler.is_like_clang() || compiler.is_like_gnu() || is_msvc) {
+        return Err(format!(
+            "FIPS verification requires a Clang-, GCC-, or MSVC-compatible compiler; \
+             {} is not supported. Set CC to a supported compiler.",
+            compiler.path().display(),
+        ));
+    }
+
+    let mut args = inherited_probe_args(&compiler);
+    append_probe_link_args(
+        &mut args,
+        is_msvc,
+        include_dir,
+        crypto_lib,
+        lib_dir,
+        &probe_src,
+        &exec_path,
+    );
+
+    let result = execute_os(compiler.path().as_os_str(), &args);
+    if !result.executed {
+        return Err(format!(
+            "FIPS verification failed: could not execute compiler {compiler}.\n\
+             Spawn error: {spawn_error}",
+            compiler = compiler.path().display(),
+            spawn_error = result.spawn_error.as_deref().unwrap_or("unknown error"),
+        ));
+    }
+    if !result.status {
+        return Err(format!(
+            "FIPS verification failed: linker rejected the probe against {lib}.\n\
+             The library is likely not an AWS-LC FIPS build (BORINGSSL_integrity_test \
+             is exported only by FIPS, non-ASAN builds); when cross-compiling it can \
+             also indicate an architecture or CRT model (/MD vs /MT) mismatch.\n\
+             Stderr: {stderr}",
+            lib = crypto_lib.path.display(),
+            stderr = result.stderr,
+        ));
+    }
+
+    Ok(exec_path)
+}
+
+/// Verifies that the supplied system `libcrypto` is a usable AWS-LC FIPS
+/// library by linking the FIPS-only probe and, when possible, running it.
+pub(crate) fn verify_fips_install(
+    manifest_dir: &Path,
+    include_dir: &Path,
+    crypto_lib: &ResolvedLib,
+    lib_dir: &Path,
+) -> Result<(), String> {
+    let probe = compile_fips_probe(manifest_dir, include_dir, crypto_lib, lib_dir)?;
+    run_fips_probe(&probe, crypto_lib)
+}
+
+const FIPS_MODE_OFF_EXIT_CODE: i32 = 42;
+
+/// Runs the probe when the host can launch a target binary.
+pub(crate) fn run_fips_probe(exec_path: &Path, crypto_lib: &ResolvedLib) -> Result<(), String> {
+    let invocation: Option<(std::ffi::OsString, Vec<std::ffi::OsString>)> = if cargo_env("HOST")
+        == target()
+    {
+        Some((exec_path.as_os_str().to_os_string(), Vec::new()))
+    } else if let Some(mut runner) = target_runner() {
+        // runner = [program, args...]; append the probe path last.
+        let program = runner.remove(0);
+        let mut run_args: Vec<std::ffi::OsString> = runner.into_iter().map(Into::into).collect();
+        run_args.push(exec_path.as_os_str().to_os_string());
+        Some((program.into(), run_args))
+    } else {
+        None
+    };
+
+    let Some((program, run_args)) = invocation else {
+        let _ = std::fs::remove_file(exec_path);
+        emit_warning(
+            "Cross-compile detected with no target runner: skipping runtime FIPS_mode() check. \
+             Build-time link probe passed; the runtime constructor in fips_runtime_check.c \
+             will assert FIPS mode at process startup.",
+        );
+        return Ok(());
+    };
+
+    let runtime_result = execute_os(program.as_os_str(), &run_args);
+    let _ = std::fs::remove_file(exec_path);
+
+    if !runtime_result.executed {
+        emit_warning(format!(
+            "FIPS runtime check skipped: probe linked but could not be executed via {program}. \
+             Relying on the build-time link probe and the runtime constructor. \
+             Spawn error: {spawn_error}. Stderr: {stderr}",
+            program = program.to_string_lossy(),
+            spawn_error = runtime_result
+                .spawn_error
+                .as_deref()
+                .unwrap_or("unknown error"),
+            stderr = runtime_result.stderr,
+        ));
+        return Ok(());
+    }
+    if runtime_result.status {
+        emit_warning(
+            "FIPS verification: build-time link probe and runtime FIPS_mode() check passed.",
+        );
+        return Ok(());
+    }
+    if runtime_result.exit_code == Some(FIPS_MODE_OFF_EXIT_CODE) {
+        return Err(format!(
+            "FIPS verification failed: probe linked but FIPS_mode() returned 0 at \
+             runtime against {lib}. The library exposes FIPS-only symbols but is \
+             not running in FIPS mode (e.g. a FIPS+ASAN build, which the AWS-LC \
+             FIPS module disables at runtime).\n\
+             Stderr: {stderr}",
+            lib = crypto_lib.path.display(),
+            stderr = runtime_result.stderr,
+        ));
+    }
+    emit_warning(format!(
+        "FIPS runtime check skipped: probe ran via {program} but exited unexpectedly. \
+         Relying on the build-time link probe and the runtime constructor. \
+         Exit code: {exit_code:?}. Stderr: {stderr}",
+        program = program.to_string_lossy(),
+        exit_code = runtime_result.exit_code,
+        stderr = runtime_result.stderr,
+    ));
+
+    Ok(())
+}
+
+/// Returns `CARGO_TARGET_<TRIPLE>_RUNNER` as `[program, args...]`, if set.
+fn target_runner() -> Option<Vec<String>> {
+    let key = format!(
+        "CARGO_TARGET_{}_RUNNER",
+        target().replace(['-', '.'], "_").to_uppercase()
+    );
+    println!("cargo:rerun-if-env-changed={key}");
+    let value = std::env::var(&key).ok()?;
+    match parse_shell_words(&value) {
+        Ok(parts) if parts.is_empty() => None,
+        Ok(parts) => Some(parts),
+        Err(err) => {
+            emit_warning(format!("Ignoring invalid {key}: {err}"));
+            None
+        }
+    }
+}
+
+fn parse_shell_words(value: &str) -> Result<Vec<String>, String> {
+    #[derive(Clone, Copy)]
+    enum Quote {
+        Single,
+        Double,
+    }
+
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escape = false;
+
+    for ch in value.chars() {
+        if escape {
+            current.push(ch);
+            escape = false;
+            continue;
+        }
+
+        match quote {
+            Some(Quote::Single) => {
+                if ch == '\'' {
+                    quote = None;
+                } else {
+                    current.push(ch);
+                }
+            }
+            Some(Quote::Double) => match ch {
+                '"' => quote = None,
+                '\\' => escape = true,
+                _ => current.push(ch),
+            },
+            None => match ch {
+                '\'' => quote = Some(Quote::Single),
+                '"' => quote = Some(Quote::Double),
+                '\\' => escape = true,
+                _ if ch.is_whitespace() => {
+                    if !current.is_empty() {
+                        parts.push(std::mem::take(&mut current));
+                    }
+                }
+                _ => current.push(ch),
+            },
+        }
+    }
+
+    if escape {
+        return Err("runner ends with an unfinished escape".to_string());
+    }
+    if quote.is_some() {
+        return Err("runner contains an unmatched quote".to_string());
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+
+    Ok(parts)
+}
+
+#[cfg(test)]
+#[path = "fips_probe_tests.rs"]
+mod tests;

--- a/builder/fips_probe_tests.rs
+++ b/builder/fips_probe_tests.rs
@@ -1,0 +1,185 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+use super::*;
+use crate::system_library::ResolvedLib;
+use crate::{EnvGuard, ENV_MUTEX};
+use std::path::{Path, PathBuf};
+
+fn setup_test_env_with_target(os: &str, env: &str) -> Vec<EnvGuard> {
+    let arch = std::env::consts::ARCH;
+    let vars: &[(&str, &str)] = &[
+        ("CARGO_CFG_TARGET_OS", os),
+        ("CARGO_CFG_TARGET_ENV", env),
+        ("CARGO_CFG_TARGET_FEATURE", ""),
+        ("CARGO_CFG_TARGET_ARCH", arch),
+        ("CARGO_CFG_TARGET_POINTER_WIDTH", "64"),
+        ("TARGET", arch),
+        ("CARGO_PKG_NAME", "aws-lc-sys"),
+    ];
+
+    vars.iter()
+        .map(|(key, val)| EnvGuard::new(key, *val))
+        .collect()
+}
+
+fn os_args_to_strings(args: &[std::ffi::OsString]) -> Vec<String> {
+    args.iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn test_target_runner_parses_program_and_args() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _target = EnvGuard::new("TARGET", "aarch64-unknown-linux-gnu");
+    let _runner = EnvGuard::new(
+        "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER",
+        "qemu-aarch64 -L /usr/aarch64-linux-gnu",
+    );
+    assert_eq!(
+        target_runner(),
+        Some(vec![
+            "qemu-aarch64".to_string(),
+            "-L".to_string(),
+            "/usr/aarch64-linux-gnu".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn test_target_runner_preserves_quoted_path_and_arg() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _target = EnvGuard::new("TARGET", "aarch64-unknown-linux-gnu");
+    let _runner = EnvGuard::new(
+        "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER",
+        "\"/opt/Program Files/qemu-aarch64\" -L \"/sdk root\"",
+    );
+    assert_eq!(
+        target_runner(),
+        Some(vec![
+            "/opt/Program Files/qemu-aarch64".to_string(),
+            "-L".to_string(),
+            "/sdk root".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn test_target_runner_absent_is_none() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _target = EnvGuard::new("TARGET", "aws-lc-fips-sys-no-runner-triple");
+    assert_eq!(target_runner(), None);
+}
+
+#[test]
+fn test_target_runner_blank_is_none() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _target = EnvGuard::new("TARGET", "x86_64-pc-windows-gnu");
+    let _runner = EnvGuard::new("CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER", "   ");
+    assert_eq!(target_runner(), None);
+}
+
+#[test]
+fn test_probe_link_args_unix_static_orders_deps_after_crypto() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _env = setup_test_env_with_target("linux", "");
+    let crypto = ResolvedLib {
+        lib_type: OutputLibType::Static,
+        name: "crypto".to_string(),
+        path: PathBuf::from("/install/lib/libcrypto.a"),
+    };
+
+    let mut args = Vec::new();
+    append_probe_link_args(
+        &mut args,
+        false,
+        Path::new("/install/include"),
+        &crypto,
+        Path::new("/install/lib"),
+        Path::new("/repo/builder/fips_link_probe.c"),
+        Path::new("/out/aws_lc_fips_link_probe"),
+    );
+    let args = os_args_to_strings(&args);
+
+    assert!(args.contains(&"-I/install/include".to_string()), "{args:?}");
+    assert!(args.contains(&"-L/install/lib".to_string()), "{args:?}");
+
+    let crypto_idx = args
+        .iter()
+        .position(|a| a == "/install/lib/libcrypto.a")
+        .expect("libcrypto.a by path");
+    let dl_idx = args.iter().position(|a| a == "-ldl").expect("-ldl");
+    assert!(
+        crypto_idx < dl_idx,
+        "libcrypto.a must come before -ldl: {args:?}"
+    );
+    assert_eq!(
+        args.last().map(String::as_str),
+        Some("/out/aws_lc_fips_link_probe")
+    );
+    assert_eq!(args[args.len() - 2], "-o");
+    assert!(!args.iter().any(|a| a == "-lcrypto"), "{args:?}");
+}
+
+#[test]
+fn test_probe_link_args_unix_dynamic_omits_static_deps() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _env = setup_test_env_with_target("linux", "");
+    let crypto = ResolvedLib {
+        lib_type: OutputLibType::Dynamic,
+        name: "crypto-awslc".to_string(),
+        path: PathBuf::from("/install/lib/libcrypto-awslc.so"),
+    };
+
+    let mut args = Vec::new();
+    append_probe_link_args(
+        &mut args,
+        false,
+        Path::new("/install/include"),
+        &crypto,
+        Path::new("/install/lib"),
+        Path::new("/repo/builder/fips_link_probe.c"),
+        Path::new("/out/aws_lc_fips_link_probe"),
+    );
+    let args = os_args_to_strings(&args);
+
+    assert!(args.contains(&"-lcrypto-awslc".to_string()), "{args:?}");
+    assert!(
+        !args.iter().any(|a| a == "-ldl" || a == "-pthread"),
+        "{args:?}"
+    );
+}
+
+#[test]
+fn test_probe_link_args_msvc_passes_lib_by_path_after_link() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _env = setup_test_env_with_target("windows", "msvc");
+    let temp_out = tempfile::tempdir().unwrap();
+    let _out_dir = EnvGuard::new("OUT_DIR", temp_out.path());
+    let crypto = ResolvedLib {
+        lib_type: OutputLibType::Static,
+        name: "crypto".to_string(),
+        path: PathBuf::from("C:/install/lib/crypto.lib"),
+    };
+
+    let mut args = Vec::new();
+    append_probe_link_args(
+        &mut args,
+        true,
+        Path::new("C:/install/include"),
+        &crypto,
+        Path::new("C:/install/lib"),
+        Path::new("C:/repo/builder/fips_link_probe.c"),
+        Path::new("C:/out/aws_lc_fips_link_probe.exe"),
+    );
+    let args = os_args_to_strings(&args);
+
+    let link_idx = args.iter().position(|a| a == "/link").expect("/link");
+    let lib_idx = args
+        .iter()
+        .position(|a| a == "C:/install/lib/crypto.lib")
+        .expect("crypto.lib by path");
+    assert!(link_idx < lib_idx, "crypto.lib must follow /link: {args:?}");
+    assert!(!args.iter().any(|a| a == "/nologo"), "{args:?}");
+}

--- a/builder/fips_runtime_check.c
+++ b/builder/fips_runtime_check.c
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// Runtime FIPS-mode self-check for the system-library path.
+
+#include <openssl/crypto.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void aws_lc_fips_sys_runtime_check(void) {
+    if (!FIPS_mode()) {
+        fprintf(stderr,
+            "aws-lc-fips-sys: linked libcrypto is not running in FIPS mode; aborting.\n");
+        abort();
+    }
+}
+
+#if defined(_MSC_VER)
+
+// MSVC uses `.CRT$XCU` instead of `__attribute__((constructor))`.
+#pragma section(".CRT$XCU", read)
+__declspec(allocate(".CRT$XCU"))
+void (*aws_lc_fips_sys_runtime_check_assert_fips_mode_v1)(void) =
+    aws_lc_fips_sys_runtime_check;
+#if defined(_M_IX86)
+#pragma comment(linker, "/include:_aws_lc_fips_sys_runtime_check_assert_fips_mode_v1")
+#else
+#pragma comment(linker, "/include:aws_lc_fips_sys_runtime_check_assert_fips_mode_v1")
+#endif
+
+#else
+
+// On ELF/Mach-O this runs via `.init_array`. Uses a late priority so that
+// library constructors (including libcrypto's own init) run first.
+__attribute__((constructor(65535)))
+void aws_lc_fips_sys_runtime_check_assert_fips_mode_v1(void) {
+    aws_lc_fips_sys_runtime_check();
+}
+
+#endif

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -75,6 +75,7 @@ const OSSL_CONF_DEFINES: &[&str] = &[
 
 mod cc_builder;
 mod cmake_builder;
+mod fips_probe;
 mod nasm_builder;
 #[cfg(any(feature = "bindgen", feature = "fips"))]
 mod sys_bindgen;
@@ -105,6 +106,12 @@ impl Drop for EnvGuard {
         }
     }
 }
+
+/// Single process-wide lock serializing all tests that mutate env vars. Every
+/// builder test module must share this one; a per-module mutex lets tests race
+/// across modules and observe each other's partially-restored env state.
+#[cfg(test)]
+pub(crate) static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 pub(crate) fn is_fips_build() -> bool {
     is_fips_crate() || cfg!(feature = "fips")
@@ -382,11 +389,13 @@ fn target_platform_prefix(name: &str) -> String {
     }
 }
 
-pub(crate) struct TestCommandResult {
+pub(crate) struct CommandResult {
     #[allow(dead_code)]
     stderr: Box<str>,
     #[allow(dead_code)]
     stdout: Box<str>,
+    spawn_error: Option<Box<str>>,
+    exit_code: Option<i32>,
     executed: bool,
     status: bool,
 }
@@ -400,28 +409,35 @@ pub(crate) fn is_lto_flag(flag: &str) -> bool {
 }
 
 const MAX_CMD_OUTPUT_SIZE: usize = 1 << 15;
-fn execute_command(executable: &OsStr, args: &[&OsStr]) -> TestCommandResult {
-    if let Ok(mut result) = Command::new(executable).args(args).output() {
-        result.stderr.truncate(MAX_CMD_OUTPUT_SIZE);
-        let stderr = String::from_utf8(result.stderr)
-            .unwrap_or_default()
-            .into_boxed_str();
-        result.stdout.truncate(MAX_CMD_OUTPUT_SIZE);
-        let stdout = String::from_utf8(result.stdout)
-            .unwrap_or_default()
-            .into_boxed_str();
-        return TestCommandResult {
-            stderr,
-            stdout,
-            executed: true,
-            status: result.status.success(),
-        };
-    }
-    TestCommandResult {
-        stderr: String::new().into_boxed_str(),
-        stdout: String::new().into_boxed_str(),
-        executed: false,
-        status: false,
+fn execute_command(executable: &OsStr, args: &[&OsStr]) -> CommandResult {
+    match Command::new(executable).args(args).output() {
+        Ok(mut result) => {
+            let exit_code = result.status.code();
+            result.stderr.truncate(MAX_CMD_OUTPUT_SIZE);
+            let stderr = String::from_utf8(result.stderr)
+                .unwrap_or_default()
+                .into_boxed_str();
+            result.stdout.truncate(MAX_CMD_OUTPUT_SIZE);
+            let stdout = String::from_utf8(result.stdout)
+                .unwrap_or_default()
+                .into_boxed_str();
+            CommandResult {
+                stderr,
+                stdout,
+                spawn_error: None,
+                exit_code,
+                executed: true,
+                status: result.status.success(),
+            }
+        }
+        Err(err) => CommandResult {
+            stderr: String::new().into_boxed_str(),
+            stdout: String::new().into_boxed_str(),
+            spawn_error: Some(err.to_string().into_boxed_str()),
+            exit_code: None,
+            executed: false,
+            status: false,
+        },
     }
 }
 
@@ -587,16 +603,6 @@ fn get_builder(prefix: &Option<String>, manifest_dir: &Path, out_dir: &Path) -> 
         ))
     };
 
-    if is_fips_build() {
-        assert!(
-            get_system_dir_path().is_none(),
-            "System-library linking is not yet supported for FIPS builds.\n\
-             Unset {} to build from source.",
-            crate_env_var_name("SYSTEM_DIR"),
-        );
-        return cmake_builder_builder();
-    }
-
     if let Some(install_dir) = get_system_dir_path() {
         return Box::new(SystemLib::new(
             manifest_dir.to_path_buf(),
@@ -604,6 +610,10 @@ fn get_builder(prefix: &Option<String>, manifest_dir: &Path, out_dir: &Path) -> 
             get_system_bindings_path(),
             get_system_skip_version_check(),
         ));
+    }
+
+    if is_fips_build() {
+        return cmake_builder_builder();
     }
 
     let cc_builder_builder = || {
@@ -1081,6 +1091,42 @@ fn canonicalized_manifest_dir() -> PathBuf {
     #[cfg(windows)]
     let manifest_dir = to_short_path(&manifest_dir);
     manifest_dir
+}
+
+/// Links the startup FIPS-mode self-check for the system-library FIPS path.
+pub(crate) fn link_fips_runtime_check(
+    manifest_dir: &Path,
+    include_dir: &Path,
+) -> Result<(), String> {
+    let source = manifest_dir.join("builder").join("fips_runtime_check.c");
+    if !source.is_file() {
+        return Err(format!(
+            "FIPS runtime check source missing: {}",
+            source.display()
+        ));
+    }
+    println!("cargo:rerun-if-changed={}", source.display());
+
+    let mut cc_build = cc::Build::default();
+    cc_build
+        .file(&source)
+        .warnings(false)
+        // We emit the link directives ourselves (with +whole-archive), so
+        // suppress cc-rs's automatic emission.
+        .cargo_metadata(false)
+        // Silence cc-rs's `ar cqD` probe, which Apple's `ar` rejects (and
+        // cc-rs leaks as warnings before retrying). Real compile errors still
+        // surface from the build-time probe in verify_fips_install().
+        .cargo_warnings(false)
+        .include(include_dir);
+
+    let lib_name = "aws_lc_fips_runtime_check";
+    cc_build.compile(lib_name);
+
+    // Keep the constructor object in the final link.
+    println!("cargo:rustc-link-search=native={}", out_dir().display());
+    println!("cargo:rustc-link-lib=static:+whole-archive={lib_name}");
+    Ok(())
 }
 
 #[cfg(not(test))]

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -10,9 +10,11 @@
 //! one, locates the bindings, copies them into `OUT_DIR`, and emits the
 //! appropriate `cargo:` directives.
 
+use crate::fips_probe::verify_fips_install;
 use crate::{
-    crate_env_var_name, emit_rustc_cfg, emit_warning, get_aws_lc_include_path, is_static_library,
-    out_dir, target_env, target_os, Builder, OutputLibType,
+    crate_env_var_name, emit_rustc_cfg, emit_warning, get_aws_lc_include_path, is_fips_build,
+    is_static_library, link_fips_runtime_check, out_dir, target_env, target_os, Builder,
+    OutputLibType,
 };
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
@@ -165,15 +167,6 @@ impl SystemLib {
             }
         }
 
-        // AWS-LC's CMake does not rename the library file when BORINGSSL_PREFIX is
-        // set — only the symbols inside — and the pre-generated bindings shipped
-        // alongside the install are already prefix-aware. This is purely a
-        // diagnostic surface for the build log; no link-time handling is required.
-        let prefix_aware = include_dir
-            .join("openssl/boringssl_prefix_symbols.h")
-            .is_file();
-        emit_warning(format!("System AWS-LC: prefix-aware={prefix_aware}"));
-
         let bindings = resolve_bindings(install_dir, &self.bindings_file)?;
         std::fs::copy(&bindings, out_dir().join("bindings.rs"))
             .map_err(|e| format!("Failed to copy bindings from {}: {}", bindings.display(), e))?;
@@ -187,6 +180,15 @@ impl SystemLib {
             "Using system-installed AWS-LC from: {}",
             install_dir.display()
         ));
+
+        if is_fips_build() {
+            // Verify the supplied FIPS library before emitting the libcrypto
+            // link directive, then add the startup self-check.
+            let manifest_dir = self.manifest_dir.as_path();
+            verify_fips_install(manifest_dir, &include_dir, crypto_lib, lib_dir)?;
+            link_fips_runtime_check(manifest_dir, &include_dir)?;
+        }
+
         self.emit_link_directives(crypto_lib, &include_dir, lib_dir);
         Ok(())
     }

--- a/builder/system_library_tests.rs
+++ b/builder/system_library_tests.rs
@@ -2,13 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use super::*;
-use crate::EnvGuard;
-use std::sync::{Mutex, MutexGuard};
-
-/// Mutex to serialize tests that modify environment variables.
-/// Environment variables are process-global state, so tests that modify them
-/// must not run in parallel.
-static ENV_MUTEX: Mutex<()> = Mutex::new(());
+use crate::fips_probe::verify_fips_install;
+use crate::{EnvGuard, ENV_MUTEX};
+use std::sync::MutexGuard;
 
 /// RAII bundle that pairs a set of `EnvGuard`s (which restore env vars on
 /// drop) with the global `ENV_MUTEX` guard. Drop order is field-declaration
@@ -559,4 +555,150 @@ fn test_resolve_bindings_missing_returns_helpful_error() {
     let _env = setup_test_env();
     let err = resolve_bindings(temp.path(), &None).unwrap_err();
     assert!(err.contains("No pre-generated bindings found"), "{err}");
+}
+
+// -------------------------------------------------------------------------
+// FIPS verification (fixture-based integration tests)
+//
+// Skipped unless the matching env vars point at install prefixes containing
+// `include/` and `lib/`.
+// -------------------------------------------------------------------------
+
+/// Env-var name pointing at a real FIPS AWS-LC install (positive fixture).
+const FIXTURE_FIPS_ENV: &str = "AWS_LC_FIPS_SYS_FIXTURE_FIPS";
+/// Env-var name pointing at a real non-FIPS AWS-LC install (negative fixture).
+const FIXTURE_NONFIPS_ENV: &str = "AWS_LC_FIPS_SYS_FIXTURE_NONFIPS";
+
+/// Cargo env vars the FIPS verifier reads, with HOST == TARGET so the runtime
+/// probe path runs. `_temp_out_dir` keeps OUT_DIR alive; `_env` restores the
+/// env vars and releases the global mutex on drop.
+struct FixtureEnvGuard<'a> {
+    _env: TestEnvGuard<'a>,
+    _temp_out_dir: tempfile::TempDir,
+}
+
+fn repo_manifest_dir() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("builder-test lives under the repo root")
+}
+
+fn setup_fixture_env() -> FixtureEnvGuard<'static> {
+    // Acquire the env mutex first; layered EnvGuards below take effect under it.
+    let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let arch = std::env::consts::ARCH;
+    let host_triple = format!("{arch}-fixture-host");
+    let temp_out = tempfile::tempdir().unwrap();
+
+    let vars: Vec<(&str, String)> = vec![
+        ("CARGO_CFG_TARGET_OS", std::env::consts::OS.to_string()),
+        ("CARGO_CFG_TARGET_ENV", String::new()),
+        ("CARGO_CFG_TARGET_FEATURE", String::new()),
+        ("CARGO_CFG_TARGET_ARCH", arch.to_string()),
+        ("CARGO_CFG_TARGET_POINTER_WIDTH", "64".to_string()),
+        ("HOST", host_triple.clone()),
+        ("TARGET", host_triple),
+        ("CARGO_PKG_NAME", "aws-lc-fips-sys".to_string()),
+        ("OUT_DIR", temp_out.path().to_string_lossy().into_owned()),
+        // cc::Build::get_compiler() requires these to derive flags.
+        ("OPT_LEVEL", "0".to_string()),
+        ("DEBUG", "true".to_string()),
+    ];
+    let guards: Vec<EnvGuard> = vars
+        .iter()
+        .map(|(key, val)| EnvGuard::new(key, val.as_str()))
+        .collect();
+
+    FixtureEnvGuard {
+        _env: TestEnvGuard {
+            _guards: guards,
+            _lock: lock,
+        },
+        _temp_out_dir: temp_out,
+    }
+}
+
+/// Resolves `crypto` for an install rooted at `install_dir`, mirroring what
+/// `SystemLib::check_dependencies` does so the FIPS verifier can be invoked
+/// directly without the full builder setup.
+fn resolve_crypto_for_fixture(install_dir: &Path) -> ResolvedLib {
+    for sub in ["lib64", "lib"] {
+        let lib_dir = install_dir.join(sub);
+        if !lib_dir.is_dir() {
+            continue;
+        }
+        if let Ok(lib) = resolve_library(&lib_dir, None, "crypto", CRYPTO_LIB_CANDIDATES) {
+            return lib;
+        }
+    }
+    panic!(
+        "fixture {} does not contain a resolvable libcrypto",
+        install_dir.display()
+    );
+}
+
+#[test]
+fn test_verify_fips_library_accepts_fips_install() {
+    let Ok(install) = std::env::var(FIXTURE_FIPS_ENV) else {
+        eprintln!("skip: {FIXTURE_FIPS_ENV} not set");
+        return;
+    };
+    let install_dir = PathBuf::from(install);
+    assert!(
+        install_dir.is_dir(),
+        "{FIXTURE_FIPS_ENV}={} is not a directory",
+        install_dir.display()
+    );
+
+    let _env = setup_fixture_env();
+    let crypto_lib = resolve_crypto_for_fixture(&install_dir);
+    let lib_dir = crypto_lib
+        .path
+        .parent()
+        .expect("resolved libcrypto has no parent")
+        .to_path_buf();
+    let include_dir = install_dir.join("include");
+
+    verify_fips_install(repo_manifest_dir(), &include_dir, &crypto_lib, &lib_dir).expect(
+        "verify_fips_library should accept a real FIPS install (build-time + runtime probes)",
+    );
+}
+
+#[test]
+fn test_verify_fips_library_rejects_nonfips_install() {
+    let Ok(install) = std::env::var(FIXTURE_NONFIPS_ENV) else {
+        eprintln!("skip: {FIXTURE_NONFIPS_ENV} not set");
+        return;
+    };
+    let install_dir = PathBuf::from(install);
+    assert!(
+        install_dir.is_dir(),
+        "{FIXTURE_NONFIPS_ENV}={} is not a directory",
+        install_dir.display()
+    );
+
+    let _env = setup_fixture_env();
+    let crypto_lib = resolve_crypto_for_fixture(&install_dir);
+    let lib_dir = crypto_lib
+        .path
+        .parent()
+        .expect("resolved libcrypto has no parent")
+        .to_path_buf();
+    let include_dir = install_dir.join("include");
+
+    let err = verify_fips_install(repo_manifest_dir(), &include_dir, &crypto_lib, &lib_dir)
+        .expect_err("verify_fips_library must reject a non-FIPS install");
+    assert!(
+        err.contains("FIPS verification failed"),
+        "unexpected error message: {err}"
+    );
+    // Assert the failure is specifically the FIPS link-probe rejection, not an
+    // earlier stage (missing probe source, unusable compiler) or the runtime
+    // FIPS_mode() check. This is the unforgeable part of the check: a non-FIPS
+    // libcrypto does not export BORINGSSL_integrity_test, so the probe cannot
+    // link against it.
+    assert!(
+        err.contains("linker rejected the probe against"),
+        "error should be the FIPS link-probe rejection: {err}"
+    );
 }

--- a/scripts/tests/test_system_lib_fips.sh
+++ b/scripts/tests/test_system_lib_fips.sh
@@ -1,0 +1,323 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR ISC
+
+# Integration test script for system-library AWS-LC FIPS linking support.
+#
+# Usage:
+#   ./scripts/tests/test_system_lib_fips.sh <AWS_LC_FIPS_INSTALL_DIR>
+#
+# Required:
+#   AWS_LC_FIPS_INSTALL_DIR     AWS-LC FIPS installation (built with -DFIPS=1)
+#                               that provides the crypto library and headers.
+#
+# Optional environment variables:
+#   NONFIPS_INSTALL_DIR         Path to a non-FIPS AWS-LC install. Used to
+#                               verify that the FIPS probe correctly rejects
+#                               a non-FIPS library. Required for Test 5.
+#   PREFIXED_FIPS_INSTALL_DIR   Path to a FIPS AWS-LC install built with
+#                               BORINGSSL_PREFIX. Required for Test 6.
+#   INSTALL_WITH_BINDINGS_DIR   Path to a FIPS install that populated
+#                               share/rust/aws_lc_bindings.rs via
+#                               GENERATE_RUST_BINDINGS. Required for Test 7.
+#   ALLOW_SKIPS                 Set to "0" to fail the script if any test
+#                               gets skipped. Intended for CI, where every
+#                               fixture should be present. Default is "1"
+#                               (skip-tolerant), which is convenient for
+#                               local runs.
+#   SKIP_CLEAN                  Set to "1" to skip the initial `cargo clean`
+#                               during local iteration.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <AWS_LC_FIPS_INSTALL_DIR>"
+    echo ""
+    echo "This script tests linking aws-lc-fips-sys against a system-installed AWS-LC FIPS module."
+    echo ""
+    echo "Required:"
+    echo "  AWS_LC_FIPS_INSTALL_DIR    Path to AWS-LC FIPS installation directory"
+    echo ""
+    echo "Optional environment variables:"
+    echo "  NONFIPS_INSTALL_DIR          Path to a non-FIPS AWS-LC installation (negative fixture)"
+    echo "  PREFIXED_FIPS_INSTALL_DIR    Path to a prefixed FIPS AWS-LC installation"
+    echo "  INSTALL_WITH_BINDINGS_DIR    Path to FIPS installation with share/rust/aws_lc_bindings.rs"
+    echo "  ALLOW_SKIPS                  Set to 0 to fail on any skipped test (default 1)"
+    echo "  SKIP_CLEAN                   Set to 1 to skip the initial cargo clean"
+    echo ""
+    echo "Example:"
+    echo "  $0 /usr/local/aws-lc-fips"
+    exit 1
+fi
+
+INSTALL_DIR="$1"
+ALLOW_SKIPS="${ALLOW_SKIPS:-1}"
+
+cd "${REPO_ROOT}"
+
+echo "=== Testing system-library AWS-LC FIPS linking ==="
+echo "Repository root: ${REPO_ROOT}"
+echo "FIPS install directory: ${INSTALL_DIR}"
+echo "ALLOW_SKIPS: ${ALLOW_SKIPS}"
+echo ""
+
+# Validate install directory
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "ERROR: Install directory not found: $INSTALL_DIR"
+    exit 1
+fi
+
+if [ ! -d "$INSTALL_DIR/include/openssl" ]; then
+    echo "ERROR: Headers not found at $INSTALL_DIR/include/openssl"
+    exit 1
+fi
+
+if [ ! -d "$INSTALL_DIR/lib" ] && [ ! -d "$INSTALL_DIR/lib64" ]; then
+    echo "ERROR: Library directory not found at $INSTALL_DIR/lib or $INSTALL_DIR/lib64"
+    exit 1
+fi
+
+# Clean previous builds (set SKIP_CLEAN=1 to speed up repeated local runs)
+if [ "${SKIP_CLEAN:-0}" != "1" ]; then
+    echo "Cleaning previous builds..."
+    cargo clean
+fi
+
+# Temp files created during tests; cleaned up on exit.
+CLEANUP_FILES=()
+cleanup() { rm -f "${CLEANUP_FILES[@]}"; }
+trap cleanup EXIT
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+run_test() {
+    local test_name="$1"
+    local test_cmd="$2"
+
+    echo ""
+    echo "=== Test: $test_name ==="
+    if eval "$test_cmd"; then
+        echo "SUCCESS: $test_name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "FAILED: $test_name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+skip_test() {
+    local test_name="$1"
+    local reason="$2"
+    echo ""
+    echo "=== Test: $test_name ==="
+    echo "SKIPPED: $reason"
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+}
+
+# Args: <env_var_name> <path> <type: dir|file>
+# Returns 0 if fixture is valid, 1 otherwise.
+require_fixture() {
+    local var_name="$1"
+    local path="$2"
+    local kind="$3"
+
+    if [ -z "$path" ]; then
+        if [ "$ALLOW_SKIPS" = "0" ]; then
+            echo "ERROR: ${var_name} must be set (ALLOW_SKIPS=0)"
+            exit 1
+        fi
+        return 1
+    fi
+
+    case "$kind" in
+        dir)  [ -d "$path" ] && return 0 ;;
+        file) [ -f "$path" ] && return 0 ;;
+        *)    echo "internal error: unknown fixture kind '$kind'"; exit 2 ;;
+    esac
+
+    if [ "$ALLOW_SKIPS" = "0" ]; then
+        echo "ERROR: ${var_name} points to a missing ${kind}: ${path} (ALLOW_SKIPS=0)"
+        exit 1
+    fi
+    return 1
+}
+
+# Asserts that a cargo log file contains evidence the system-library path was
+# entered and the FIPS verification ran. Returns non-zero on failure.
+assert_system_fips_path() {
+    local log_file="$1"
+    if ! grep -q 'Using system-installed AWS-LC from' "$log_file"; then
+        echo "  ERROR: System-library code path was not entered (possible silent fallback to source build)."
+        return 1
+    fi
+    if ! grep -q 'FIPS verification' "$log_file"; then
+        echo "  ERROR: FIPS verification did not run on the system-library path."
+        return 1
+    fi
+    return 0
+}
+
+# Determine library linkage form: static on Linux, dynamic on macOS.
+# AWS-LC FIPS only supports static builds on Linux; macOS/Windows require shared.
+select_static_preference() {
+    case "$(uname -s)" in
+        Linux)  echo "1" ;;
+        *)      echo "0" ;;
+    esac
+}
+
+FIPS_STATIC="$(select_static_preference)"
+echo "FIPS link preference: $([ "$FIPS_STATIC" = "1" ] && echo "static" || echo "dynamic")"
+echo ""
+
+# Common env vars for FIPS system-library tests.
+# AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1 is set because the installed
+# library may not match the bundled submodule version exactly.
+FIPS_ENV_BASE="AWS_LC_FIPS_SYS_SYSTEM_DIR='$INSTALL_DIR' AWS_LC_FIPS_SYS_STATIC='$FIPS_STATIC' AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1"
+
+# For dynamic linking (macOS), the shared library must be discoverable at runtime.
+LIB_DIR="$INSTALL_DIR/lib"
+if [ -d "$INSTALL_DIR/lib64" ]; then
+    LIB_DIR="$INSTALL_DIR/lib64"
+fi
+
+case "$(uname)" in
+    Darwin) LIB_PATH_VAR="DYLD_LIBRARY_PATH" ;;
+    *)      LIB_PATH_VAR="LD_LIBRARY_PATH" ;;
+esac
+
+RUNTIME_LIB_PATH="${LIB_PATH_VAR}='${LIB_DIR}'"
+
+# Test 1: Build aws-lc-fips-sys with conventional bindings location.
+CONVENTIONAL_BINDINGS="$INSTALL_DIR/share/rust/aws_lc_bindings.rs"
+if require_fixture "INSTALL_DIR/share/rust/aws_lc_bindings.rs" "$CONVENTIONAL_BINDINGS" file; then
+    run_test "aws-lc-fips-sys build with conventional bindings" \
+        "${RUNTIME_LIB_PATH} ${FIPS_ENV_BASE} cargo build -vv -p aws-lc-fips-sys 2>&1 | tee /tmp/fips_test1.log && assert_system_fips_path /tmp/fips_test1.log"
+else
+    skip_test "aws-lc-fips-sys build with conventional bindings" \
+        "No share/rust/aws_lc_bindings.rs under \$INSTALL_DIR (GENERATE_RUST_BINDINGS was OFF)"
+fi
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 2: Build and test aws-lc-rs with FIPS feature.
+run_test "aws-lc-rs fips tests" \
+    "${RUNTIME_LIB_PATH} ${FIPS_ENV_BASE} cargo test -vv -p aws-lc-rs --no-default-features --features fips --lib 2>&1 | tee /tmp/fips_test2.log && assert_system_fips_path /tmp/fips_test2.log"
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 3: Explicit static linking (Linux only — macOS/Windows FIPS requires shared).
+if [ "$FIPS_STATIC" = "1" ]; then
+    run_test "aws-lc-rs fips tests, explicit static" \
+        "${RUNTIME_LIB_PATH} AWS_LC_FIPS_SYS_SYSTEM_DIR='$INSTALL_DIR' AWS_LC_FIPS_SYS_STATIC=1 AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1 cargo test -vv -p aws-lc-rs --no-default-features --features fips --lib 2>&1 | tee /tmp/fips_test3.log && assert_system_fips_path /tmp/fips_test3.log"
+else
+    # On macOS, test explicit dynamic linking.
+    run_test "aws-lc-rs fips tests, explicit dynamic" \
+        "${RUNTIME_LIB_PATH} AWS_LC_FIPS_SYS_SYSTEM_DIR='$INSTALL_DIR' AWS_LC_FIPS_SYS_STATIC=0 AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1 cargo test -vv -p aws-lc-rs --no-default-features --features fips --lib 2>&1 | tee /tmp/fips_test3.log && assert_system_fips_path /tmp/fips_test3.log"
+fi
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 4: Build aws-lc-fips-sys only (no tests — useful for verifying the
+# build script path in isolation).
+run_test "aws-lc-fips-sys build only" \
+    "${RUNTIME_LIB_PATH} ${FIPS_ENV_BASE} cargo build -vv -p aws-lc-fips-sys 2>&1 | tee /tmp/fips_test4.log && assert_system_fips_path /tmp/fips_test4.log"
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 5: Non-FIPS install must be rejected.
+#
+# The FIPS link probe checks for BORINGSSL_integrity_test, which is only
+# exported by FIPS builds. A non-FIPS library must cause a build failure.
+if require_fixture "NONFIPS_INSTALL_DIR" "$NONFIPS_INSTALL_DIR" dir; then
+    run_test "aws-lc-fips-sys rejects non-FIPS install" \
+        "if AWS_LC_FIPS_SYS_SYSTEM_DIR='$NONFIPS_INSTALL_DIR' AWS_LC_FIPS_SYS_STATIC=1 AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1 cargo build -p aws-lc-fips-sys -vv 2>&1 | tee /tmp/fips_test5.log; then
+            echo '  ERROR: Build unexpectedly succeeded against a non-FIPS install.'
+            false
+        else
+            if grep -q 'FIPS verification failed' /tmp/fips_test5.log; then
+                true
+            else
+                echo '  ERROR: Build failed, but not at the FIPS probe rejection.'
+                cat /tmp/fips_test5.log | tail -20
+                false
+            fi
+        fi"
+else
+    skip_test "aws-lc-fips-sys rejects non-FIPS install" \
+        "NONFIPS_INSTALL_DIR not set or directory doesn't exist"
+fi
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 6: Prefixed FIPS build.
+#
+# Exercises BORINGSSL_PREFIX detection with a FIPS install.
+if require_fixture "PREFIXED_FIPS_INSTALL_DIR" "$PREFIXED_FIPS_INSTALL_DIR" dir; then
+    run_test "aws-lc-fips-sys with prefixed FIPS install" \
+        "${RUNTIME_LIB_PATH} AWS_LC_FIPS_SYS_SYSTEM_DIR='$PREFIXED_FIPS_INSTALL_DIR' AWS_LC_FIPS_SYS_STATIC=1 AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1 cargo build -vv -p aws-lc-fips-sys 2>&1 | tee /tmp/fips_test6.log && assert_system_fips_path /tmp/fips_test6.log"
+else
+    skip_test "aws-lc-fips-sys with prefixed FIPS install" \
+        "PREFIXED_FIPS_INSTALL_DIR not set or directory doesn't exist"
+fi
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 7: Custom bindings override.
+#
+# Exercises the override branch in resolve_bindings: an explicit
+# AWS_LC_FIPS_SYS_SYSTEM_BINDINGS path beats the conventional location.
+if require_fixture "INSTALL_WITH_BINDINGS_DIR" "$INSTALL_WITH_BINDINGS_DIR" dir \
+    && require_fixture "INSTALL_WITH_BINDINGS_DIR/share/rust/aws_lc_bindings.rs" \
+        "$INSTALL_WITH_BINDINGS_DIR/share/rust/aws_lc_bindings.rs" file; then
+    OVERRIDE_BINDINGS="$(mktemp "${TMPDIR:-/tmp}/aws_lc_fips_bindings_override.XXXXXX.rs")"
+    CLEANUP_FILES+=("$OVERRIDE_BINDINGS")
+    cp "$INSTALL_WITH_BINDINGS_DIR/share/rust/aws_lc_bindings.rs" "$OVERRIDE_BINDINGS"
+    run_test "aws-lc-fips-sys with custom bindings override" \
+        "${RUNTIME_LIB_PATH} AWS_LC_FIPS_SYS_SYSTEM_DIR='$INSTALL_WITH_BINDINGS_DIR' AWS_LC_FIPS_SYS_STATIC='$FIPS_STATIC' AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1 AWS_LC_FIPS_SYS_SYSTEM_BINDINGS='$OVERRIDE_BINDINGS' cargo build -vv -p aws-lc-fips-sys 2>&1 | tee /tmp/fips_test7.log && assert_system_fips_path /tmp/fips_test7.log"
+else
+    skip_test "aws-lc-fips-sys with custom bindings override" \
+        "INSTALL_WITH_BINDINGS_DIR not set or bindings file doesn't exist"
+fi
+
+# Clean between tests
+cargo clean -p aws-lc-fips-sys -p aws-lc-rs 2>/dev/null || true
+
+# Test 8: Invalid SYSTEM_DIR must fail.
+run_test "aws-lc-fips-sys rejects invalid SYSTEM_DIR" \
+    "! AWS_LC_FIPS_SYS_SYSTEM_DIR='/nonexistent/path' cargo build -p aws-lc-fips-sys 2>/dev/null"
+
+# Summary
+echo ""
+echo "=========================================="
+echo "FIPS System Library Test Summary"
+echo "=========================================="
+echo "Passed:  $TESTS_PASSED"
+echo "Failed:  $TESTS_FAILED"
+echo "Skipped: $TESTS_SKIPPED"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    echo "RESULT: Some tests failed!"
+    exit 1
+fi
+
+if [ "$ALLOW_SKIPS" = "0" ] && [ $TESTS_SKIPPED -gt 0 ]; then
+    echo "RESULT: ${TESTS_SKIPPED} test(s) skipped with ALLOW_SKIPS=0; treating as failure."
+    exit 1
+fi
+
+echo "RESULT: All tests passed!"
+exit 0


### PR DESCRIPTION
## Motivation

Some consumers need to link against an AWS-LC FIPS module that is built or installed separately from the crate build. This allows those users to consume `aws-lc-fips-sys` while supplying their own AWS-LC FIPS `libcrypto`.

## Description

Adds support for linking `aws-lc-fips-sys` against a pre-existing AWS-LC FIPS installation via `AWS_LC_FIPS_SYS_SYSTEM_DIR`, mirroring the existing system-library flow for `aws-lc-sys`.

This path:
- Resolves `libcrypto` and optional `libssl` from the configured install prefix.
- Uses pre-generated bindings from either `AWS_LC_FIPS_SYS_SYSTEM_BINDINGS` or `<install_dir>/share/rust/aws_lc_bindings.rs`.
- Enforces installed AWS-LC version compatibility, with `AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1` as an override.
- Verifies the supplied library is a FIPS build by linking a probe against `BORINGSSL_integrity_test()`.
- Adds a runtime startup check that aborts if the linked library is not running in FIPS mode.
- Adds CI coverage for system-installed AWS-LC FIPS builds.

## Testing

- Added builder unit coverage for system-library FIPS resolution and probe argument assembly.
- Added GitHub Actions coverage for system-installed AWS-LC FIPS.
- Ran `cargo fmt --check`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
