### PR TITLE
fix(system-lib): gate system AWS-LC on a declared minimum version

### DIFF
--- a/.github/workflows/system-lib-tests-fips.yml
+++ b/.github/workflows/system-lib-tests-fips.yml
@@ -254,10 +254,16 @@ jobs:
             cargo_args: "-p aws-lc-rs --no-default-features --features fips --lib"
             cargo_cmd: "test"
     steps:
-      # Do not initialize the aws-lc submodule; that makes fallback-to-source a
-      # hard failure instead of a silent regression. The version check still
-      # runs (it compares against a declared minimum, not submodule headers).
+      # Do not initialize the aws-lc submodule, then remove its working tree
+      # outright; that makes fallback-to-source a hard failure instead of a
+      # silent regression, and stays robust even if a future actions/checkout
+      # starts initializing submodules by default. The version check still runs
+      # (it compares against a declared minimum, not submodule headers).
       - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-fips-sys/aws-lc
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -298,6 +304,84 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # Proves the declared FIPS floor: build AWS-LC FIPS at the oldest branch that
+  # both reports MINIMUM_FIPS_VERSION (see builder/system_library.rs) and can
+  # emit Rust bindings, then run the suite against it with the version check
+  # enabled. The fips-2024-09-27 branch reports library version 3.x with no
+  # AWSLC_FIPS_VERSION_NUMBER macro, so resolve_fips_version() falls back to the
+  # version-string major and yields FIPS version 3 — exactly the floor. A
+  # failure means the floor is unsupported and must be raised together with this
+  # pin.
+  # ---------------------------------------------------------------------------
+  test-fips-minimum-version:
+    if: github.repository_owner == 'aws'
+    name: "Test: declared minimum AWS-LC FIPS version"
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      # Keep in sync with MINIMUM_FIPS_VERSION in builder/system_library.rs: the
+      # oldest FIPS branch that reports that module version and supports
+      # -DGENERATE_RUST_BINDINGS=ON.
+      AWS_LC_FIPS_MIN_REF: "fips-2024-09-27"
+    steps:
+      # aws-lc-rs checkout WITHOUT the submodule (and remove its working tree),
+      # so a from-source fallback is impossible (see test-fips-unix).
+      - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-fips-sys/aws-lc
+
+      - name: Checkout AWS-LC at the declared minimum FIPS version
+        uses: actions/checkout@v7
+        with:
+          repository: aws/aws-lc
+          ref: ${{ env.AWS_LC_FIPS_MIN_REF }}
+          submodules: 'recursive'
+          path: aws-lc-fips-min-src
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '>=1.18'
+
+      - name: Install bindgen-cli
+        run: cargo install --force --locked bindgen-cli
+
+      - name: Build and install AWS-LC FIPS (static) with Rust bindings
+        run: |
+          cmake -S aws-lc-fips-min-src -B build-fips-min \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFIPS=1 \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-fips-min"
+          cmake --build build-fips-min --target install -j
+
+      - name: Run aws-lc-rs FIPS tests against the minimum install (version check enabled)
+        env:
+          AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/install-fips-min
+          AWS_LC_FIPS_SYS_STATIC: "1"
+          LD_LIBRARY_PATH: ${{ github.workspace }}/install-fips-min/lib
+        run: |
+          set -o pipefail
+          cargo test -vv -p aws-lc-rs --no-default-features --features fips --lib 2>&1 | tee cargo.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo.log; then
+            echo '::error::System-library code path was not entered; aws-lc-fips-sys silently fell back to building from source.'
+            exit 1
+          fi
+          if ! grep -q 'FIPS verification' cargo.log; then
+            echo '::error::FIPS verification did not run on the system-library FIPS path.'
+            exit 1
+          fi
+
+  # ---------------------------------------------------------------------------
   # Prefixed-install path (Linux): verify that prefix-aware bindings work and
   # that the FIPS probe resolves the renamed FIPS-only symbol.
   # ---------------------------------------------------------------------------
@@ -318,8 +402,13 @@ jobs:
             cargo_args: "-p aws-lc-rs --no-default-features --features fips --lib"
             cargo_cmd: "test"
     steps:
-      # Do not initialize the aws-lc submodule (see test-fips-unix).
+      # Do not initialize the aws-lc submodule, and remove its working tree
+      # outright (see test-fips-unix).
       - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-fips-sys/aws-lc
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -373,8 +462,13 @@ jobs:
             cargo_args: "-p aws-lc-rs --no-default-features --features fips --lib"
             cargo_cmd: "test"
     steps:
-      # Do not initialize the aws-lc submodule (see test-fips-unix).
+      # Do not initialize the aws-lc submodule, and remove its working tree
+      # outright (see test-fips-unix).
       - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-fips-sys/aws-lc
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: ilammy/msvc-dev-cmd@v1
@@ -425,6 +519,13 @@ jobs:
         aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
       - uses: actions/checkout@v7
+
+      # Remove the submodule working tree so fallback-to-source is impossible
+      # (see test-fips-unix).
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-fips-sys/aws-lc
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Download AWS-LC install
@@ -460,6 +561,13 @@ jobs:
         aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
       - uses: actions/checkout@v7
+
+      # Remove the submodule working tree so fallback-to-source is impossible
+      # (see test-fips-unix).
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-fips-sys/aws-lc
+
       - uses: dtolnay/rust-toolchain@stable
       - uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/system-lib-tests-fips.yml
+++ b/.github/workflows/system-lib-tests-fips.yml
@@ -2,8 +2,10 @@ name: System Library Tests (FIPS)
 # Exercises the system-library FIPS path enabled by
 # AWS_LC_FIPS_SYS_SYSTEM_DIR, including the link probe and runtime check.
 #
-# Builds AWS-LC FIPS from the fips-2025-09-12-lts branch, which supports
-# -DGENERATE_RUST_BINDINGS=ON for system-installed bindings.
+# Builds AWS-LC FIPS from each ref listed in the `setup` job (FIPS branches
+# plus a FIPS build of `main`) and runs the system-library FIPS path against
+# each. Every ref must support -DGENERATE_RUST_BINDINGS=ON. Ensuring a given
+# library meets compliance requirements is the consumer's responsibility.
 #
 # Two AWS-LC FIPS build constraints drive the matrix:
 #   * A *static* FIPS build is supported only on Linux; macOS and Windows FIPS
