### PR TITLE
Return TooSmall/TooLarge for out-of-range RSA private keys

### DIFF
--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -177,7 +177,8 @@ impl KeyPair {
         }
         match key.as_const().key_size_bits() {
             2048..=8192 => Ok(()),
-            _ => Err(KeyRejected::unspecified()),
+            bits if bits < 2048 => Err(KeyRejected::too_small()),
+            _ => Err(KeyRejected::too_large()),
         }
     }
 

--- a/aws-lc-rs/tests/basic_rsa_test.rs
+++ b/aws-lc-rs/tests/basic_rsa_test.rs
@@ -218,3 +218,19 @@ fn test_encryption_rsa_primitive() {
 
     assert_ne!(encrypted, msg);
 }
+
+// Keys outside the supported 2048..=8192 range are reported with a specific
+// reason rather than the generic "Unspecified". See aws/aws-lc-rs#1082.
+#[test]
+fn test_rsa_pkcs8_key_too_small() {
+    let key = include_bytes!("data/rsa_test_private_key_1024.p8");
+    let err = RsaKeyPair::from_pkcs8(key).unwrap_err();
+    assert_eq!(err.description_(), "TooSmall");
+}
+
+#[test]
+fn test_rsa_pkcs8_key_too_large() {
+    let key = include_bytes!("data/rsa_test_private_key_16384.p8");
+    let err = RsaKeyPair::from_pkcs8(key).unwrap_err();
+    assert_eq!(err.description_(), "TooLarge");
+}


### PR DESCRIPTION
### Issues:
Addresses #1082

### Description of changes:
`RsaKeyPair::validate_private_key` rejected any RSA private key outside the supported `2048..=8192` bit range with the generic `KeyRejected("Unspecified")`, which doesn't tell the caller what's wrong. As noted in #1082, a too-small key (e.g. 1024-bit) should report that it's too small.

`KeyRejected::too_small()` and `too_large()` already exist, so this returns those reasons instead — `TooSmall` for keys below 2048 bits and `TooLarge` for keys above 8192 bits. No behavior change beyond the error reason; out-of-range keys are still rejected.

### Call-outs:
This only changes the error *reason*, not which keys are accepted. The 2048–8192 bit support range is unchanged.

### Testing:
Added two regression tests in `basic_rsa_test.rs` using the existing `tests/data/rsa_test_private_key_1024.p8` (too small) and `rsa_test_private_key_16384.p8` (too large) fixtures, asserting the rejection reason. Verified they fail against the previous `Unspecified` behavior and pass with the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
