### PR TITLE
fix(builder): select flag dialect by compiler driver mode, not target ABI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -875,14 +875,50 @@ jobs:
       - name: Install Rust
         shell: pwsh
         run: rustup toolchain install stable --profile minimal
-      - name: Run cargo build
+      # `-flto=thin` makes clang emit LLVM bitcode objects, so use `lld-link`
+      # from the same LLVM install for this GNU-driver-mode-on-MSVC-ABI lane.
+      #
+      # `--tests` skips doctests because rustdoc would still link them via
+      # `link.exe`; doctests are covered by the non-LTO Windows jobs.
+      - name: Run cargo build & test
         shell: pwsh
         run: |
           $env:CC='${{ matrix.cc }}'
           $env:CXX='${{ matrix.cxx }}'
           $env:AR='llvm-lib'
           $env:CFLAGS='${{ matrix.cflags }}'
+          $env:RUSTFLAGS='-Clinker=lld-link'
           cargo build -p aws-lc-rs
+          cargo test -p aws-lc-rs --tests
+
+  windows-clang-cl:
+    if: github.repository_owner == 'aws'
+    # Explicit clang-cl baseline for the cl-driver-mode side of #1146.
+    name: Windows clang-cl - ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+    runs-on: windows-latest
+    env:
+      CC: clang-cl
+      CXX: clang-cl
+      AWS_LC_SYS_PREBUILT_NASM: 1
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+      - name: Install Rust toolchain
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal --target ${{ matrix.target }} --no-self-update
+          rustup default stable
+      - name: Run cargo build & test
+        shell: pwsh
+        run: |
+          cargo build -p aws-lc-rs --target ${{ matrix.target }}
+          cargo test -p aws-lc-rs --target ${{ matrix.target }}
 
   hardened-environment:
     if: github.repository_owner == 'aws'

--- a/book/src/requirements/windows.md
+++ b/book/src/requirements/windows.md
@@ -43,6 +43,26 @@ scenarios or when using MSYS2/MinGW environments. When using Clang:
 * Ensure `clang` or `clang-cl` is available in your PATH
 * For MSYS2 environments, the `clang64` or `ucrt64` subsystems provide Clang toolchains
 
+#### Clang driver mode on the MSVC ABI
+
+For `*-pc-windows-msvc` targets, the C compiler flag *dialect* is determined by the compiler's
+**driver mode**, not by the target ABI:
+
+* `clang-cl` (like `cl.exe`) runs in **cl driver mode** and takes MSVC-style flags (`/Od`, `/FI`, ...).
+* plain `clang` (for example `CC=clang`, or cross-compiling with [`cargo-xwin`]) runs in **GNU driver
+  mode** and takes GNU-style flags, even when targeting the MSVC ABI.
+
+Both driver modes are supported, and both are exercised in CI for `x86_64-pc-windows-msvc`. If you
+override `CC`, the rest of the build environment (such as `AR`) should match the driver mode of the
+compiler you select.
+
+> **Note:** If you build the C sources with LTO under plain `clang` (e.g. `CFLAGS=-flto=thin`), the
+> resulting objects are LLVM bitcode, which the default MSVC `link.exe` cannot consume. Link with
+> `lld-link` from the same LLVM toolchain (for example `RUSTFLAGS=-Clinker=lld-link`) so the bitcode
+> is understood.
+
+[`cargo-xwin`]: https://github.com/rust-cross/cargo-xwin
+
 ## CMake
 
 CMake is only required for FIPS builds on Windows.

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -453,10 +453,8 @@ impl CcBuilder {
         }
     }
 
