### PR TITLE
ci(cross): generate MSRV-aware lockfile for alpine-linux

### DIFF
--- a/.github/docker_images/alpine-3.20/aws_lc_rs_build.sh
+++ b/.github/docker_images/alpine-3.20/aws_lc_rs_build.sh
@@ -8,10 +8,7 @@ SRC_DIR="${SRC_DIR:-/aws_lc_rs}"
 
 pushd "${SRC_DIR}"
 
-cargo update -p clap --precise 4.5.61
-cargo update -p clap_lex --precise 1.0.1
-
-cargo test -p aws-lc-rs
+cargo test -p aws-lc-rs --locked
 cargo clean
 
 popd # ${SRC_DIR}

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -563,6 +563,20 @@ jobs:
         working-directory: .github/docker_images/alpine-3.20
         run: |
           ./build_image.sh
+      # Alpine 3.20 ships Cargo 1.78, which cannot parse edition-2024 manifests
+      # adopted by some transitive deps. Generate the lockfile with the runner's
+      # modern Cargo so the in-container build can consume it via --locked.
+      #
+      # The MSRV-aware resolver downgrades crates that declare a too-new
+      # rust-version (e.g. zeroize 1.9 requires Rust 1.85). It is not sufficient
+      # on its own: clap >=4.6 adopted edition 2024 without bumping its declared
+      # rust-version, so the resolver does not avoid it. Pin clap (and clap_lex)
+      # to the last edition-2021 releases that Cargo 1.78 can parse.
+      - name: Resolve MSRV-compatible dependencies
+        run: |
+          cargo --config "resolver.incompatible-rust-versions='fallback'" generate-lockfile
+          cargo update -p clap --precise 4.5.61
+          cargo update -p clap_lex --precise 1.0.1
       - name: Build
         run: |
           docker run -v "${{ github.workspace }}:/aws_lc_rs" alpine:3.20


### PR DESCRIPTION
### Description of changes:
The `alpine-linux` job started failing because Alpine 3.20 ships Cargo 1.78, which can't parse edition-2024 manifests. Since we don't commit a `Cargo.lock`, the in-container build resolves dependencies fresh, and it recently started selecting `zeroize 1.9.0` (edition 2024) within our `zeroize = "1.8.1"` caret range, failing at manifest parse time.

This generates the lockfile on the runner (which has a modern Cargo) using the MSRV-aware resolver via `resolver.incompatible-rust-versions='fallback'`, then builds inside the container with `--locked`. This mirrors the approach already used in the `msrv` job. The manual `clap`/`clap_lex` `--precise` pins in the build script are now redundant — the fallback resolver downgrades those automatically — so they've been removed.

### Call-outs:
- The lockfile is generated on the host runner rather than in the container on purpose: the container's Cargo 1.78 can't even parse the offending manifest, so it can't generate or pin its way out. The modern runner Cargo does the resolution; the container only consumes the lockfile with `--locked`.
- This relies on the runner's default Cargo being ≥1.84 for the `resolver.incompatible-rust-versions` config key, which is true on current `ubuntu-latest`. If we'd rather be explicit, I can add a `rustup toolchain install stable` step and use `cargo +stable …`, exactly like the `msrv` job.

### Testing:
CI only — verified by the `alpine-linux` job in this PR. Reviewer should confirm that job goes green (it should now resolve `zeroize 1.8.1` and other MSRV-compatible versions instead of pulling `zeroize 1.9.0`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