@@ -27,12 +29,26 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Build AWS-LC FIPS (and a non-FIPS negative fixture) from the LTS branch into
+  # Single edit point for the AWS-LC refs the workflow fans out over. Each must
+  # support -DGENERATE_RUST_BINDINGS=ON and be a plain branch/tag name (no
+  # slashes, so it can go in artifact names).
+  # ---------------------------------------------------------------------------
+  setup:
+    if: github.repository_owner == 'aws'
+    runs-on: ubuntu-latest
+    outputs:
+      refs: ${{ steps.refs.outputs.refs }}
+    steps:
+      - id: refs
+        run: echo 'refs=["fips-2025-09-12-lts","main"]' >> "$GITHUB_OUTPUT"
+  # ---------------------------------------------------------------------------
+  # Build AWS-LC FIPS (and a non-FIPS negative fixture) from each ref into
   # install prefixes the test jobs consume via workflow artifacts.
   # ---------------------------------------------------------------------------
   build-fips-unix:
     if: github.repository_owner == 'aws'
-    name: Build AWS-LC FIPS (${{ matrix.os }})
+    needs: setup
+    name: Build AWS-LC FIPS (${{ matrix.aws_lc_ref }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:
       CC: clang
@@ -42,12 +58,13 @@ jobs:
       matrix:
         # Cover both Apple architectures.
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
-      - name: Checkout AWS-LC (fips-2025-09-12-lts)
+      - name: Checkout AWS-LC (${{ matrix.aws_lc_ref }})
         uses: actions/checkout@v7
         with:
           repository: aws/aws-lc
-          ref: fips-2025-09-12-lts
+          ref: ${{ matrix.aws_lc_ref }}
           submodules: 'recursive'
           path: aws-lc-fips-src
 
@@ -133,7 +150,7 @@ jobs:
       - name: Upload install artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: aws-lc-fips-install-${{ matrix.os }}
+          name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: |
             install-fips/
             install-nonfips/
@@ -143,20 +160,25 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
-          name: aws-lc-fips-install-prefixed
+          name: aws-lc-fips-install-prefixed-${{ matrix.aws_lc_ref }}
           path: install-fips-prefixed/
           retention-days: 1
 
   build-fips-windows:
     if: github.repository_owner == 'aws'
-    name: Build AWS-LC FIPS (windows-latest)
+    needs: setup
+    name: Build AWS-LC FIPS (${{ matrix.aws_lc_ref }}, windows-latest)
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
-      - name: Checkout AWS-LC (fips-2025-09-12-lts)
+      - name: Checkout AWS-LC (${{ matrix.aws_lc_ref }})
         uses: actions/checkout@v7
         with:
           repository: aws/aws-lc
-          ref: fips-2025-09-12-lts
+          ref: ${{ matrix.aws_lc_ref }}
           submodules: 'recursive'
           path: aws-lc-fips-src
 
@@ -204,7 +226,7 @@ jobs:
       - name: Upload install artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: aws-lc-fips-install-windows-latest
+          name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: |
             install-fips/
             install-nonfips/
@@ -216,13 +238,14 @@ jobs:
   # ---------------------------------------------------------------------------
   test-fips-unix:
     if: github.repository_owner == 'aws'
-    needs: build-fips-unix
-    name: "Test: ${{ matrix.config.name }} (${{ matrix.os }})"
+    needs: [setup, build-fips-unix]
+    name: "Test: ${{ matrix.config.name }} (${{ matrix.aws_lc_ref }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
         config:
           - name: "aws-lc-fips-sys"
             cargo_args: "-p aws-lc-fips-sys"
@@ -232,8 +255,8 @@ jobs:
             cargo_cmd: "test"
     steps:
       # Do not initialize the aws-lc submodule; that makes fallback-to-source a
-      # hard failure instead of a silent regression. SKIP_VERSION_CHECK is
-      # required because the version check reads submodule headers.
+      # hard failure instead of a silent regression. The version check still
+      # runs (it compares against a declared minimum, not submodule headers).
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
@@ -241,7 +264,7 @@ jobs:
       - name: Download AWS-LC FIPS install
         uses: actions/download-artifact@v8
         with:
-          name: aws-lc-fips-install-${{ matrix.os }}
+          name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: ${{ github.workspace }}/fips-artifacts
 
       - name: Determine link form
@@ -258,7 +281,6 @@ jobs:
         env:
           AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-fips
           AWS_LC_FIPS_SYS_STATIC: ${{ steps.form.outputs.static }}
-          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
           # A shared install (macOS) must be discoverable at runtime.
           LD_LIBRARY_PATH: ${{ github.workspace }}/fips-artifacts/install-fips/lib
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/fips-artifacts/install-fips/lib
@@ -281,12 +303,13 @@ jobs:
   # ---------------------------------------------------------------------------
   test-fips-prefixed-linux:
     if: github.repository_owner == 'aws'
-    needs: build-fips-unix
-    name: "Test: ${{ matrix.config.name }} (ubuntu-latest)"
+    needs: [setup, build-fips-unix]
+    name: "Test: ${{ matrix.config.name }} (${{ matrix.aws_lc_ref }}, ubuntu-latest)"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
         config:
           - name: "aws-lc-fips-sys, prefixed"
             cargo_args: "-p aws-lc-fips-sys"
@@ -303,7 +326,7 @@ jobs:
       - name: Download prefixed AWS-LC FIPS install
         uses: actions/download-artifact@v8
         with:
-          name: aws-lc-fips-install-prefixed
+          name: aws-lc-fips-install-prefixed-${{ matrix.aws_lc_ref }}
           path: ${{ github.workspace }}/fips-artifacts/install-fips-prefixed
 
       - name: Sanity-check that the install is actually prefixed
@@ -321,7 +344,6 @@ jobs:
         env:
           AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-fips-prefixed
           AWS_LC_FIPS_SYS_STATIC: "1"
-          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
         run: |
           set -o pipefail
           cargo ${{ matrix.config.cargo_cmd }} -vv ${{ matrix.config.cargo_args }} 2>&1 | tee cargo.log
@@ -336,12 +358,13 @@ jobs:
 
   test-fips-windows:
     if: github.repository_owner == 'aws'
-    needs: build-fips-windows
-    name: "Test: ${{ matrix.config.name }} (windows-latest)"
+    needs: [setup, build-fips-windows]
+    name: "Test: ${{ matrix.config.name }} (${{ matrix.aws_lc_ref }}, windows-latest)"
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
         config:
           - name: "aws-lc-fips-sys"
             cargo_args: "-p aws-lc-fips-sys"
@@ -359,7 +382,7 @@ jobs:
       - name: Download AWS-LC FIPS install
         uses: actions/download-artifact@v8
         with:
-          name: aws-lc-fips-install-windows-latest
+          name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: ${{ github.workspace }}/fips-artifacts
 
       - name: Run cargo ${{ matrix.config.cargo_cmd }}
@@ -368,7 +391,6 @@ jobs:
           AWS_LC_FIPS_SYS_SYSTEM_DIR: ${{ github.workspace }}/fips-artifacts/install-fips
           # Windows FIPS is a shared build.
           AWS_LC_FIPS_SYS_STATIC: "0"
-          AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
         run: |
           # Windows needs the DLL on PATH for both the probe and the test binary.
           $env:Path = "$env:AWS_LC_FIPS_SYS_SYSTEM_DIR\bin;$env:AWS_LC_FIPS_SYS_SYSTEM_DIR\lib;$env:Path"
@@ -393,13 +415,14 @@ jobs:
   # ---------------------------------------------------------------------------
   reject-nonfips-unix:
     if: github.repository_owner == 'aws'
-    needs: build-fips-unix
-    name: "Reject non-FIPS install (${{ matrix.os }})"
+    needs: [setup, build-fips-unix]
+    name: "Reject non-FIPS install (${{ matrix.aws_lc_ref }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -407,7 +430,7 @@ jobs:
       - name: Download AWS-LC install
         uses: actions/download-artifact@v8
         with:
-          name: aws-lc-fips-install-${{ matrix.os }}
+          name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: ${{ github.workspace }}/fips-artifacts
 
       - name: Assert the FIPS probe rejects a non-FIPS install
@@ -428,9 +451,13 @@ jobs:
 
   reject-nonfips-windows:
     if: github.repository_owner == 'aws'
-    needs: build-fips-windows
-    name: "Reject non-FIPS install (windows-latest)"
+    needs: [setup, build-fips-windows]
+    name: "Reject non-FIPS install (${{ matrix.aws_lc_ref }}, windows-latest)"
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -439,7 +466,7 @@ jobs:
       - name: Download AWS-LC install
         uses: actions/download-artifact@v8
         with:
-          name: aws-lc-fips-install-windows-latest
+          name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: ${{ github.workspace }}/fips-artifacts
 
       - name: Assert the FIPS probe rejects a non-FIPS install

--- a/.github/workflows/system-lib-tests.yml
+++ b/.github/workflows/system-lib-tests.yml
@@ -286,14 +286,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Keep in sync with MINIMUM_AWS_LC_VERSION in builder/system_library.rs.
-      AWS_LC_MIN_VERSION: "v1.72.1"
+      AWS_LC_MIN_VERSION: "v1.68.0"
     steps:
       # aws-lc-rs checkout WITHOUT the submodule, so a from-source fallback is
       # impossible (see test-unix).
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Checkout AWS-LC at the declared minimum version
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: aws/aws-lc
           ref: ${{ env.AWS_LC_MIN_VERSION }}

--- a/.github/workflows/system-lib-tests.yml
+++ b/.github/workflows/system-lib-tests.yml
@@ -241,12 +241,19 @@ jobs:
             cargo_cmd: "test"
 
     steps:
-      # Intentionally do NOT initialize the aws-lc/ submodule. This makes the
-      # from-source build path physically impossible, so a regression where
-      # the system-library code path is silently bypassed will hard-fail rather
-      # than fall through to a source build. The version check still runs (it
-      # compares against a declared minimum, not the submodule).
+      # Intentionally do NOT initialize the aws-lc/ submodule, then remove its
+      # working tree outright. This makes the from-source build path physically
+      # impossible, so a regression where the system-library code path is
+      # silently bypassed hard-fails rather than falling through to a source
+      # build. Removing the tree (rather than merely skipping init) stays robust
+      # even if a future actions/checkout starts initializing submodules by
+      # default. The version check still runs (it compares against a declared
+      # minimum, not the submodule).
       - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-sys/aws-lc
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -292,6 +299,10 @@ jobs:
       # impossible (see test-unix).
       - uses: actions/checkout@v7
 
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-sys/aws-lc
+
       - name: Checkout AWS-LC at the declared minimum version
         uses: actions/checkout@v7
         with:
@@ -300,6 +311,8 @@ jobs:
           path: aws-lc-min-src
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Install bindgen-cli
         run: cargo install --force --locked bindgen-cli
@@ -369,9 +382,14 @@ jobs:
             cargo_cmd: "test"
 
     steps:
-      # Intentionally do NOT initialize the aws-lc/ submodule (see test-unix).
-      # The version check still runs against the installed version.
+      # Intentionally do NOT initialize the aws-lc/ submodule, and remove its
+      # working tree outright (see test-unix). The version check still runs
+      # against the installed version.
       - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-sys/aws-lc
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/system-lib-tests.yml
+++ b/.github/workflows/system-lib-tests.yml
@@ -244,8 +244,8 @@ jobs:
       # Intentionally do NOT initialize the aws-lc/ submodule. This makes the
       # from-source build path physically impossible, so a regression where
       # the system-library code path is silently bypassed will hard-fail rather
-      # than fall through to a source build. Skipping the version check is
-      # required because that path reads aws-lc/include/openssl/base.h.
+      # than fall through to a source build. The version check still runs (it
+      # compares against a declared minimum, not the submodule).
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
@@ -260,7 +260,6 @@ jobs:
         env:
           AWS_LC_SYS_SYSTEM_DIR: ${{ github.workspace }}/aws-lc-artifacts/${{ matrix.config.install_subdir }}
           AWS_LC_SYS_STATIC: ${{ matrix.config.static }}
-          AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
           LD_LIBRARY_PATH: ${{ github.workspace }}/aws-lc-artifacts/${{ matrix.config.install_subdir }}/lib
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/aws-lc-artifacts/${{ matrix.config.install_subdir }}/lib
         run: |
@@ -270,6 +269,61 @@ jobs:
           # its absence in the log indicates a silent fallback.
           set -o pipefail
           cargo ${{ matrix.config.cargo_cmd }} -vv ${{ matrix.config.cargo_args }} 2>&1 | tee cargo.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo.log; then
+            echo '::error::System-library code path was not entered; aws-lc-sys silently fell back to building from source.'
+            exit 1
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Proves the declared minimum: build AWS-LC at MINIMUM_AWS_LC_VERSION (see
+  # builder/system_library.rs) and run the full test suite against it with the
+  # version check enabled. A failure means the minimum is unsupported and must
+  # be raised together with this pin.
+  # ---------------------------------------------------------------------------
+  test-minimum-version:
+    if: github.repository_owner == 'aws'
+    name: "Test: declared minimum AWS-LC version"
+    runs-on: ubuntu-latest
+    env:
+      # Keep in sync with MINIMUM_AWS_LC_VERSION in builder/system_library.rs.
+      AWS_LC_MIN_VERSION: "v1.72.1"
+    steps:
+      # aws-lc-rs checkout WITHOUT the submodule, so a from-source fallback is
+      # impossible (see test-unix).
+      - uses: actions/checkout@v6
+
+      - name: Checkout AWS-LC at the declared minimum version
+        uses: actions/checkout@v6
+        with:
+          repository: aws/aws-lc
+          ref: ${{ env.AWS_LC_MIN_VERSION }}
+          path: aws-lc-min-src
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install bindgen-cli
+        run: cargo install --force --locked bindgen-cli
+
+      - name: Build and install AWS-LC (static) with Rust bindings
+        run: |
+          cmake -S aws-lc-min-src -B build-min \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_TOOL=OFF \
+            -DDISABLE_GO=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGENERATE_RUST_BINDINGS=ON \
+            -DCMAKE_INSTALL_PREFIX="${PWD}/install-min"
+          cmake --build build-min --target install -j
+
+      - name: Run aws-lc-rs tests against the minimum install (version check enabled)
+        env:
+          AWS_LC_SYS_SYSTEM_DIR: ${{ github.workspace }}/install-min
+          AWS_LC_SYS_STATIC: "1"
+          LD_LIBRARY_PATH: ${{ github.workspace }}/install-min/lib
+        run: |
+          set -o pipefail
+          cargo test -vv -p aws-lc-rs --lib 2>&1 | tee cargo.log
           if ! grep -q 'Using system-installed AWS-LC from' cargo.log; then
             echo '::error::System-library code path was not entered; aws-lc-sys silently fell back to building from source.'
             exit 1
@@ -316,6 +370,7 @@ jobs:
 
     steps:
       # Intentionally do NOT initialize the aws-lc/ submodule (see test-unix).
+      # The version check still runs against the installed version.
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
@@ -331,7 +386,6 @@ jobs:
         env:
           AWS_LC_SYS_SYSTEM_DIR: ${{ github.workspace }}/aws-lc-artifacts/${{ matrix.config.install_subdir }}
           AWS_LC_SYS_STATIC: ${{ matrix.config.static }}
-          AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK: "1"
         run: |
           # For dynamic linking, the DLLs must be on PATH
           if [ "$AWS_LC_SYS_STATIC" = "0" ]; then

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -110,8 +110,13 @@ version-stamped prefix and are not suitable for an arbitrary system install.
 
 ### Version compatibility
 
-The version embedded in the installed headers must be greater than or equal to the AWS-LC
-version bundled with this crate. Override with `AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
+FIPS installs are gated on the AWS-LC **FIPS module version** (an integer
+identifying a validation submission, decoupled from the library version; see
+[aws/aws-lc#3211](https://github.com/aws/aws-lc/pull/3211)), which must be at
+least the minimum supported by this crate (currently `3`). It is read from
+`AWSLC_FIPS_VERSION_NUMBER`, falling back to the major of
+`AWSLC_VERSION_NUMBER_STRING` on older branches (e.g. FIPS 3.x → `3`). To bypass
+this check (not recommended), set `AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
 ## Build Prerequisites
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -124,7 +124,7 @@ If neither is available the build fails with guidance on how to proceed.
 ### Version compatibility
 
 The installed AWS-LC version must be at least the minimum supported by this
-crate (currently `1.72.1`), independent of the bundled version. To bypass this
+crate (currently `1.68.0`), independent of the bundled version. To bypass this
 check (not recommended), set `AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
 ### Limitations

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -124,7 +124,8 @@ If neither is available the build fails with guidance on how to proceed.
 ### Version compatibility
 
 The installed AWS-LC version must be at least the minimum supported by this
-crate (currently `1.68.0`), independent of the bundled version. To bypass this
+crate, independent of the bundled version. That floor is declared as the
+`MINIMUM_AWS_LC_VERSION` constant in `builder/system_library.rs`. To bypass this
 check (not recommended), set `AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
 ### Limitations

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -123,9 +123,9 @@ If neither is available the build fails with guidance on how to proceed.
 
 ### Version compatibility
 
-The version embedded in the installed headers must be greater than or equal to
-the AWS-LC version bundled with this crate. To bypass this check (not
-recommended), set `AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
+The installed AWS-LC version must be at least the minimum supported by this
+crate (currently `1.72.1`), independent of the bundled version. To bypass this
+check (not recommended), set `AWS_LC_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
 ### Limitations
 

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -245,6 +245,25 @@ const MINIMUM_AWS_LC_VERSION: &str = "1.68.0";
 /// TODO: bump to `4` when switching to the `fips-2025-09-12-lts` branch.
 const MINIMUM_FIPS_VERSION: u32 = 3;
 
+/// Finds the first `#define <name> ...` line in `base.h` content and returns
+/// the value token following the macro name (or `""` for a bare `#define
+/// <name>` with no value), or `None` if the macro is not `#define`d. Matching
+/// on the leading whitespace-separated tokens — rather than a bare `contains`
+/// — prevents a comment that merely mentions the macro name from
+/// false-matching.
+fn find_define<'a>(content: &'a str, name: &str) -> Option<&'a str> {
+    content.lines().find_map(|line| {
+        let mut tokens = line.split_whitespace();
+        if tokens.next() == Some("#define") && tokens.next() == Some(name) {
+            // Map a valueless `#define <name>` to "" so callers still
+            // distinguish "defined" (`Some`) from "absent" (`None`).
+            Some(tokens.next().unwrap_or(""))
+        } else {
+            None
+        }
+    })
+}
+
 /// Reads `<include_dir>/openssl/base.h`, verifies the `OPENSSL_IS_AWSLC` marker
 /// (rejecting `OpenSSL`/`BoringSSL`), and returns the header path and contents.
 fn read_and_validate_base_h(include_dir: &Path) -> Result<(PathBuf, String), String> {
@@ -252,10 +271,7 @@ fn read_and_validate_base_h(include_dir: &Path) -> Result<(PathBuf, String), Str
     let content = std::fs::read_to_string(&base_h)
         .map_err(|e| format!("Failed to read {}: {}", base_h.display(), e))?;
 
-    let has_awslc_marker = content.lines().any(|line| {
-        let mut tokens = line.split_whitespace();
-        tokens.next() == Some("#define") && tokens.next() == Some("OPENSSL_IS_AWSLC")
-    });
+    let has_awslc_marker = find_define(&content, "OPENSSL_IS_AWSLC").is_some();
     if !has_awslc_marker {
         return Err(format!(
             "Headers at {} are not valid AWS-LC headers.\n\
@@ -282,37 +298,26 @@ fn validate_and_resolve_fips_version(include_dir: &Path) -> Result<u32, String> 
 }
 
 /// Extracts `AWSLC_VERSION_NUMBER_STRING` from already-loaded `base.h`
-/// content. Used by both the system-install validator and the bundled-version
-/// helper, the latter of which doesn't need the AWS-LC marker check (the
-/// bundled headers are AWS-LC by construction).
+/// content. Kept separate from `validate_and_extract_version` so the
+/// bundled-version guard test can call it directly, skipping the
+/// `OPENSSL_IS_AWSLC` marker check (the bundled headers are AWS-LC by
+/// construction).
 fn extract_version(base_h: &Path, content: &str) -> Result<String, String> {
-    // Match on the first whitespace-separated tokens rather than a bare
-    // `contains`, so that an unrelated line that merely mentions the macro
-    // name (e.g. a comment) cannot false-match.
-    for line in content.lines() {
-        let mut tokens = line.split_whitespace();
-        if tokens.next() != Some("#define") {
-            continue;
-        }
-        if tokens.next() != Some("AWSLC_VERSION_NUMBER_STRING") {
-            continue;
-        }
-        if let Some(value) = tokens.next() {
-            let trimmed = value.trim_matches('"');
-            if trimmed != value && !trimmed.is_empty() {
-                return Ok(trimmed.to_string());
-            }
-        }
+    let Some(value) = find_define(content, "AWSLC_VERSION_NUMBER_STRING") else {
         return Err(format!(
-            "Malformed AWSLC_VERSION_NUMBER_STRING in {}",
+            "Could not find AWSLC_VERSION_NUMBER_STRING in {}.",
             base_h.display()
         ));
+    };
+    let trimmed = value.trim_matches('"');
+    if trimmed != value && !trimmed.is_empty() {
+        Ok(trimmed.to_string())
+    } else {
+        Err(format!(
+            "Malformed AWSLC_VERSION_NUMBER_STRING in {}",
+            base_h.display()
+        ))
     }
-
-    Err(format!(
-        "Could not find AWSLC_VERSION_NUMBER_STRING in {}.",
-        base_h.display()
-    ))
 }
 
 fn version_at_least(installed: &str, required: &str) -> Result<bool, String> {
@@ -356,26 +361,13 @@ fn resolve_fips_version(base_h: &Path, content: &str) -> Result<u32, String> {
 /// post-decoupling (aws/aws-lc#3211) the library version is not a reliable
 /// substitute, so masking a malformed authoritative value would be wrong.
 fn extract_fips_version_number(content: &str) -> Result<Option<u32>, String> {
-    for line in content.lines() {
-        let mut tokens = line.split_whitespace();
-        if tokens.next() != Some("#define") {
-            continue;
-        }
-        if tokens.next() != Some("AWSLC_FIPS_VERSION_NUMBER") {
-            continue;
-        }
-        let raw = tokens.next();
-        return raw
-            .and_then(|v| v.parse::<u32>().ok())
-            .map(Some)
-            .ok_or_else(|| {
-                format!(
-                    "Malformed AWSLC_FIPS_VERSION_NUMBER: expected an integer, found {}",
-                    raw.unwrap_or("<empty>")
-                )
-            });
-    }
-    Ok(None)
+    let Some(value) = find_define(content, "AWSLC_FIPS_VERSION_NUMBER") else {
+        return Ok(None);
+    };
+    value.parse::<u32>().map(Some).map_err(|_| {
+        let shown = if value.is_empty() { "<empty>" } else { value };
+        format!("Malformed AWSLC_FIPS_VERSION_NUMBER: expected an unsigned integer, found {shown}")
+    })
 }
 
 /// Parses the MAJOR component of a `MAJOR.MINOR.PATCH` version string.

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -230,10 +230,12 @@ impl SystemLib {
 // =============================================================================
 
 /// Minimum AWS-LC (mainline) version supported via the system-library path,
-/// for the non-FIPS `aws-lc-sys` crate. A declared floor (not derived from the
+/// for the non-FIPS `aws-lc-sys` crate. `1.68.0` is the first release that can
+/// emit Rust bindings (`-DGENERATE_RUST_BINDINGS=ON`), which the
+/// system-library path consumes. A declared floor (not derived from the
 /// bundled submodule) whose support is proven by CI; bump it and the CI pin
 /// together. See `.github/workflows/system-lib-tests.yml`.
-const MINIMUM_AWS_LC_VERSION: &str = "1.72.1";
+const MINIMUM_AWS_LC_VERSION: &str = "1.68.0";
 
 /// Minimum AWS-LC FIPS *module* version supported via the system-library path,
 /// for `aws-lc-fips-sys`. The FIPS version (aws/aws-lc#3211) is decoupled from
@@ -339,15 +341,21 @@ fn version_at_least(installed: &str, required: &str) -> Result<bool, String> {
 /// falling back to the major of `AWSLC_VERSION_NUMBER_STRING` on legacy FIPS
 /// branches (<= 3.x) that predate the macro.
 fn resolve_fips_version(base_h: &Path, content: &str) -> Result<u32, String> {
-    if let Some(version) = extract_fips_version_number(content) {
+    if let Some(version) = extract_fips_version_number(content)? {
         return Ok(version);
     }
     let version = extract_version(base_h, content)?;
     version_major(&version)
 }
 
-/// Extracts the integer `AWSLC_FIPS_VERSION_NUMBER` macro, if present.
-fn extract_fips_version_number(content: &str) -> Option<u32> {
+/// Extracts the integer `AWSLC_FIPS_VERSION_NUMBER` macro.
+///
+/// Returns `Ok(None)` when the macro is absent (a legacy FIPS branch that
+/// predates it; callers fall back to the version-string major). A macro that is
+/// *present but unparseable* is a hard error rather than a silent fallback:
+/// post-decoupling (aws/aws-lc#3211) the library version is not a reliable
+/// substitute, so masking a malformed authoritative value would be wrong.
+fn extract_fips_version_number(content: &str) -> Result<Option<u32>, String> {
     for line in content.lines() {
         let mut tokens = line.split_whitespace();
         if tokens.next() != Some("#define") {
@@ -356,9 +364,18 @@ fn extract_fips_version_number(content: &str) -> Option<u32> {
         if tokens.next() != Some("AWSLC_FIPS_VERSION_NUMBER") {
             continue;
         }
-        return tokens.next().and_then(|v| v.parse::<u32>().ok());
+        let raw = tokens.next();
+        return raw
+            .and_then(|v| v.parse::<u32>().ok())
+            .map(Some)
+            .ok_or_else(|| {
+                format!(
+                    "Malformed AWSLC_FIPS_VERSION_NUMBER: expected an integer, found {}",
+                    raw.unwrap_or("<empty>")
+                )
+            });
     }
-    None
+    Ok(None)
 }
 
 /// Parses the MAJOR component of a `MAJOR.MINOR.PATCH` version string.

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -12,9 +12,8 @@
 
 use crate::fips_probe::verify_fips_install;
 use crate::{
-    crate_env_var_name, emit_rustc_cfg, emit_warning, get_aws_lc_include_path, is_fips_build,
-    is_static_library, link_fips_runtime_check, out_dir, target_env, target_os, Builder,
-    OutputLibType,
+    crate_env_var_name, emit_rustc_cfg, emit_warning, is_fips_build, is_static_library,
+    link_fips_runtime_check, out_dir, target_env, target_os, Builder, OutputLibType,
 };
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
@@ -153,12 +152,26 @@ impl SystemLib {
 
         if self.skip_version_check {
             emit_warning("Skipping AWS-LC version compatibility check.");
+        } else if is_fips_build() {
+            // FIPS gates on the FIPS module version (see MINIMUM_FIPS_VERSION),
+            // not the library version string.
+            let fips_version = validate_and_resolve_fips_version(&include_dir)?;
+            if fips_version < MINIMUM_FIPS_VERSION {
+                return Err(format!(
+                    "AWS-LC FIPS module version too old: installed FIPS version {fips_version} < \
+                     minimum supported {MINIMUM_FIPS_VERSION}.\n\
+                     Please use a newer AWS-LC FIPS build or unset {} to build from source.\n\
+                     To bypass this check (not recommended), set {}=1",
+                    crate_env_var_name("SYSTEM_DIR"),
+                    crate_env_var_name("SYSTEM_SKIP_VERSION_CHECK"),
+                ));
+            }
         } else {
             let version = validate_and_extract_version(&include_dir)?;
-            let required = bundled_awslc_version(self.manifest_dir.as_path());
-            if !version_at_least(&version, &required)? {
+            if !version_at_least(&version, MINIMUM_AWS_LC_VERSION)? {
                 return Err(format!(
-                    "AWS-LC version mismatch: installed {version} < required {required}.\n\
+                    "AWS-LC version too old: installed {version} < minimum supported \
+                     {MINIMUM_AWS_LC_VERSION}.\n\
                      Please upgrade AWS-LC or unset {} to build from source.\n\
                      To bypass this check (not recommended), set {}=1",
                     crate_env_var_name("SYSTEM_DIR"),
@@ -216,13 +229,27 @@ impl SystemLib {
 // Header validation / version extraction
 // =============================================================================
 
-fn validate_and_extract_version(include_dir: &Path) -> Result<String, String> {
+/// Minimum AWS-LC (mainline) version supported via the system-library path,
+/// for the non-FIPS `aws-lc-sys` crate. A declared floor (not derived from the
+/// bundled submodule) whose support is proven by CI; bump it and the CI pin
+/// together. See `.github/workflows/system-lib-tests.yml`.
+const MINIMUM_AWS_LC_VERSION: &str = "1.72.1";
+
+/// Minimum AWS-LC FIPS *module* version supported via the system-library path,
+/// for `aws-lc-fips-sys`. The FIPS version (aws/aws-lc#3211) is decoupled from
+/// the library version and increases monotonically across FIPS branches, so it
+/// is a stable basis for comparison.
+///
+/// TODO: bump to `4` when switching to the `fips-2025-09-12-lts` branch.
+const MINIMUM_FIPS_VERSION: u32 = 3;
+
+/// Reads `<include_dir>/openssl/base.h`, verifies the `OPENSSL_IS_AWSLC` marker
+/// (rejecting `OpenSSL`/`BoringSSL`), and returns the header path and contents.
+fn read_and_validate_base_h(include_dir: &Path) -> Result<(PathBuf, String), String> {
     let base_h = include_dir.join("openssl").join("base.h");
     let content = std::fs::read_to_string(&base_h)
         .map_err(|e| format!("Failed to read {}: {}", base_h.display(), e))?;
 
-    // Verify this is AWS-LC (not OpenSSL or BoringSSL). Tokenize each line so
-    // that an unrelated comment that mentions the macro can't false-match.
     let has_awslc_marker = content.lines().any(|line| {
         let mut tokens = line.split_whitespace();
         tokens.next() == Some("#define") && tokens.next() == Some("OPENSSL_IS_AWSLC")
@@ -236,7 +263,20 @@ fn validate_and_extract_version(include_dir: &Path) -> Result<String, String> {
         ));
     }
 
+    Ok((base_h, content))
+}
+
+/// Validates the headers are AWS-LC and returns the library version string
+/// (`AWSLC_VERSION_NUMBER_STRING`).
+fn validate_and_extract_version(include_dir: &Path) -> Result<String, String> {
+    let (base_h, content) = read_and_validate_base_h(include_dir)?;
     extract_version(&base_h, &content)
+}
+
+/// Validates the headers are AWS-LC and returns the FIPS module version.
+fn validate_and_resolve_fips_version(include_dir: &Path) -> Result<u32, String> {
+    let (base_h, content) = read_and_validate_base_h(include_dir)?;
+    resolve_fips_version(&base_h, &content)
 }
 
 /// Extracts `AWSLC_VERSION_NUMBER_STRING` from already-loaded `base.h`
@@ -294,32 +334,40 @@ fn version_at_least(installed: &str, required: &str) -> Result<bool, String> {
     Ok(parse(installed)? >= parse(required)?)
 }
 
-/// Reads the bundled (submodule) AWS-LC version, panicking with a helpful
-/// message if it can't. Also emits a `rerun-if-changed` for the bundled
-/// `base.h` so the build re-runs when the submodule moves.
-///
-/// The bundled headers are AWS-LC by construction, so this skips the
-/// `OPENSSL_IS_AWSLC` marker check and uses `extract_version` directly.
-fn bundled_awslc_version(manifest_dir: &Path) -> String {
-    let bundled_include = get_aws_lc_include_path(manifest_dir);
-    let base_h = bundled_include.join("openssl").join("base.h");
-    println!("cargo:rerun-if-changed={}", base_h.display());
-    let content = std::fs::read_to_string(&base_h).unwrap_or_else(|e| {
-        panic!(
-            "Failed to read bundled AWS-LC headers at {}: {e}\n\
-             The system-library linking path reads the bundled AWS-LC headers to enforce\n\
-             a minimum version. If the git submodule is not initialized, either run\n\
-             `git submodule update --init --recursive` or set {}=1 to bypass.",
-            base_h.display(),
-            crate_env_var_name("SYSTEM_SKIP_VERSION_CHECK"),
-        )
-    });
-    extract_version(&base_h, &content).unwrap_or_else(|e| {
-        panic!(
-            "Failed to extract bundled AWS-LC version from {}: {e}",
-            base_h.display()
-        )
-    })
+/// Resolves the FIPS module version from `base.h`: prefers the
+/// `AWSLC_FIPS_VERSION_NUMBER` macro (FIPS 4.x+ / mainline, aws/aws-lc#3211),
+/// falling back to the major of `AWSLC_VERSION_NUMBER_STRING` on legacy FIPS
+/// branches (<= 3.x) that predate the macro.
+fn resolve_fips_version(base_h: &Path, content: &str) -> Result<u32, String> {
+    if let Some(version) = extract_fips_version_number(content) {
+        return Ok(version);
+    }
+    let version = extract_version(base_h, content)?;
+    version_major(&version)
+}
+
+/// Extracts the integer `AWSLC_FIPS_VERSION_NUMBER` macro, if present.
+fn extract_fips_version_number(content: &str) -> Option<u32> {
+    for line in content.lines() {
+        let mut tokens = line.split_whitespace();
+        if tokens.next() != Some("#define") {
+            continue;
+        }
+        if tokens.next() != Some("AWSLC_FIPS_VERSION_NUMBER") {
+            continue;
+        }
+        return tokens.next().and_then(|v| v.parse::<u32>().ok());
+    }
+    None
+}
+
+/// Parses the MAJOR component of a `MAJOR.MINOR.PATCH` version string.
+fn version_major(version: &str) -> Result<u32, String> {
+    version
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u32>().ok())
+        .ok_or_else(|| format!("Invalid version format: {version}"))
 }
 
 // =============================================================================

--- a/builder/system_library_tests.rs
+++ b/builder/system_library_tests.rs
@@ -196,13 +196,13 @@ fn test_validate_and_extract_version_missing_version_string() {
 #[test]
 fn test_extract_fips_version_number_present() {
     let content = "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_FIPS_VERSION_NUMBER 4\n";
-    assert_eq!(extract_fips_version_number(content), Some(4));
+    assert_eq!(extract_fips_version_number(content).unwrap(), Some(4));
 }
 
 #[test]
 fn test_extract_fips_version_number_absent() {
     let content = "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_VERSION_NUMBER_STRING \"3.3.0\"\n";
-    assert_eq!(extract_fips_version_number(content), None);
+    assert_eq!(extract_fips_version_number(content).unwrap(), None);
 }
 
 #[test]
@@ -210,7 +210,16 @@ fn test_extract_fips_version_number_ignores_comment_false_match() {
     // A comment mentioning the macro shouldn't false-match.
     let content =
         "// AWSLC_FIPS_VERSION_NUMBER is defined below\n#define AWSLC_FIPS_VERSION_NUMBER 7\n";
-    assert_eq!(extract_fips_version_number(content), Some(7));
+    assert_eq!(extract_fips_version_number(content).unwrap(), Some(7));
+}
+
+#[test]
+fn test_extract_fips_version_number_present_but_malformed_is_error() {
+    // A present-but-unparseable macro must not silently fall back to the
+    // (post-decoupling unreliable) library version.
+    let content = "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_FIPS_VERSION_NUMBER notanumber\n";
+    let err = extract_fips_version_number(content).unwrap_err();
+    assert!(err.contains("Malformed AWSLC_FIPS_VERSION_NUMBER"), "{err}");
 }
 
 #[test]

--- a/builder/system_library_tests.rs
+++ b/builder/system_library_tests.rs
@@ -190,6 +190,149 @@ fn test_validate_and_extract_version_missing_version_string() {
 }
 
 // -------------------------------------------------------------------------
+// FIPS module version resolution
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_extract_fips_version_number_present() {
+    let content = "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_FIPS_VERSION_NUMBER 4\n";
+    assert_eq!(extract_fips_version_number(content), Some(4));
+}
+
+#[test]
+fn test_extract_fips_version_number_absent() {
+    let content = "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_VERSION_NUMBER_STRING \"3.3.0\"\n";
+    assert_eq!(extract_fips_version_number(content), None);
+}
+
+#[test]
+fn test_extract_fips_version_number_ignores_comment_false_match() {
+    // A comment mentioning the macro shouldn't false-match.
+    let content =
+        "// AWSLC_FIPS_VERSION_NUMBER is defined below\n#define AWSLC_FIPS_VERSION_NUMBER 7\n";
+    assert_eq!(extract_fips_version_number(content), Some(7));
+}
+
+#[test]
+fn test_version_major() {
+    assert_eq!(version_major("3.3.0").unwrap(), 3);
+    assert_eq!(version_major("12.1.4").unwrap(), 12);
+    assert!(version_major("").is_err());
+    assert!(version_major("x.y.z").is_err());
+}
+
+#[test]
+fn test_resolve_fips_version_prefers_macro() {
+    // The macro is authoritative and wins over the legacy version string.
+    let content =
+        "#define AWSLC_VERSION_NUMBER_STRING \"3.3.0\"\n#define AWSLC_FIPS_VERSION_NUMBER 4\n";
+    assert_eq!(
+        resolve_fips_version(Path::new("base.h"), content).unwrap(),
+        4
+    );
+}
+
+#[test]
+fn test_resolve_fips_version_legacy_fallback() {
+    // No macro (legacy FIPS branch <= 3.x): infer from the version major.
+    let content = "#define AWSLC_VERSION_NUMBER_STRING \"3.3.0\"\n";
+    assert_eq!(
+        resolve_fips_version(Path::new("base.h"), content).unwrap(),
+        3
+    );
+}
+
+#[test]
+fn test_validate_and_resolve_fips_version_requires_awslc_marker() {
+    // Missing OPENSSL_IS_AWSLC marker is rejected even if a FIPS macro exists.
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_base_h(temp_dir.path(), "#define AWSLC_FIPS_VERSION_NUMBER 4\n");
+    let err = validate_and_resolve_fips_version(temp_dir.path()).unwrap_err();
+    assert!(err.contains("not valid AWS-LC headers"), "{err}");
+}
+
+#[test]
+fn test_validate_and_resolve_fips_version_macro() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_base_h(
+        temp_dir.path(),
+        "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_FIPS_VERSION_NUMBER 4\n",
+    );
+    assert_eq!(
+        validate_and_resolve_fips_version(temp_dir.path()).unwrap(),
+        4
+    );
+}
+
+#[test]
+fn test_validate_and_resolve_fips_version_legacy() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    write_base_h(
+        temp_dir.path(),
+        "#define OPENSSL_IS_AWSLC 1\n#define AWSLC_VERSION_NUMBER_STRING \"3.3.0\"\n",
+    );
+    assert_eq!(
+        validate_and_resolve_fips_version(temp_dir.path()).unwrap(),
+        3
+    );
+}
+
+// -------------------------------------------------------------------------
+// Declared minimums must not exceed what we vendor
+// -------------------------------------------------------------------------
+//
+// Guards against declaring a minimum newer than the bundled submodule. Skips
+// when the submodule is absent; submodule-initialized CI enforces it.
+
+/// Path to a sibling sys crate's bundled `base.h`, relative to `builder-test`.
+fn bundled_base_h(sys_crate: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("builder-test should have a parent directory")
+        .join(sys_crate)
+        .join("aws-lc")
+        .join("include")
+        .join("openssl")
+        .join("base.h")
+}
+
+#[test]
+fn test_minimum_aws_lc_version_not_newer_than_bundled() {
+    let base_h = bundled_base_h("aws-lc-sys");
+    let Ok(content) = std::fs::read_to_string(&base_h) else {
+        eprintln!(
+            "skipping: bundled base.h not found at {} (submodule not initialized)",
+            base_h.display()
+        );
+        return;
+    };
+    let bundled = extract_version(&base_h, &content).unwrap();
+    assert!(
+        version_at_least(&bundled, MINIMUM_AWS_LC_VERSION).unwrap(),
+        "MINIMUM_AWS_LC_VERSION ({MINIMUM_AWS_LC_VERSION}) must not exceed the bundled \
+         aws-lc-sys version ({bundled})",
+    );
+}
+
+#[test]
+fn test_minimum_fips_version_not_newer_than_bundled() {
+    let base_h = bundled_base_h("aws-lc-fips-sys");
+    let Ok(content) = std::fs::read_to_string(&base_h) else {
+        eprintln!(
+            "skipping: bundled FIPS base.h not found at {} (submodule not initialized)",
+            base_h.display()
+        );
+        return;
+    };
+    let bundled = resolve_fips_version(&base_h, &content).unwrap();
+    assert!(
+        bundled >= MINIMUM_FIPS_VERSION,
+        "MINIMUM_FIPS_VERSION ({MINIMUM_FIPS_VERSION}) must not exceed the bundled \
+         aws-lc-fips-sys FIPS version ({bundled})",
+    );
+}
+
+// -------------------------------------------------------------------------
 // resolve_library — no explicit preference
 // -------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description of changes:

The system-library version check previously required the installed AWS-LC to be `>=` the bundled submodule's version. That floor ratcheted up on every submodule bump, rejected older-but-compatible installs, and couldn't run in CI without the submodule checked out (it read the submodule headers).

This replaces it with a declared minimum that's independent of the submodule:
- `aws-lc-sys` gates on mainline `1.68.0` — the first AWS-LC release that emits Rust bindings (`-DGENERATE_RUST_BINDINGS=ON`), which the system-library path consumes, so it's the genuine floor for this path.
- `aws-lc-fips-sys` gates on the FIPS *module* version (`AWSLC_FIPS_VERSION_NUMBER`, falling back to the version-string major on legacy `<=3.x` branches). aws/aws-lc#3211 decoupled the FIPS version from the library version, so the library version string is no longer a reliable ordering across the mainline/LTS split.

### Call-outs:

- The declared minimums are hand-maintained constants, *not* derived from the submodule. CI is the source of truth: `test-minimum-version` builds the mainline floor (`v1.68.0`) and `test-fips-minimum-version` builds the oldest FIPS branch that both reports `MINIMUM_FIPS_VERSION` and emits Rust bindings (`fips-2024-09-27`, which resolves to FIPS version 3 via the legacy fallback); both run the suite with the check enabled. A unit test guards that the declared minimums never exceed what we bundle.
- A *present-but-unparseable* `AWSLC_FIPS_VERSION_NUMBER` is a hard error, not a silent fallback to the library-version major — post-decoupling that value isn't a trustworthy substitute, so masking it would hide a real problem. An *absent* macro still falls back (the legacy `<=3.x` path).
- `MINIMUM_FIPS_VERSION` is `3` today, with a TODO to bump to `4` when the crate moves to `fips-2025-09-12-lts` (which would also move the FIPS floor job's pin).
- The FIPS workflow fans out over a configurable set of refs (FIPS branches + a FIPS build of `main`), edited in one place in the `setup` job. Listed refs must support `-DGENERATE_RUST_BINDINGS=ON` and be plain branch/tag names (they're embedded in artifact names).
- The system-library test jobs `rm -rf` the submodule tree after checkout (rather than only skipping init), so a from-source fallback stays physically impossible even if a future `actions/checkout` inits submodules by default.

### Testing:

- `cargo test -p builder-test` — FIPS-version resolution (including the malformed-macro path), the minimum-vs-bundled guards, and existing system-lib tests. Passing locally.
- CI: existing system-library jobs now run with the version check enabled (skip removed); `test-minimum-version` and `test-fips-minimum-version` exercise the non-FIPS and FIPS floors end-to-end. Needs a CI run to confirm `v1.68.0`, `fips-2024-09-27`, and a FIPS build of `main` build cleanly with Rust bindings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