-    fn prepare_jitter_entropy_builder(&self) -> cc::Build {
+    fn prepare_jitter_entropy_builder(&self, is_cl_like: bool) -> cc::Build {
         // See: https://github.com/aws/aws-lc/blob/2294510cd0ecb2d5946461e3dbb038363b7b94cb/third_party/jitterentropy/CMakeLists.txt#L19-L35
-        // Resolve the flag dialect here so the caller cannot pass the wrong mode.
-        let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
         let mut build_options: Vec<BuildOption> = Vec::new();
         self.add_includes(&mut build_options);
         self.add_defines(&mut build_options, is_cl_like);
@@ -618,7 +616,7 @@ impl CcBuilder {
         s2n_bignum_builder.define("S2N_BN_HIDE_SYMBOLS", "1");
 
         // CPU Jitter Entropy is compiled separately due to needing specific flags
-        let mut jitter_entropy_builder = self.prepare_jitter_entropy_builder();
+        let mut jitter_entropy_builder = self.prepare_jitter_entropy_builder(is_cl_like);
         jitter_entropy_builder.flag(format!(
             "{}{}",
             force_include_option,

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -458,11 +458,13 @@ impl CcBuilder {
         }
     }
 
-    fn prepare_jitter_entropy_builder(&self, is_msvc_target: bool) -> cc::Build {
+    fn prepare_jitter_entropy_builder(&self) -> cc::Build {
         // See: https://github.com/aws/aws-lc/blob/2294510cd0ecb2d5946461e3dbb038363b7b94cb/third_party/jitterentropy/CMakeLists.txt#L19-L35
+        // Resolve the flag dialect here so the caller cannot pass the wrong mode.
+        let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
         let mut build_options: Vec<BuildOption> = Vec::new();
         self.add_includes(&mut build_options);
-        self.add_defines(&mut build_options, is_msvc_target);
+        self.add_defines(&mut build_options, is_cl_like);
 
         let mut je_builder = cc::Build::new();
         for option in build_options {
@@ -478,31 +480,14 @@ impl CcBuilder {
         if target_os() != "windows" {
             je_builder.pic(true);
         }
-        if is_msvc_target {
-            je_builder.flag("-Od").flag("-W4").flag("-DYNAMICBASE");
-        } else {
-            je_builder
-                .flag("-fwrapv")
-                .flag("--param")
-                .flag("ssp-buffer-size=4")
-                .flag("-fvisibility=hidden")
-                .flag("-Wcast-align")
-                .flag("-Wmissing-field-initializers")
-                .flag("-Wshadow")
-                .flag("-Wswitch-enum")
-                .flag("-Wextra")
-                .flag("-Wall")
-                .flag("-pedantic")
-                // Compilation will fail if optimizations are enabled.
-                .flag("-O0")
-                .flag("-fwrapv")
-                .flag("-Wconversion");
+        for &flag in Self::jitter_entropy_dialect_flags(is_cl_like) {
+            je_builder.flag(flag);
         }
 
         // Jitter uses a separate `cc::Build`, so it needs its own path-mapping
         // flags even when the main builder already has them. Apply them here
         // unconditionally because jitter is always compiled at `-O0`.
-        for option in self.collect_path_reproducibility_options(&je_builder, is_like_msvc) {
+        for option in self.collect_path_reproducibility_options(&je_builder, is_cl_like) {
             option.apply_cc(&mut je_builder);
         }
         je_builder
@@ -544,6 +529,35 @@ impl CcBuilder {
         }
 
         opts
+    }
+
+    /// Dialect-specific compiler flags for the jitterentropy sub-build.
+    ///
+    /// Keyed on compiler driver mode: `clang-cl` rejects the GNU-only
+    /// `--param ssp-buffer-size=4` pair, while plain `clang` rejects the
+    /// cl-style `-Od`/`-W4` flags. See: <https://github.com/aws/aws-lc-rs/issues/1146>
+    fn jitter_entropy_dialect_flags(is_cl_like: bool) -> &'static [&'static str] {
+        if is_cl_like {
+            &["-Od", "-W4", "-DYNAMICBASE"]
+        } else {
+            &[
+                "-fwrapv",
+                "--param",
+                "ssp-buffer-size=4",
+                "-fvisibility=hidden",
+                "-Wcast-align",
+                "-Wmissing-field-initializers",
+                "-Wshadow",
+                "-Wswitch-enum",
+                "-Wextra",
+                "-Wall",
+                "-pedantic",
+                // Compilation will fail if optimizations are enabled.
+                "-O0",
+                "-fwrapv",
+                "-Wconversion",
+            ]
+        }
     }
 
     /// The cc crate appends CFLAGS at the end of the compiler command line,
@@ -610,7 +624,7 @@ impl CcBuilder {
         s2n_bignum_builder.define("S2N_BN_HIDE_SYMBOLS", "1");
 
         // CPU Jitter Entropy is compiled separately due to needing specific flags
-        let mut jitter_entropy_builder = self.prepare_jitter_entropy_builder(is_cl_like);
+        let mut jitter_entropy_builder = self.prepare_jitter_entropy_builder();
         jitter_entropy_builder.flag(format!(
             "{}{}",
             force_include_option,
@@ -956,5 +970,79 @@ impl crate::Builder for CcBuilder {
 
     fn name(&self) -> &'static str {
         "CC"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EnvGuard, ENV_MUTEX};
+
+    /// Runs `f` with `CARGO_CFG_TARGET_ENV` forced to `env_val`, restoring the
+    /// previous value afterward. Holds the shared env lock so it doesn't race
+    /// other env-mutating builder tests.
+    fn with_target_env<R>(env_val: &str, f: impl FnOnce() -> R) -> R {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = EnvGuard::new("CARGO_CFG_TARGET_ENV", env_val);
+        f()
+    }
+
+    #[test]
+    fn test_target_is_msvc_matches_msvc_abi_only() {
+        assert!(with_target_env("msvc", target_is_msvc));
+        assert!(!with_target_env("gnu", target_is_msvc));
+        assert!(!with_target_env("musl", target_is_msvc));
+        assert!(!with_target_env("", target_is_msvc));
+    }
+
+    // Guards https://github.com/aws/aws-lc-rs/issues/1146: in cl driver mode
+    // the GNU-only `--param ssp-buffer-size=4` pair (rejected by `clang-cl`)
+    // must never be selected.
+    #[test]
+    fn test_jitter_entropy_flags_cl_dialect_omit_gnu_only() {
+        let cl = CcBuilder::jitter_entropy_dialect_flags(true);
+        assert!(
+            !cl.contains(&"--param") && !cl.contains(&"ssp-buffer-size=4"),
+            "cl-mode jitter flags must not contain the GNU-only ssp-buffer-size pair: {cl:?}"
+        );
+        assert!(cl.contains(&"-Od"), "expected cl-style -Od: {cl:?}");
+    }
+
+    // Guards the inverse of #1146: in GNU driver mode (e.g. plain `clang`, even
+    // on a windows-msvc target) the cl-only `-Od`/`-W4` flags must not be
+    // selected and the GNU hardening flags must be preserved.
+    #[test]
+    fn test_jitter_entropy_gnu_dialect_keeps_hardening_flags() {
+        let gnu = CcBuilder::jitter_entropy_dialect_flags(false);
+        assert!(gnu.contains(&"--param"));
+        assert!(gnu.contains(&"ssp-buffer-size=4"));
+        assert!(
+            !gnu.contains(&"-Od"),
+            "GNU dialect must not use cl-style -Od: {gnu:?}"
+        );
+        // jitterentropy must always be built unoptimized.
+        assert!(gnu.contains(&"-O0"), "expected -O0: {gnu:?}");
+    }
+
+    // Driver mode is selected by the compiler program name (argv[0]); this is
+    // the robust fallback when `cc`'s family probe misfires. `clang-cl`/`cl`
+    // are cl mode; plain `clang`/`gcc` are not -- guarding both #1146 and its
+    // inverse (plain clang on a windows-msvc target).
+    #[test]
+    fn test_program_name_is_cl_driver() {
+        use crate::program_name_is_cl_driver;
+        use std::path::Path;
+        for cl in ["clang-cl", "clang-cl.exe", "CLANG-CL.EXE", "cl", "cl.exe"] {
+            assert!(
+                program_name_is_cl_driver(Path::new(cl)),
+                "{cl} should be detected as cl driver mode"
+            );
+        }
+        for gnu in ["clang", "clang.exe", "clang-18", "gcc", "cc"] {
+            assert!(
+                !program_name_is_cl_driver(Path::new(gnu)),
+                "{gnu} should not be detected as cl driver mode"
+            );
+        }
     }
 }

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -191,8 +191,6 @@ impl CcBuilder {
     ) -> (bool, Vec<BuildOption>) {
         let mut build_options: Vec<BuildOption> = Vec::new();
 
-        // Flag dialect follows the compiler driver mode, not the target ABI;
-        // see `compiler_is_cl_like`.
         let is_cl_like = compiler_is_cl_like(&cc_build.get_compiler());
 
         match requested_c_std() {
@@ -287,8 +285,6 @@ impl CcBuilder {
 
     pub fn collect_cc_only_build_options(&self) -> Vec<BuildOption> {
         let mut build_options: Vec<BuildOption> = Vec::new();
-        // GNU-only flags below are gated on the compiler driver mode, not the
-        // target ABI; see `compiler_is_cl_like`.
         let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
         if !is_cl_like {
             build_options.push(BuildOption::flag("-Wno-unused-parameter"));
@@ -366,8 +362,7 @@ impl CcBuilder {
         }
 
         let mut cc_build = self.create_builder();
-        let (compiler_is_msvc, build_options) =
-            self.collect_universal_build_options(&cc_build, false);
+        let (is_cl_like, build_options) = self.collect_universal_build_options(&cc_build, false);
         for option in build_options {
             option.apply_cc(&mut cc_build);
         }
@@ -385,7 +380,7 @@ impl CcBuilder {
         // and skip paths with spaces because `-Wa,...` must stay a bare token.
         let opt_level = cargo_env("OPT_LEVEL");
         if (target_os() == "linux" || target_os().ends_with("bsd"))
-            && !compiler_is_msvc
+            && !is_cl_like
             && !matches!(opt_level.as_str(), "0" | "1" | "2")
             && !self.manifest_dir.to_string_lossy().contains(' ')
         {
@@ -495,14 +490,15 @@ impl CcBuilder {
 
     /// Returns path-reproducibility flags for the configured compiler.
     /// These rewrite DWARF source paths and `__FILE__`; clang may also need
-    /// extra stripping for `UBSan` metadata. Returns an empty `Vec` on MSVC.
+    /// extra stripping for `UBSan` metadata. Returns an empty `Vec` in cl
+    /// driver mode, which has no equivalent flags.
     fn collect_path_reproducibility_options(
         &self,
         cc_build: &cc::Build,
-        is_like_msvc: bool,
+        is_cl_like: bool,
     ) -> Vec<BuildOption> {
         let mut opts: Vec<BuildOption> = Vec::new();
-        if is_like_msvc {
+        if is_cl_like {
             return opts;
         }
 
@@ -605,8 +601,6 @@ impl CcBuilder {
     }
 
     fn add_all_files(&self, sources: &[&'static str], cc_build: &mut cc::Build) {
-        // Force-include flag syntax follows the compiler driver mode, not the
-        // target ABI; see `compiler_is_cl_like`.
         let is_cl_like = compiler_is_cl_like(&cc_build.get_compiler());
 
         let force_include_option = if is_cl_like { "/FI" } else { "--include=" };
@@ -774,8 +768,7 @@ impl CcBuilder {
             cc_build.flag(flag);
         }
 
-        // Capability probe of the actual compiler, so keyed on the family
-        // (not the target ABI): only adds a GNU-style flag to a throwaway probe.
+        // GNU-style flag, so gated on the actual compiler family.
         let compiler = cc_build.get_compiler();
         if compiler.is_like_gnu() || compiler.is_like_clang() {
             cc_build.flag("-Wno-unused-parameter");
@@ -814,12 +807,8 @@ impl CcBuilder {
         let exec_path = out_dir().join(basename);
         let memcmp_build = cc::Build::default();
         let memcmp_compiler = memcmp_build.get_compiler();
-        // The logic below assumes a Clang or GCC compiler; skip otherwise. This
-        // is a property of the actual compiler, so it is keyed on the family
-        // rather than the target ABI. Kept as an explicit "not clang and not
-        // gnu" gate (rather than `is_like_msvc()`) so an unrecognized future
-        // compiler family is skipped rather than run through Clang/GCC logic --
-        // mirroring the supported-compiler gate in `fips_probe`.
+        // The logic below assumes a Clang or GCC compiler; skip any other
+        // family (keyed on the compiler, not the target ABI).
         if !memcmp_compiler.is_like_clang() && !memcmp_compiler.is_like_gnu() {
             return;
         }

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -19,10 +19,10 @@ mod win_x86_64;
 
 use crate::nasm_builder::NasmBuilder;
 use crate::{
-    cargo_env, emit_warning, env_var_to_bool, execute_command, find_clang_cl, get_crate_cc,
-    get_crate_cflags, get_crate_cxx, is_link_whole_archive, is_no_asm, out_dir, requested_c_std,
-    set_env_for_target, should_build_jitter_entropy, target, target_arch, target_env, target_os,
-    target_vendor, CStdRequested, EnvGuard, OutputLibType,
+    cargo_env, compiler_is_cl_like, emit_warning, env_var_to_bool, execute_command, find_clang_cl,
+    get_crate_cc, get_crate_cflags, get_crate_cxx, is_link_whole_archive, is_no_asm, out_dir,
+    requested_c_std, set_env_for_target, should_build_jitter_entropy, target, target_arch,
+    target_env, target_is_msvc, target_os, target_vendor, CStdRequested, EnvGuard, OutputLibType,
 };
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -133,9 +133,9 @@ impl BuildOption {
     pub(crate) fn apply_cmake<'a>(
         &self,
         cmake_cfg: &'a mut cmake::Config,
-        is_like_msvc: bool,
+        is_cl_like: bool,
     ) -> &'a mut cmake::Config {
-        if is_like_msvc {
+        if is_cl_like {
             match self {
                 BuildOption::STD(val) => cmake_cfg.define(
                     "CMAKE_C_STANDARD",
@@ -191,10 +191,9 @@ impl CcBuilder {
     ) -> (bool, Vec<BuildOption>) {
         let mut build_options: Vec<BuildOption> = Vec::new();
 
-        let compiler_is_msvc = {
-            let compiler = cc_build.get_compiler();
-            !compiler.is_like_gnu() && !compiler.is_like_clang()
-        };
+        // Flag dialect follows the compiler driver mode, not the target ABI;
+        // see `compiler_is_cl_like`.
+        let is_cl_like = compiler_is_cl_like(&cc_build.get_compiler());
 
         match requested_c_std() {
             CStdRequested::C99 => {
@@ -204,7 +203,7 @@ impl CcBuilder {
                 build_options.push(BuildOption::std("c11"));
             }
             CStdRequested::None => {
-                if !compiler_is_msvc {
+                if !is_cl_like {
                     if self.compiler_check("c11", Vec::<String>::new()) {
                         build_options.push(BuildOption::std("c11"));
                     } else {
@@ -221,7 +220,7 @@ impl CcBuilder {
             set_env_for_target("CXX", &cxx);
         }
 
-        if target_arch() == "x86" && !compiler_is_msvc {
+        if target_arch() == "x86" && !is_cl_like {
             if let Some(option) = BuildOption::flag_if_supported(cc_build, "-msse2") {
                 build_options.push(option);
             }
@@ -245,7 +244,7 @@ impl CcBuilder {
                     !is_no_asm(),
                     "AWS_LC_SYS_NO_ASM only allowed for debug builds!"
                 );
-                if !compiler_is_msvc {
+                if !is_cl_like {
                     let path_str = if do_quote_paths {
                         format!("\"{}\"", self.manifest_dir.display())
                     } else {
@@ -283,16 +282,15 @@ impl CcBuilder {
                 build_options.push(option);
             }
         }
-        (compiler_is_msvc, build_options)
+        (is_cl_like, build_options)
     }
 
-    pub fn collect_cc_only_build_options(&self, cc_build: &cc::Build) -> Vec<BuildOption> {
+    pub fn collect_cc_only_build_options(&self) -> Vec<BuildOption> {
         let mut build_options: Vec<BuildOption> = Vec::new();
-        let is_like_msvc = {
-            let compiler = cc_build.get_compiler();
-            !compiler.is_like_gnu() && !compiler.is_like_clang()
-        };
-        if !is_like_msvc {
+        // GNU-only flags below are gated on the compiler driver mode, not the
+        // target ABI; see `compiler_is_cl_like`.
+        let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
+        if !is_cl_like {
             build_options.push(BuildOption::flag("-Wno-unused-parameter"));
             build_options.push(BuildOption::flag("-pthread"));
             if target_os() == "linux" {
@@ -306,7 +304,7 @@ impl CcBuilder {
             build_options.push(BuildOption::define("DISABLE_CPU_JITTER_ENTROPY", "1"));
         }
         self.add_includes(&mut build_options);
-        self.add_defines(&mut build_options, is_like_msvc);
+        self.add_defines(&mut build_options, is_cl_like);
 
         build_options
     }
@@ -355,7 +353,7 @@ impl CcBuilder {
 
     pub fn create_builder(&self) -> cc::Build {
         let mut cc_build = cc::Build::new();
-        let build_options = self.collect_cc_only_build_options(&cc_build);
+        let build_options = self.collect_cc_only_build_options();
         for option in build_options {
             option.apply_cc(&mut cc_build);
         }
@@ -414,7 +412,7 @@ impl CcBuilder {
     }
 
     #[allow(clippy::unused_self)]
-    fn add_defines(&self, build_options: &mut Vec<BuildOption>, is_like_msvc: bool) {
+    fn add_defines(&self, build_options: &mut Vec<BuildOption>, is_cl_like: bool) {
         // WIN32_LEAN_AND_MEAN and NOMINMAX are needed for all Windows targets to avoid
         // header type definition errors, no matter the compiler. This matches the behavior
         // in aws-lc/CMakeLists.txt, which defines these for all WIN32 targets
@@ -425,12 +423,14 @@ impl CcBuilder {
 
         // Suppress MSVC CRT deprecation warnings (fopen, getenv, strerror, etc.).
         // This applies to any compiler targeting the MSVC environment since the
-        // warnings originate from the Windows SDK/CRT headers, not the compiler.
-        if target_env() == "msvc" {
+        // warnings originate from the Windows SDK/CRT headers, not the compiler,
+        // so it is keyed on the target ABI rather than the driver mode.
+        if target_is_msvc() {
             build_options.push(BuildOption::define("_CRT_SECURE_NO_WARNINGS", "1"));
         }
 
-        if is_like_msvc {
+        // MSVC STL macros: only meaningful when compiling in cl driver mode.
+        if is_cl_like {
             build_options.push(BuildOption::define("_HAS_EXCEPTIONS", "0"));
             build_options.push(BuildOption::define(
                 "_STL_EXTRA_DISABLED_WARNINGS",
@@ -452,17 +452,17 @@ impl CcBuilder {
             // from using it even when `_WIN32_WINNT` targets Win7. We define
             // AWSLC_WINDOWS_7_COMPAT directly to bypass that guard until the
             // upstream fix lands: https://github.com/aws/aws-lc/pull/3239
-            if !is_like_msvc {
+            if !is_cl_like {
                 build_options.push(BuildOption::define("AWSLC_WINDOWS_7_COMPAT", ""));
             }
         }
     }
 
-    fn prepare_jitter_entropy_builder(&self, is_like_msvc: bool) -> cc::Build {
+    fn prepare_jitter_entropy_builder(&self, is_msvc_target: bool) -> cc::Build {
         // See: https://github.com/aws/aws-lc/blob/2294510cd0ecb2d5946461e3dbb038363b7b94cb/third_party/jitterentropy/CMakeLists.txt#L19-L35
         let mut build_options: Vec<BuildOption> = Vec::new();
         self.add_includes(&mut build_options);
-        self.add_defines(&mut build_options, is_like_msvc);
+        self.add_defines(&mut build_options, is_msvc_target);
 
         let mut je_builder = cc::Build::new();
         for option in build_options {
@@ -478,7 +478,7 @@ impl CcBuilder {
         if target_os() != "windows" {
             je_builder.pic(true);
         }
-        if is_like_msvc {
+        if is_msvc_target {
             je_builder.flag("-Od").flag("-W4").flag("-DYNAMICBASE");
         } else {
             je_builder
@@ -556,7 +556,7 @@ impl CcBuilder {
     ///   1. `CFLAGS_{target}` (e.g. `CFLAGS_x86_64_unknown_freebsd`)
     ///   2. `HOST_CFLAGS` or `TARGET_CFLAGS`
     ///   3. `CFLAGS`
-    fn jitter_entropy_cflags_guards(is_like_msvc: bool) -> Vec<EnvGuard> {
+    fn jitter_entropy_cflags_guards(is_cl_like: bool) -> Vec<EnvGuard> {
         let target_u = target().to_lowercase().replace('-', "_");
 
         let cflags_env_names: Vec<String> = vec![
@@ -572,7 +572,7 @@ impl CcBuilder {
                 .filter(|flag| !flag.starts_with("-O") && !flag.starts_with("/O"))
                 .collect::<Vec<_>>()
                 .join(" ");
-            if is_like_msvc {
+            if is_cl_like {
                 format!("{filtered} -Od").trim().to_string()
             } else {
                 format!("{filtered} -O0 -U_FORTIFY_SOURCE")
@@ -591,13 +591,11 @@ impl CcBuilder {
     }
 
     fn add_all_files(&self, sources: &[&'static str], cc_build: &mut cc::Build) {
-        let compiler = cc_build.get_compiler();
+        // Force-include flag syntax follows the compiler driver mode, not the
+        // target ABI; see `compiler_is_cl_like`.
+        let is_cl_like = compiler_is_cl_like(&cc_build.get_compiler());
 
-        let force_include_option = if compiler.is_like_msvc() {
-            "/FI"
-        } else {
-            "--include="
-        };
+        let force_include_option = if is_cl_like { "/FI" } else { "--include=" };
         // s2n-bignum is compiled separately due to needing extra flags
         let mut s2n_bignum_builder = cc_build.clone();
         s2n_bignum_builder.flag(format!(
@@ -612,8 +610,7 @@ impl CcBuilder {
         s2n_bignum_builder.define("S2N_BN_HIDE_SYMBOLS", "1");
 
         // CPU Jitter Entropy is compiled separately due to needing specific flags
-        let mut jitter_entropy_builder =
-            self.prepare_jitter_entropy_builder(compiler.is_like_msvc());
+        let mut jitter_entropy_builder = self.prepare_jitter_entropy_builder(is_cl_like);
         jitter_entropy_builder.flag(format!(
             "{}{}",
             force_include_option,
@@ -681,7 +678,7 @@ impl CcBuilder {
             cc_build.object(object);
         }
         if should_build_jitter_entropy() {
-            let _je_cflags_guards = Self::jitter_entropy_cflags_guards(compiler.is_like_msvc());
+            let _je_cflags_guards = Self::jitter_entropy_cflags_guards(is_cl_like);
             let jitter_entropy_object_files = jitter_entropy_builder.compile_intermediates();
             for object in jitter_entropy_object_files {
                 cc_build.object(object);
@@ -763,6 +760,8 @@ impl CcBuilder {
             cc_build.flag(flag);
         }
 
+        // Capability probe of the actual compiler, so keyed on the family
+        // (not the target ABI): only adds a GNU-style flag to a throwaway probe.
         let compiler = cc_build.get_compiler();
         if compiler.is_like_gnu() || compiler.is_like_clang() {
             cc_build.flag("-Wno-unused-parameter");
@@ -801,8 +800,13 @@ impl CcBuilder {
         let exec_path = out_dir().join(basename);
         let memcmp_build = cc::Build::default();
         let memcmp_compiler = memcmp_build.get_compiler();
+        // The logic below assumes a Clang or GCC compiler; skip otherwise. This
+        // is a property of the actual compiler, so it is keyed on the family
+        // rather than the target ABI. Kept as an explicit "not clang and not
+        // gnu" gate (rather than `is_like_msvc()`) so an unrecognized future
+        // compiler family is skipped rather than run through Clang/GCC logic --
+        // mirroring the supported-compiler gate in `fips_probe`.
         if !memcmp_compiler.is_like_clang() && !memcmp_compiler.is_like_gnu() {
-            // The logic below assumes a Clang or GCC compiler is in use
             return;
         }
         // Only pass -O3 to trigger the optimization bug. We intentionally ignore
@@ -880,7 +884,7 @@ impl CcBuilder {
         // try_compile_intermediates succeeds but __builtin_bswap* are unresolved at
         // link time. Without this guard the define is set and crypto/internal.h skips
         // the correct _MSC_VER path that uses _byteswap_* intrinsics.
-        if target_env() != "msvc"
+        if !target_is_msvc()
             && self.compiler_check("builtin_swap_check", Vec::<&'static str>::new())
         {
             cc_build.define("AWS_LC_BUILTIN_SWAP_SUPPORTED", Some("1"));
@@ -926,7 +930,7 @@ impl crate::Builder for CcBuilder {
     fn build(&self) -> Result<(), String> {
         if target_os() == "windows"
             && target_arch() == "aarch64"
-            && target_env() == "msvc"
+            && target_is_msvc()
             && get_crate_cc().is_none()
         {
             if let Some(clang_cl) = find_clang_cl() {

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -109,7 +109,7 @@ impl CmakeBuilder {
         // `-Wa,--debug-prefix-map=...`, and skip paths with spaces because the
         // flag must survive CMake and the assembler as one bare token.
         let opt_level = cargo_env("OPT_LEVEL");
-        if !is_like_msvc
+        if !is_cl_like
             && (target_os() == "linux" || target_os().ends_with("bsd"))
             && !matches!(opt_level.as_str(), "0" | "1" | "2")
             && !self.manifest_dir.to_string_lossy().contains(' ')

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -7,8 +7,8 @@ use crate::{
     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
     get_crate_cflags, is_crt_static, is_fips_build, is_no_asm, is_no_pregenerated_src,
     optional_env, optional_env_optional_crate_target, sanitizer, set_env, set_env_for_target,
-    should_build_jitter_entropy, target, target_arch, target_env, target_os, test_clang_cl_command,
-    test_nasm_command, use_prebuilt_nasm, OutputLibType,
+    should_build_jitter_entropy, target, target_arch, target_env, target_is_msvc, target_os,
+    test_clang_cl_command, test_nasm_command, use_prebuilt_nasm, OutputLibType,
 };
 use std::collections::HashMap;
 use std::env;
@@ -97,10 +97,10 @@ impl CmakeBuilder {
             self.output_lib_type,
         );
         let cc_build = cc::Build::new();
-        let (is_like_msvc, build_options) =
+        let (is_cl_like, build_options) =
             cc_builder.collect_universal_build_options(&cc_build, true);
         for option in &build_options {
-            option.apply_cmake(cmake_cfg, is_like_msvc);
+            option.apply_cmake(cmake_cfg, is_cl_like);
         }
 
         // CMake seeds `CMAKE_C_FLAGS` and `CMAKE_ASM_FLAGS` separately, so the
@@ -238,7 +238,7 @@ impl CmakeBuilder {
             } else if use_prebuilt_nasm() {
                 self.configure_prebuilt_nasm(&mut cmake_cfg);
             }
-            if target_env().as_str() == "msvc" {
+            if target_is_msvc() {
                 let mut msvcrt = String::from_str("MultiThreaded").unwrap();
                 if is_crt_static() {
                     cmake_cfg.static_crt(true);
@@ -670,7 +670,7 @@ impl crate::Builder for CmakeBuilder {
         }
         if target_os() == "windows"
             && target_arch() == "aarch64"
-            && target_env() == "msvc"
+            && target_is_msvc()
             && !test_clang_cl_command()
         {
             eprintln!("Missing dependency: clang-cl");

--- a/builder/fips_probe.rs
+++ b/builder/fips_probe.rs
@@ -3,8 +3,8 @@
 
 use crate::system_library::ResolvedLib;
 use crate::{
-    cargo_env, emit_warning, execute_command, is_lto_flag, out_dir, target, target_os,
-    OutputLibType,
+    cargo_env, compiler_is_cl_like, emit_warning, execute_command, is_lto_flag, out_dir, target,
+    target_os, OutputLibType,
 };
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -53,14 +53,14 @@ fn inherited_probe_args(compiler: &cc::Tool) -> Vec<std::ffi::OsString> {
 /// Appends the probe source and link arguments to the inherited compiler flags.
 fn append_probe_link_args(
     args: &mut Vec<std::ffi::OsString>,
-    is_msvc: bool,
+    is_cl_like: bool,
     include_dir: &Path,
     crypto_lib: &ResolvedLib,
     lib_dir: &Path,
     probe_src: &Path,
     exec_path: &Path,
 ) {
-    if is_msvc {
+    if is_cl_like {
         let obj_path = out_dir().join("aws_lc_fips_link_probe.obj");
         args.extend([
             prefixed_os_arg("/I", include_dir.as_os_str()),
@@ -112,8 +112,9 @@ pub(crate) fn compile_fips_probe(
 
     let cc_build = cc::Build::new();
     let compiler = cc_build.get_compiler();
-    let is_msvc = compiler.is_like_msvc();
-    if !(compiler.is_like_clang() || compiler.is_like_gnu() || is_msvc) {
+    // Guard on the actual compiler family, with a clear error if cc-rs ever
+    // starts reporting a new unsupported family here.
+    if !(compiler.is_like_clang() || compiler.is_like_gnu() || compiler.is_like_msvc()) {
         return Err(format!(
             "FIPS verification requires a Clang-, GCC-, or MSVC-compatible compiler; \
              {} is not supported. Set CC to a supported compiler.",
@@ -124,7 +125,8 @@ pub(crate) fn compile_fips_probe(
     let mut args = inherited_probe_args(&compiler);
     append_probe_link_args(
         &mut args,
-        is_msvc,
+        // Probe link-flag syntax follows the compiler driver mode, not the ABI.
+        compiler_is_cl_like(&compiler),
         include_dir,
         crypto_lib,
         lib_dir,

--- a/builder/fips_probe.rs
+++ b/builder/fips_probe.rs
@@ -112,8 +112,7 @@ pub(crate) fn compile_fips_probe(
 
     let cc_build = cc::Build::new();
     let compiler = cc_build.get_compiler();
-    // Guard on the actual compiler family, with a clear error if cc-rs ever
-    // starts reporting a new unsupported family here.
+    // Keyed on the compiler family (not the target ABI); unsupported families error below.
     if !(compiler.is_like_clang() || compiler.is_like_gnu() || compiler.is_like_msvc()) {
         return Err(format!(
             "FIPS verification requires a Clang-, GCC-, or MSVC-compatible compiler; \

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -498,6 +498,52 @@ fn target_env() -> String {
     cargo_env("CARGO_CFG_TARGET_ENV")
 }
 
+/// Whether the target ABI is MSVC (a `*-pc-windows-msvc` target).
+///
+/// This reflects the target ABI only and is the right signal for ABI/CRT/SDK
+/// decisions (MSVC CRT linkage, `_CRT_SECURE_NO_WARNINGS`, the `clang-cl`
+/// dependency checks). It is *not* a reliable signal for the compiler's flag
+/// *dialect*: a `*-pc-windows-msvc` target can be built with plain `clang` in
+/// GNU driver mode (e.g. `CC=clang`), which needs GNU-style flags. For dialect
+/// decisions use `compiler_is_cl_like` instead.
+#[allow(unused)]
+fn target_is_msvc() -> bool {
+    target_env() == "msvc"
+}
+
+/// Whether the active C compiler is driven in MSVC "cl" mode (`cl.exe` or
+/// `clang-cl`), which is what determines cl-style flag *dialect* (`/Fo`, `/FI`,
+/// `/Od`, no `--param ...`).
+///
+/// Driver mode is a property of the *compiler*, not the target ABI, and the two
+/// can diverge in both directions:
+/// - plain `clang` targeting `*-pc-windows-msvc` runs in GNU mode and needs
+///   GNU-style flags (so the target ABI alone is not enough), and
+/// - `cc::Tool::is_like_msvc()` can misclassify `clang-cl` as plain Clang when
+///   its probe misfires in a sandbox (e.g. cargo-xwin), emitting GNU-only flags
+///   to a cl-mode driver (so `is_like_msvc()` alone is not enough).
+///
+/// `clang` selects its driver mode from `argv[0]`, so a `clang-cl`/`cl` program
+/// name is an authoritative fallback when `cc`'s family probe is unreliable.
+/// See: <https://github.com/aws/aws-lc-rs/issues/1146>
+#[allow(unused)]
+pub(crate) fn compiler_is_cl_like(compiler: &cc::Tool) -> bool {
+    compiler.is_like_msvc() || program_name_is_cl_driver(compiler.path())
+}
+
+/// Whether a compiler program name selects clang's cl driver mode (`clang-cl`)
+/// or is `cl` itself. Robust fallback for `compiler_is_cl_like`.
+#[allow(unused)]
+pub(crate) fn program_name_is_cl_driver(path: &Path) -> bool {
+    match path.file_name().and_then(OsStr::to_str) {
+        Some(name) => {
+            let name = name.to_ascii_lowercase();
+            name.contains("clang-cl") || name == "cl" || name == "cl.exe"
+        }
+        None => false,
+    }
+}
+
 #[allow(unused)]
 fn target_vendor() -> String {
     cargo_env("CARGO_CFG_TARGET_VENDOR")

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -506,7 +506,6 @@ fn target_env() -> String {
 /// *dialect*: a `*-pc-windows-msvc` target can be built with plain `clang` in
 /// GNU driver mode (e.g. `CC=clang`), which needs GNU-style flags. For dialect
 /// decisions use `compiler_is_cl_like` instead.
-#[allow(unused)]
 fn target_is_msvc() -> bool {
     target_env() == "msvc"
 }
@@ -526,14 +525,12 @@ fn target_is_msvc() -> bool {
 /// `clang` selects its driver mode from `argv[0]`, so a `clang-cl`/`cl` program
 /// name is an authoritative fallback when `cc`'s family probe is unreliable.
 /// See: <https://github.com/aws/aws-lc-rs/issues/1146>
-#[allow(unused)]
 pub(crate) fn compiler_is_cl_like(compiler: &cc::Tool) -> bool {
     compiler.is_like_msvc() || program_name_is_cl_driver(compiler.path())
 }
 
 /// Whether a compiler program name selects clang's cl driver mode (`clang-cl`)
 /// or is `cl` itself. Robust fallback for `compiler_is_cl_like`.
-#[allow(unused)]
 pub(crate) fn program_name_is_cl_driver(path: &Path) -> bool {
     match path.file_name().and_then(OsStr::to_str) {
         Some(name) => {


### PR DESCRIPTION
### Issues:
Resolves #1146

### Description of changes:
`aws-lc-sys` was deciding several Windows compiler flag choices from the wrong signal.

The bug in #1146 is about compiler driver mode, not just the target ABI: a `*-pc-windows-msvc` build can still use plain `clang` in GNU mode, while `clang-cl` can be misdetected by `cc-rs` and still requires cl-style flags. This change introduces `compiler_is_cl_like()` and routes dialect-sensitive decisions through that helper, while keeping `target_is_msvc()` only for true ABI/CRT/SDK decisions.

That fixes the jitterentropy `--param ssp-buffer-size=4` failure under cargo-xwin / `clang-cl`, and it also preserves the inverse case where plain `clang` targets the MSVC ABI in GNU mode.

The PR also adds CI coverage for both Windows clang driver modes on the MSVC ABI and documents the distinction in the Windows requirements guide.

### Call-outs:
- Review focus is the split between `compiler_is_cl_like()` and `target_is_msvc()`: dialect-sensitive flag selection now uses driver mode, while ABI-specific behavior still keys off the target.
- `prepare_jitter_entropy_builder()` now derives its own dialect choice instead of accepting a caller-supplied bool.
- The original cargo-xwin failure is environment-specific, so the regression is guarded with deterministic unit tests around flag selection and driver detection, plus explicit CI lanes for `CC=clang` and `CC=clang-cl`.

### Testing:
- `cargo test -p builder-test --lib`
- `cargo test -p aws-lc-rs --tests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
