### PR TITLE
Automatically optimize aws-lc for size when opt-level is "s" or "z"

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,0 +1,109 @@
+name: binary-size
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!generate/aws-lc-*'
+  pull_request:
+    branches:
+      - '*'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+  # Minimum expected size reduction percentage when opt-level = "z" vs "3".
+  # Measured at ~67% on x86_64 Linux; threshold set conservatively.
+  EXPECTED_REDUCTION_PERCENT: 40
+
+permissions:
+  contents: read
+
+jobs:
+  binary-size-check:
+    if: github.repository_owner == 'aws'
+    name: Binary size reduction (x86_64 Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+
+      - name: Build with opt-level=3 (performance, no size optimization)
+        working-directory: tests/binary-size
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: "3"
+        run: |
+          cargo build --release
+          cp target/release/binary-size binary-size-default
+
+      - name: Build with opt-level=z (size-optimized, triggers OPENSSL_SMALL)
+        working-directory: tests/binary-size
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: "z"
+        run: |
+          cargo clean
+          cargo build --release
+          cp target/release/binary-size binary-size-small
+
+      - name: Verify small binary runs correctly
+        working-directory: tests/binary-size
+        run: ./binary-size-small
+
+      - name: Compare sizes
+        working-directory: tests/binary-size
+        run: |
+          size_default=$(stat --format="%s" binary-size-default)
+          size_small=$(stat --format="%s" binary-size-small)
+
+          echo "Default binary size (opt-level=3): ${size_default} bytes ($(numfmt --to=iec ${size_default}))"
+          echo "Small binary size (opt-level=z):   ${size_small} bytes ($(numfmt --to=iec ${size_small}))"
+
+          if [ "$size_default" -eq 0 ]; then
+            echo "ERROR: default binary has zero size"
+            exit 1
+          fi
+
+          reduction=$(( (size_default - size_small) * 100 / size_default ))
+          echo "Size reduction: ${reduction}%"
+          echo ""
+
+          echo "## Binary Size Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Variant | Size |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Default (opt-level=3) | $(numfmt --to=iec ${size_default}) (${size_default} bytes) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Small (opt-level=z)   | $(numfmt --to=iec ${size_small}) (${size_small} bytes) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Reduction** | **${reduction}%** |" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$reduction" -lt "$EXPECTED_REDUCTION_PERCENT" ]; then
+            echo "FAIL: Expected at least ${EXPECTED_REDUCTION_PERCENT}% reduction, got ${reduction}%"
+            exit 1
+          fi
+
+          echo "PASS: ${reduction}% reduction meets the ${EXPECTED_REDUCTION_PERCENT}% threshold"
+
+  small-tests:
+    if: github.repository_owner == 'aws'
+    name: Test suite with opt-level=z
+    runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_DEV_OPT_LEVEL: "z"
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+
+      - name: Run aws-lc-rs tests
+        run: cargo test -p aws-lc-rs --features unstable

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -3,8 +3,7 @@ name: binary-size
 on:
   push:
     branches:
-      - '*'
-      - '!generate/aws-lc-*'
+      - 'main'
   pull_request:
     branches:
       - '*'
@@ -14,9 +13,6 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
-  # Minimum expected size reduction percentage when opt-level = "z" vs "3".
-  # Measured at ~67% on x86_64 Linux; threshold set conservatively.
-  EXPECTED_REDUCTION_PERCENT: 40
 
 permissions:
   contents: read
@@ -24,9 +20,26 @@ permissions:
 jobs:
   binary-size-check:
     if: github.repository_owner == 'aws'
-    name: Binary size reduction (x86_64 Linux)
-    runs-on: ubuntu-latest
+    name: Binary size reduction (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Minimum expected size reduction percentage when opt-level = "z" vs "3".
+        # Measured at ~67% on x86_64 Linux and ~40% on aarch64; thresholds are
+        # set conservatively per platform.
+        include:
+          - os: ubuntu-latest
+            expected_reduction: 40
+          - os: windows-latest
+            expected_reduction: 25
+          - os: macos-latest
+            expected_reduction: 20
     steps:
+      - name: Install NASM
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
       - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
@@ -38,33 +51,43 @@ jobs:
 
       - name: Build with opt-level=3 (performance, no size optimization)
         working-directory: tests/binary-size
+        shell: bash
         env:
           CARGO_PROFILE_RELEASE_OPT_LEVEL: "3"
         run: |
           cargo build --release
-          cp target/release/binary-size binary-size-default
+          bin=target/release/binary-size
+          [ -f "${bin}.exe" ] && bin="${bin}.exe"
+          cp "$bin" binary-size-default
 
       - name: Build with opt-level=z (size-optimized, triggers OPENSSL_SMALL)
         working-directory: tests/binary-size
+        shell: bash
         env:
           CARGO_PROFILE_RELEASE_OPT_LEVEL: "z"
         run: |
           cargo clean
           cargo build --release
-          cp target/release/binary-size binary-size-small
+          bin=target/release/binary-size
+          [ -f "${bin}.exe" ] && bin="${bin}.exe"
+          cp "$bin" binary-size-small
 
       - name: Verify small binary runs correctly
         working-directory: tests/binary-size
+        shell: bash
         run: ./binary-size-small
 
       - name: Compare sizes
         working-directory: tests/binary-size
+        shell: bash
+        env:
+          EXPECTED_REDUCTION_PERCENT: ${{ matrix.expected_reduction }}
         run: |
-          size_default=$(stat --format="%s" binary-size-default)
-          size_small=$(stat --format="%s" binary-size-small)
+          size_default=$(wc -c < binary-size-default | tr -d '[:space:]')
+          size_small=$(wc -c < binary-size-small | tr -d '[:space:]')
 
-          echo "Default binary size (opt-level=3): ${size_default} bytes ($(numfmt --to=iec ${size_default}))"
-          echo "Small binary size (opt-level=z):   ${size_small} bytes ($(numfmt --to=iec ${size_small}))"
+          echo "Default binary size (opt-level=3): ${size_default} bytes"
+          echo "Small binary size (opt-level=z):   ${size_small} bytes"
 
           if [ "$size_default" -eq 0 ]; then
             echo "ERROR: default binary has zero size"
@@ -75,11 +98,11 @@ jobs:
           echo "Size reduction: ${reduction}%"
           echo ""
 
-          echo "## Binary Size Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Variant | Size |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---------|------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Default (opt-level=3) | $(numfmt --to=iec ${size_default}) (${size_default} bytes) |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Small (opt-level=z)   | $(numfmt --to=iec ${size_small}) (${size_small} bytes) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Binary Size Results (${{ matrix.os }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Variant | Size (bytes) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|--------------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Default (opt-level=3) | ${size_default} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Small (opt-level=z)   | ${size_small} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Reduction** | **${reduction}%** |" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$reduction" -lt "$EXPECTED_REDUCTION_PERCENT" ]; then
@@ -91,11 +114,19 @@ jobs:
 
   small-tests:
     if: github.repository_owner == 'aws'
-    name: Test suite with opt-level=z
-    runs-on: ubuntu-latest
+    name: Test suite with opt-level=z (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     env:
       CARGO_PROFILE_DEV_OPT_LEVEL: "z"
     steps:
+      - name: Install NASM
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
       - uses: actions/checkout@v7
         with:
           submodules: 'recursive'

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -31,6 +31,8 @@ jobs:
         include:
           - os: ubuntu-latest
             expected_reduction: 40
+          - os: ubuntu-24.04-arm
+            expected_reduction: 25
           - os: windows-latest
             expected_reduction: 25
           - os: macos-latest
@@ -119,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest ]
     env:
       CARGO_PROFILE_DEV_OPT_LEVEL: "z"
     steps:

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -25,9 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Minimum expected size reduction percentage when opt-level = "z" vs "3".
-        # Measured at ~67% on x86_64 Linux and ~40% on aarch64; thresholds are
-        # set conservatively per platform.
+        # Minimum expected size reduction for opt-level "z" vs "3", set conservatively
+        # per platform (measured: ~67% on x86_64 Linux, ~40% on aarch64).
         include:
           - os: ubuntu-latest
             expected_reduction: 40

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -171,6 +171,23 @@ least the minimum supported by this crate (currently `3`). It is read from
 `AWSLC_VERSION_NUMBER_STRING` on older branches (e.g. FIPS 3.x → `3`). To bypass
 this check (not recommended), set `AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
+## Optimizing for binary size
+
+When you build with `opt-level = "s"` or `opt-level = "z"`, `aws-lc-fips-sys`
+automatically applies compile-time defines that reduce binary size at the cost
+of performance (primarily elliptic curve operations). Set
+`AWS_LC_FIPS_SYS_SMALL=0` to prevent this, or `AWS_LC_FIPS_SYS_SMALL=1` to
+force it regardless of opt-level.
+
+**Note:** Enabling this optimization changes the compiled FIPS module and may
+affect FIPS validation status. A build-time warning is emitted when it is
+active. Consult your compliance requirements before shipping this configuration
+in a FIPS-regulated environment.
+
+See [aws-lc-sys/README.md](../aws-lc-sys/README.md#optimizing-for-binary-size)
+for details on the size reduction, performance trade-offs, and affected
+algorithms.
+
 ## Build Prerequisites
 
 Since this crate builds AWS-LC as a native library, all build tools needed to build AWS-LC are applicable to

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -173,11 +173,11 @@ this check (not recommended), set `AWS_LC_FIPS_SYS_SYSTEM_SKIP_VERSION_CHECK=1`.
 
 ## Optimizing for binary size
 
-When you build with `opt-level = "s"` or `opt-level = "z"`, `aws-lc-fips-sys`
-automatically applies compile-time defines that reduce binary size at the cost
-of performance (primarily elliptic curve operations). Set
-`AWS_LC_FIPS_SYS_SMALL=0` to prevent this, or `AWS_LC_FIPS_SYS_SMALL=1` to
-force it regardless of opt-level.
+Unlike `aws-lc-sys`, this crate never enables the size optimization
+automatically based on opt-level. Because the optimization changes the
+compiled FIPS module, it must be explicitly requested by setting
+`AWS_LC_FIPS_SYS_SMALL=1`. This applies compile-time defines that reduce
+binary size at the cost of performance (primarily elliptic curve operations).
 
 **Note:** Enabling this optimization changes the compiled FIPS module and may
 affect FIPS validation status. A build-time warning is emitted when it is

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -196,9 +196,9 @@ or you may get link errors when the `ssl` feature is on.
 
 When you build with `opt-level = "s"` or `opt-level = "z"` (Cargo's
 size-optimizing profiles), `aws-lc-sys` automatically applies compile-time
-defines that replace high-performance implementations (precomputed EC tables,
-AVX-512 vectorized AES-GCM/SHA routines) with smaller generic equivalents.
-No configuration is needed — set the opt-level in your `Cargo.toml` profile:
+defines that replace high-performance implementations with smaller generic
+equivalents. No configuration is needed — set the opt-level in your
+`Cargo.toml` profile:
 
 ```toml
 [profile.release]
@@ -206,16 +206,21 @@ opt-level = "z"
 ```
 
 On x86_64 Linux, this typically reduces the aws-lc footprint by ~60–70%.
-The effect is platform-dependent — x86_64 benefits most because the AVX-512
-assembly is large; aarch64 sees a smaller reduction from the EC table
-elimination alone.
+aarch64 sees a ~40% reduction. The effect is platform-dependent — x86_64
+benefits most because disabling AVX-512 assembly removes large vectorized
+routines.
 
 Key properties:
 
 * **Automatic.** Triggered by `opt-level = "s"` or `"z"`.
 * **Behavior-preserving.** All algorithms remain available; outputs are
-  identical. Only performance characteristics change (slower bulk
-  AES-GCM/SHA on AVX-512-capable CPUs, slower EC scalar operations).
+  identical.
+* **Performance trade-off.** Elliptic curve operations (ECDSA, ECDH) are
+  significantly slower due to the removal of precomputed tables — expect
+  P-256 operations to be roughly 2–3× slower and P-384 roughly 3–6×
+  slower. Symmetric operations (AES-GCM, SHA) and RSA are largely
+  unaffected on aarch64; on x86_64 bulk throughput may decrease due to
+  the removal of AVX-512 code paths.
 * **Not applied to FIPS builds.** The defines are suppressed for
   `aws-lc-fips-sys`, since changing the compiled code would invalidate
   the FIPS module integrity check.

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -213,6 +213,9 @@ routines.
 Key properties:
 
 * **Automatic.** Triggered by `opt-level = "s"` or `"z"`.
+* **Overridable.** Set `AWS_LC_SYS_SMALL=1` to force the size-optimized
+  build regardless of opt-level, or `AWS_LC_SYS_SMALL=0` to prevent it
+  even when the opt-level would otherwise trigger it.
 * **Behavior-preserving.** All algorithms remain available; outputs are
   identical.
 * **Performance trade-off.** Elliptic curve operations (ECDSA, ECDH) are
@@ -221,11 +224,6 @@ Key properties:
   slower. Symmetric operations (AES-GCM, SHA) and RSA are largely
   unaffected on aarch64; on x86_64 bulk throughput may decrease due to
   the removal of AVX-512 code paths.
-* **FIPS builds.** The optimization is applied to `aws-lc-fips-sys` when
-  the opt-level triggers it, but a build-time warning is emitted. Changing
-  the compiled module may affect FIPS validation status — consult your
-  compliance requirements before shipping this configuration in a
-  FIPS-regulated environment.
 
 ## Build Prerequisites
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -221,9 +221,11 @@ Key properties:
   slower. Symmetric operations (AES-GCM, SHA) and RSA are largely
   unaffected on aarch64; on x86_64 bulk throughput may decrease due to
   the removal of AVX-512 code paths.
-* **Not applied to FIPS builds.** The defines are suppressed for
-  `aws-lc-fips-sys`, since changing the compiled code would invalidate
-  the FIPS module integrity check.
+* **FIPS builds.** The optimization is applied to `aws-lc-fips-sys` when
+  the opt-level triggers it, but a build-time warning is emitted. Changing
+  the compiled module may affect FIPS validation status — consult your
+  compliance requirements before shipping this configuration in a
+  FIPS-regulated environment.
 
 ## Build Prerequisites
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -192,6 +192,34 @@ produces such a combined file by default; if you supply your own bindings
 via `AWS_LC_SYS_SYSTEM_BINDINGS`, ensure they include the `ssl` symbols
 or you may get link errors when the `ssl` feature is on.
 
+## Optimizing for binary size
+
+When you build with `opt-level = "s"` or `opt-level = "z"` (Cargo's
+size-optimizing profiles), `aws-lc-sys` automatically applies compile-time
+defines that replace high-performance implementations (precomputed EC tables,
+AVX-512 vectorized AES-GCM/SHA routines) with smaller generic equivalents.
+No configuration is needed — set the opt-level in your `Cargo.toml` profile:
+
+```toml
+[profile.release]
+opt-level = "z"
+```
+
+On x86_64 Linux, this typically reduces the aws-lc footprint by ~60–70%.
+The effect is platform-dependent — x86_64 benefits most because the AVX-512
+assembly is large; aarch64 sees a smaller reduction from the EC table
+elimination alone.
+
+Key properties:
+
+* **Automatic.** Triggered by `opt-level = "s"` or `"z"`.
+* **Behavior-preserving.** All algorithms remain available; outputs are
+  identical. Only performance characteristics change (slower bulk
+  AES-GCM/SHA on AVX-512-capable CPUs, slower EC scalar operations).
+* **Not applied to FIPS builds.** The defines are suppressed for
+  `aws-lc-fips-sys`, since changing the compiled code would invalidate
+  the FIPS module integrity check.
+
 ## Build Prerequisites
 
 Since this crate builds AWS-LC as a native library, most build tools needed to build AWS-LC are applicable

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -224,6 +224,9 @@ Key properties:
   slower. Symmetric operations (AES-GCM, SHA) and RSA are largely
   unaffected on aarch64; on x86_64 bulk throughput may decrease due to
   the removal of AVX-512 code paths.
+* **Windows NASM.** Source-built NASM assembly honors the size-optimization
+  definitions. Prebuilt NASM objects cannot be reconfigured; install NASM
+  to obtain the full assembly size reduction on Windows.
 
 ## Build Prerequisites
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -197,7 +197,7 @@ or you may get link errors when the `ssl` feature is on.
 When you build with `opt-level = "s"` or `opt-level = "z"` (Cargo's
 size-optimizing profiles), `aws-lc-sys` automatically applies compile-time
 defines that replace high-performance implementations with smaller generic
-equivalents. No configuration is needed — set the opt-level in your
+equivalents. No configuration is needed -- set the opt-level in your
 `Cargo.toml` profile:
 
 ```toml
@@ -205,8 +205,8 @@ equivalents. No configuration is needed — set the opt-level in your
 opt-level = "z"
 ```
 
-On x86_64 Linux, this typically reduces the aws-lc footprint by ~60–70%.
-aarch64 sees a ~40% reduction. The effect is platform-dependent — x86_64
+On x86_64 Linux, this typically reduces the aws-lc footprint by ~60-70%.
+aarch64 sees a ~40% reduction. The effect is platform-dependent -- x86_64
 benefits most because disabling AVX-512 assembly removes large vectorized
 routines.
 
@@ -219,8 +219,8 @@ Key properties:
 * **Behavior-preserving.** All algorithms remain available; outputs are
   identical.
 * **Performance trade-off.** Elliptic curve operations (ECDSA, ECDH) are
-  significantly slower due to the removal of precomputed tables — expect
-  P-256 operations to be roughly 2–3× slower and P-384 roughly 3–6×
+  significantly slower due to the removal of precomputed tables -- expect
+  P-256 operations to be roughly 2-3x slower and P-384 roughly 3-6x
   slower. Symmetric operations (AES-GCM, SHA) and RSA are largely
   unaffected on aarch64; on x86_64 bulk throughput may decrease due to
   the removal of AVX-512 code paths.

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -227,6 +227,8 @@ Key properties:
 * **Windows NASM.** Source-built NASM assembly honors the size-optimization
   definitions. Prebuilt NASM objects cannot be reconfigured; install NASM
   to obtain the full assembly size reduction on Windows.
+* **FIPS.** `aws-lc-fips-sys` never enables this automatically; it requires
+  an explicit `AWS_LC_FIPS_SYS_SMALL=1`. See its README for details.
 
 ## Build Prerequisites
 

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -21,9 +21,9 @@ use crate::nasm_builder::NasmBuilder;
 use crate::{
     cargo_env, compiler_is_cl_like, emit_warning, env_var_to_bool, execute_command, find_clang_cl,
     get_crate_cc, get_crate_cflags, get_crate_cxx, is_cross_compiling, is_link_whole_archive,
-    is_no_asm, out_dir, requested_c_std, set_env_for_target, should_build_jitter_entropy, target,
-    target_arch, target_env, target_is_msvc, target_os, target_vendor, CStdRequested, EnvGuard,
-    OutputLibType,
+    is_no_asm, is_small, out_dir, requested_c_std, set_env_for_target, should_build_jitter_entropy,
+    target, target_arch, target_env, target_is_msvc, target_os, target_vendor, CStdRequested,
+    EnvGuard, OutputLibType,
 };
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -266,6 +266,17 @@ impl CcBuilder {
             }
         }
 
+        if is_small() {
+            emit_warning(
+                "Size-optimized build (opt-level=s/z). Applying OPENSSL_SMALL and disabling AVX-512 assembly.",
+            );
+            build_options.push(BuildOption::define("OPENSSL_SMALL", "1"));
+            build_options.push(BuildOption::define(
+                "MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX",
+                "1",
+            ));
+        }
+
         if target_os() == "macos" {
             // This compiler error has only been seen on MacOS x86_64:
             // ```
@@ -288,6 +299,7 @@ impl CcBuilder {
         let mut build_options: Vec<BuildOption> = Vec::new();
         let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
         if !is_cl_like {
+            build_options.push(BuildOption::flag("-fvisibility=hidden"));
             build_options.push(BuildOption::flag("-Wno-unused-parameter"));
             // On emscripten, `-pthread` forces a shared-memory wasm module
             // (requires SharedArrayBuffer); build single-threaded instead.

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -171,13 +171,13 @@ impl BuildOption {
 }
 
 impl CcBuilder {
-    fn small_c_build_options() -> [BuildOption; 1] {
-        [BuildOption::define("OPENSSL_SMALL", "1")]
+    fn small_c_build_options() -> Vec<BuildOption> {
+        vec![BuildOption::define("OPENSSL_SMALL", "1")]
     }
 
-    fn small_nasm_build_options() -> [BuildOption; 2] {
+    fn small_nasm_build_options() -> Vec<BuildOption> {
         // Raw NASM sources cannot include target.h, where OPENSSL_SMALL implies this gate.
-        [
+        vec![
             BuildOption::define("OPENSSL_SMALL", "1"),
             BuildOption::define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", "1"),
         ]

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -301,7 +301,6 @@ impl CcBuilder {
         let mut build_options: Vec<BuildOption> = Vec::new();
         let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
         if !is_cl_like {
-            build_options.push(BuildOption::flag("-fvisibility=hidden"));
             build_options.push(BuildOption::flag("-Wno-unused-parameter"));
             // On emscripten, `-pthread` forces a shared-memory wasm module
             // (requires SharedArrayBuffer); build single-threaded instead.

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -22,8 +22,8 @@ use crate::{
     cargo_env, compiler_is_cl_like, emit_warning, env_var_to_bool, execute_command, find_clang_cl,
     get_crate_cc, get_crate_cflags, get_crate_cxx, is_cross_compiling, is_link_whole_archive,
     is_no_asm, is_small, out_dir, requested_c_std, set_env_for_target, should_build_jitter_entropy,
-    target, target_arch, target_env, target_is_msvc, target_os, target_vendor, CStdRequested,
-    EnvGuard, OutputLibType,
+    target, target_arch, target_env, target_is_msvc, target_os, target_vendor, use_prebuilt_nasm,
+    CStdRequested, EnvGuard, OutputLibType,
 };
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -93,6 +93,7 @@ fn identify_sources() -> Vec<&'static str> {
 }
 
 #[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum BuildOption {
     STD(String),
     FLAG(String),
@@ -170,6 +171,18 @@ impl BuildOption {
 }
 
 impl CcBuilder {
+    fn small_c_build_options() -> [BuildOption; 1] {
+        [BuildOption::define("OPENSSL_SMALL", "1")]
+    }
+
+    fn small_nasm_build_options() -> [BuildOption; 2] {
+        // Raw NASM sources cannot include target.h, where OPENSSL_SMALL implies this gate.
+        [
+            BuildOption::define("OPENSSL_SMALL", "1"),
+            BuildOption::define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", "1"),
+        ]
+    }
+
     pub(crate) fn new(
         manifest_dir: PathBuf,
         out_dir: PathBuf,
@@ -264,17 +277,6 @@ impl CcBuilder {
                     }
                 }
             }
-        }
-
-        if is_small() {
-            emit_warning(
-                "Size-optimized build (opt-level=s/z). Applying OPENSSL_SMALL and disabling AVX-512 assembly.",
-            );
-            build_options.push(BuildOption::define("OPENSSL_SMALL", "1"));
-            build_options.push(BuildOption::define(
-                "MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX",
-                "1",
-            ));
         }
 
         if target_os() == "macos" {
@@ -382,6 +384,14 @@ impl CcBuilder {
         let (is_cl_like, build_options) = self.collect_universal_build_options(&cc_build, false);
         for option in build_options {
             option.apply_cc(&mut cc_build);
+        }
+        if is_small() {
+            emit_warning(
+                "Size-optimized AWS-LC build enabled. Applying OPENSSL_SMALL and disabling AVX-512 assembly.",
+            );
+            for option in Self::small_c_build_options() {
+                option.apply_cc(&mut cc_build);
+            }
         }
 
         // Add --noexecstack flag for assembly files to prevent executable stacks
@@ -654,6 +664,17 @@ impl CcBuilder {
 
         for option in &build_options {
             option.apply_nasm(&mut nasm_builder);
+        }
+        if is_small() {
+            for option in Self::small_nasm_build_options() {
+                option.apply_nasm(&mut nasm_builder);
+            }
+            if use_prebuilt_nasm() {
+                emit_warning(
+                    "Prebuilt NASM objects cannot apply size-optimization definitions. \
+                     Install NASM to minimize Windows assembly code.",
+                );
+            }
         }
 
         let s2n_bignum_source_feature_map = Self::build_s2n_bignum_source_feature_map();
@@ -1199,5 +1220,30 @@ mod tests {
                 "{gnu} should not be detected as cl driver mode"
             );
         }
+    }
+
+    #[test]
+    fn test_small_c_build_options() {
+        assert_eq!(
+            CcBuilder::small_c_build_options(),
+            [BuildOption::DEFINE(
+                "OPENSSL_SMALL".to_string(),
+                "1".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_small_nasm_build_options() {
+        assert_eq!(
+            CcBuilder::small_nasm_build_options(),
+            [
+                BuildOption::DEFINE("OPENSSL_SMALL".to_string(), "1".to_string()),
+                BuildOption::DEFINE(
+                    "MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX".to_string(),
+                    "1".to_string(),
+                ),
+            ]
+        );
     }
 }

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -5,7 +5,7 @@ use crate::cc_builder::CcBuilder;
 use crate::OutputLib::{Crypto, Ssl};
 use crate::{
     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
-    get_crate_cflags, is_crt_static, is_fips_build, is_no_asm, is_no_pregenerated_src,
+    get_crate_cflags, is_crt_static, is_fips_build, is_no_asm, is_no_pregenerated_src, is_small,
     optional_env, optional_env_optional_crate_target, sanitizer, set_env, set_env_for_target,
     should_build_jitter_entropy, target, target_arch, target_env, target_is_msvc, target_os,
     test_clang_cl_command, test_nasm_command, use_prebuilt_nasm, OutputLibType,
@@ -204,6 +204,14 @@ impl CmakeBuilder {
             } else {
                 panic!("AWS_LC_SYS_NO_ASM only allowed for debug builds!")
             }
+        }
+
+        if is_small() {
+            emit_warning(
+                "Size-optimized build (opt-level=s/z). Applying OPENSSL_SMALL and disabling AVX-512 assembly.",
+            );
+            cmake_cfg.define("OPENSSL_SMALL", "1");
+            cmake_cfg.define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", "1");
         }
 
         Self::configure_sanitizer(&mut cmake_cfg);

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -33,6 +33,22 @@ fn strip_lto_flags(cflags: &str) -> String {
         .join(" ")
 }
 
+const fn cmake_bool(value: bool) -> &'static str {
+    if value {
+        "ON"
+    } else {
+        "OFF"
+    }
+}
+
+const fn cmake_nasm_small_flags(value: bool) -> &'static str {
+    if value {
+        "-DOPENSSL_SMALL=1 -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=1"
+    } else {
+        ""
+    }
+}
+
 pub(crate) struct CmakeBuilder {
     manifest_dir: PathBuf,
     out_dir: PathBuf,
@@ -206,12 +222,21 @@ impl CmakeBuilder {
             }
         }
 
-        if is_small() {
+        let small = is_small();
+        let small_value = cmake_bool(small);
+        cmake_cfg.define("OPENSSL_SMALL", small_value);
+        if is_fips_build() {
+            // The pinned FIPS AWS-LC branch does not yet derive this from OPENSSL_SMALL.
+            cmake_cfg.define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", small_value);
+        }
+        if target_os() == "windows" && target_arch() == "x86_64" {
+            // Raw NASM cannot include target.h, and add_definitions does not reach it.
+            cmake_cfg.define("CMAKE_ASM_NASM_FLAGS", cmake_nasm_small_flags(small));
+        }
+        if small {
             emit_warning(
-                "Size-optimized build (opt-level=s/z). Applying OPENSSL_SMALL and disabling AVX-512 assembly.",
+                "Size-optimized AWS-LC build enabled. Applying OPENSSL_SMALL and disabling AVX-512 assembly.",
             );
-            cmake_cfg.define("OPENSSL_SMALL", "1");
-            cmake_cfg.define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", "1");
         }
 
         Self::configure_sanitizer(&mut cmake_cfg);
@@ -490,6 +515,12 @@ impl CmakeBuilder {
         emit_warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         emit_warning("!!!   Using pre-built NASM binaries   !!!");
         emit_warning("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+        if is_small() {
+            emit_warning(
+                "Prebuilt NASM objects cannot apply size-optimization definitions. \
+                 Install NASM to minimize Windows assembly code.",
+            );
+        }
 
         let script_path = self.select_prebuilt_nasm_script();
         let script_path = script_path.display().to_string();
@@ -733,7 +764,22 @@ impl crate::Builder for CmakeBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::strip_lto_flags;
+    use super::{cmake_bool, cmake_nasm_small_flags, strip_lto_flags};
+
+    #[test]
+    fn test_cmake_bool() {
+        assert_eq!(cmake_bool(true), "ON");
+        assert_eq!(cmake_bool(false), "OFF");
+    }
+
+    #[test]
+    fn test_cmake_nasm_small_flags() {
+        assert_eq!(
+            cmake_nasm_small_flags(true),
+            "-DOPENSSL_SMALL=1 -DMY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX=1"
+        );
+        assert_eq!(cmake_nasm_small_flags(false), "");
+    }
 
     #[test]
     fn test_strip_lto_flags() {

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -222,6 +222,10 @@ impl CmakeBuilder {
             }
         }
 
+        // These cache entries are set unconditionally (ON/OFF or flags/empty) so
+        // that toggling the size optimization between builds updates the persisted
+        // CMake cache in OUT_DIR; if we only defined them when enabled, a stale
+        // cached value could survive after the setting is turned off.
         let small = is_small();
         let small_value = cmake_bool(small);
         cmake_cfg.define("OPENSSL_SMALL", small_value);

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -223,17 +223,14 @@ impl CmakeBuilder {
             }
         }
 
-        // These cache entries are set unconditionally (ON/OFF or flags/empty) so
-        // that toggling the size optimization between builds updates the persisted
-        // CMake cache in OUT_DIR; if we only defined them when enabled, a stale
-        // cached value could survive after the setting is turned off.
+        // Always set these cache entries (ON/OFF, flags/empty): the CMake cache in
+        // OUT_DIR persists across builds, so a stale value could survive a toggle.
         let small = is_small();
         let small_value = cmake_bool(small);
         cmake_cfg.define("OPENSSL_SMALL", small_value);
         if is_fips_crate() {
-            // Only the pinned FIPS AWS-LC branch lacks the CMake derivation of this
-            // from OPENSSL_SMALL; the mainline branch (aws-lc-sys, with or without
-            // the `fips` feature) derives it in its own CMakeLists.txt.
+            // Only the pinned FIPS branch needs this; mainline CMakeLists
+            // derives it from OPENSSL_SMALL.
             cmake_cfg.define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", small_value);
         }
         if target_os() == "windows" && target_arch() == "x86_64" {

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -5,10 +5,11 @@ use crate::cc_builder::CcBuilder;
 use crate::OutputLib::{Crypto, Ssl};
 use crate::{
     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
-    get_crate_cflags, is_crt_static, is_fips_build, is_no_asm, is_no_pregenerated_src, is_small,
-    optional_env, optional_env_optional_crate_target, sanitizer, set_env, set_env_for_target,
-    should_build_jitter_entropy, target, target_arch, target_env, target_is_msvc, target_os,
-    test_clang_cl_command, test_nasm_command, use_prebuilt_nasm, OutputLibType,
+    get_crate_cflags, is_crt_static, is_fips_build, is_fips_crate, is_no_asm,
+    is_no_pregenerated_src, is_small, optional_env, optional_env_optional_crate_target, sanitizer,
+    set_env, set_env_for_target, should_build_jitter_entropy, target, target_arch, target_env,
+    target_is_msvc, target_os, test_clang_cl_command, test_nasm_command, use_prebuilt_nasm,
+    OutputLibType,
 };
 use std::collections::HashMap;
 use std::env;
@@ -229,8 +230,10 @@ impl CmakeBuilder {
         let small = is_small();
         let small_value = cmake_bool(small);
         cmake_cfg.define("OPENSSL_SMALL", small_value);
-        if is_fips_build() {
-            // The pinned FIPS AWS-LC branch does not yet derive this from OPENSSL_SMALL.
+        if is_fips_crate() {
+            // Only the pinned FIPS AWS-LC branch lacks the CMake derivation of this
+            // from OPENSSL_SMALL; the mainline branch (aws-lc-sys, with or without
+            // the `fips` feature) derives it in its own CMakeLists.txt.
             cmake_cfg.define("MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX", small_value);
         }
         if target_os() == "windows" && target_arch() == "x86_64" {

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -919,6 +919,14 @@ fn is_no_asm() -> bool {
     unsafe { SYS_NO_ASM }
 }
 
+pub(crate) fn is_small() -> bool {
+    if is_fips_build() {
+        return false;
+    }
+    let opt_level = cargo_env("OPT_LEVEL");
+    matches!(opt_level.as_str(), "z" | "s")
+}
+
 #[allow(static_mut_refs)]
 fn sanitizer() -> Option<String> {
     unsafe { SYS_SANITIZER.clone() }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -127,7 +127,7 @@ pub(crate) fn is_fips_build() -> bool {
     is_fips_crate() || cfg!(feature = "fips")
 }
 
-fn is_fips_crate() -> bool {
+pub(crate) fn is_fips_crate() -> bool {
     crate_name().contains("fips")
 }
 
@@ -823,7 +823,7 @@ fn initialize() {
 
     // Emitted once here rather than from is_small(), which is called multiple
     // times during the build.
-    if is_fips_build() && is_small() {
+    if is_fips_crate() && is_small() {
         emit_warning(
             "OPENSSL_SMALL is being applied to a FIPS build. \
              This changes the compiled module and may affect FIPS validation status. \
@@ -936,10 +936,12 @@ pub(crate) fn is_small() -> bool {
     if let Some(explicit) = unsafe { SYS_SMALL } {
         return explicit;
     }
-    // FIPS builds never enable the size optimization implicitly. It changes the
-    // compiled FIPS module, so it must be deliberately requested via
-    // AWS_LC_FIPS_SYS_SMALL=1.
-    if is_fips_build() {
+    // aws-lc-fips-sys tracks a certified (or certification-track) FIPS module,
+    // where the module's exact shape matters; the size optimization must be
+    // deliberately requested via AWS_LC_FIPS_SYS_SMALL=1. Mainline FIPS-mode
+    // builds (aws-lc-sys with the `fips` feature) follow the normal opt-level
+    // detection: their value is the integrity check, not a validated shape.
+    if is_fips_crate() {
         return false;
     }
     matches!(cargo_env("OPT_LEVEL").as_str(), "z" | "s")

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -821,8 +821,7 @@ fn initialize() {
         "aws-lc-fips-sys requires 'fips' feature to be enabled.",
     );
 
-    // Emitted once here rather than from is_small(), which is called multiple
-    // times during the build.
+    // Emitted here because is_small() is called multiple times per build.
     if is_fips_crate() && is_small() {
         emit_warning(
             "OPENSSL_SMALL is being applied to a FIPS build. \
@@ -936,11 +935,9 @@ pub(crate) fn is_small() -> bool {
     if let Some(explicit) = unsafe { SYS_SMALL } {
         return explicit;
     }
-    // aws-lc-fips-sys tracks a certified (or certification-track) FIPS module,
-    // where the module's exact shape matters; the size optimization must be
-    // deliberately requested via AWS_LC_FIPS_SYS_SMALL=1. Mainline FIPS-mode
-    // builds (aws-lc-sys with the `fips` feature) follow the normal opt-level
-    // detection: their value is the integrity check, not a validated shape.
+    // aws-lc-fips-sys tracks a certification-track FIPS module whose exact shape
+    // matters: size optimization requires an explicit AWS_LC_FIPS_SYS_SMALL=1.
+    // Mainline FIPS-mode builds (`fips` feature) use normal opt-level detection.
     if is_fips_crate() {
         return false;
     }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -821,6 +821,16 @@ fn initialize() {
         "aws-lc-fips-sys requires 'fips' feature to be enabled.",
     );
 
+    // Emitted once here rather than from is_small(), which is called multiple
+    // times during the build.
+    if is_fips_build() && is_small() {
+        emit_warning(
+            "OPENSSL_SMALL is being applied to a FIPS build. \
+             This changes the compiled module and may affect FIPS validation status. \
+             Consult your compliance requirements before shipping this configuration.",
+        );
+    }
+
     if !is_external_bindgen_requested().unwrap_or(false)
         && (is_pregenerating_bindings() || !has_bindgen_feature())
         && !cfg!(feature = "ssl")
@@ -922,24 +932,17 @@ fn is_no_asm() -> bool {
 }
 
 pub(crate) fn is_small() -> bool {
-    // Explicit override takes precedence over opt-level detection.
-    let explicit = unsafe { SYS_SMALL };
-    let small = match explicit {
-        Some(true) => true,
-        Some(false) => return false,
-        None => {
-            let opt_level = cargo_env("OPT_LEVEL");
-            matches!(opt_level.as_str(), "z" | "s")
-        }
-    };
-    if small && is_fips_build() {
-        emit_warning(
-            "OPENSSL_SMALL is being applied to a FIPS build. \
-             This changes the compiled module and may affect FIPS validation status. \
-             Consult your compliance requirements before shipping this configuration.",
-        );
+    // An explicit setting takes precedence over opt-level detection.
+    if let Some(explicit) = unsafe { SYS_SMALL } {
+        return explicit;
     }
-    small
+    // FIPS builds never enable the size optimization implicitly. It changes the
+    // compiled FIPS module, so it must be deliberately requested via
+    // AWS_LC_FIPS_SYS_SMALL=1.
+    if is_fips_build() {
+        return false;
+    }
+    matches!(cargo_env("OPT_LEVEL").as_str(), "z" | "s")
 }
 
 #[allow(static_mut_refs)]

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -775,6 +775,7 @@ static mut SYS_NO_ASM: bool = false;
 static mut SYS_PREBUILT_NASM: Option<bool> = None;
 static mut SYS_CMAKE_BUILDER: Option<bool> = None;
 static mut SYS_NO_PREGENERATED_SRC: bool = false;
+static mut SYS_SMALL: Option<bool> = None;
 static mut SYS_EFFECTIVE_TARGET: String = String::new();
 static mut SYS_NO_JITTER_ENTROPY: Option<bool> = None;
 static mut SYS_NO_U1_BINDINGS: Option<bool> = None;
@@ -799,6 +800,7 @@ fn initialize() {
         SYS_C_STD = CStdRequested::from_env();
         SYS_CMAKE_BUILDER = env_crate_var_to_bool("CMAKE_BUILDER");
         SYS_NO_PREGENERATED_SRC = env_crate_var_to_bool("NO_PREGENERATED_SRC").unwrap_or(false);
+        SYS_SMALL = env_crate_var_to_bool("SMALL");
         SYS_EFFECTIVE_TARGET = optional_env_crate_target("EFFECTIVE_TARGET").unwrap_or_default();
         SYS_NO_JITTER_ENTROPY = env_crate_var_to_bool("NO_JITTER_ENTROPY");
         SYS_NO_U1_BINDINGS = env_crate_var_to_bool("NO_U1_BINDINGS");
@@ -920,18 +922,24 @@ fn is_no_asm() -> bool {
 }
 
 pub(crate) fn is_small() -> bool {
-    let opt_level = cargo_env("OPT_LEVEL");
-    if !matches!(opt_level.as_str(), "z" | "s") {
-        return false;
-    }
-    if is_fips_build() {
+    // Explicit override takes precedence over opt-level detection.
+    let explicit = unsafe { SYS_SMALL };
+    let small = match explicit {
+        Some(true) => true,
+        Some(false) => return false,
+        None => {
+            let opt_level = cargo_env("OPT_LEVEL");
+            matches!(opt_level.as_str(), "z" | "s")
+        }
+    };
+    if small && is_fips_build() {
         emit_warning(
-            "OPENSSL_SMALL is being applied to a FIPS build (opt-level=s/z). \
+            "OPENSSL_SMALL is being applied to a FIPS build. \
              This changes the compiled module and may affect FIPS validation status. \
              Consult your compliance requirements before shipping this configuration.",
         );
     }
-    true
+    small
 }
 
 #[allow(static_mut_refs)]

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -920,11 +920,18 @@ fn is_no_asm() -> bool {
 }
 
 pub(crate) fn is_small() -> bool {
-    if is_fips_build() {
+    let opt_level = cargo_env("OPT_LEVEL");
+    if !matches!(opt_level.as_str(), "z" | "s") {
         return false;
     }
-    let opt_level = cargo_env("OPT_LEVEL");
-    matches!(opt_level.as_str(), "z" | "s")
+    if is_fips_build() {
+        emit_warning(
+            "OPENSSL_SMALL is being applied to a FIPS build (opt-level=s/z). \
+             This changes the compiled module and may affect FIPS validation status. \
+             Consult your compliance requirements before shipping this configuration.",
+        );
+    }
+    true
 }
 
 #[allow(static_mut_refs)]

--- a/tests/binary-size/Cargo.toml
+++ b/tests/binary-size/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "binary-size"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Standalone crate (not part of the main workspace) for binary-size measurement.
+[workspace]
+
+[dependencies]
+aws-lc-rs = { path = "../../aws-lc-rs" }
+
+[profile.release]
+lto = false
+codegen-units = 16
+panic = "abort"
+strip = true

--- a/tests/binary-size/src/main.rs
+++ b/tests/binary-size/src/main.rs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+//! Minimal crypto surface binary for size measurement.
+//!
+//! Exercises SHA-256, AES-256-GCM, and ECDSA-P256 — the same surface used in
+//! the binary-size investigation. The accumulator prevents dead-code
+//! elimination from stripping the crypto operations.
+
+use aws_lc_rs::aead::{Aad, LessSafeKey, Nonce, UnboundKey, AES_256_GCM};
+use aws_lc_rs::digest;
+use aws_lc_rs::rand::SystemRandom;
+use aws_lc_rs::signature::{
+    EcdsaKeyPair, EcdsaSigningAlgorithm, KeyPair, ECDSA_P256_SHA256_ASN1,
+    ECDSA_P256_SHA256_ASN1_SIGNING,
+};
+
+fn main() {
+    let mut acc: u64 = 0;
+
+    // SHA-256
+    for i in 0u64..100 {
+        let d = digest::digest(&digest::SHA256, &i.to_le_bytes());
+        acc = acc.wrapping_add(u64::from(d.as_ref()[0]));
+    }
+
+    // AES-256-GCM
+    let key_bytes = [0x42u8; 32];
+    let unbound = UnboundKey::new(&AES_256_GCM, &key_bytes).unwrap();
+    let key = LessSafeKey::new(unbound);
+    let nonce = Nonce::assume_unique_for_key([0u8; 12]);
+    let mut buf = b"hello world!!!!X".to_vec();
+    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut buf)
+        .unwrap();
+    acc = acc.wrapping_add(u64::from(buf[0]));
+
+    // ECDSA P-256
+    let rng = SystemRandom::new();
+    let alg: &EcdsaSigningAlgorithm = &ECDSA_P256_SHA256_ASN1_SIGNING;
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(alg, &rng).unwrap();
+    let kp = EcdsaKeyPair::from_pkcs8(alg, pkcs8.as_ref()).unwrap();
+    let sig = kp.sign(&rng, b"test message").unwrap();
+    let pub_key = kp.public_key();
+    let peer_pub_key =
+        aws_lc_rs::signature::UnparsedPublicKey::new(&ECDSA_P256_SHA256_ASN1, pub_key.as_ref());
+    peer_pub_key.verify(b"test message", sig.as_ref()).unwrap();
+    acc = acc.wrapping_add(u64::from(sig.as_ref()[0]));
+
+    println!("acc={acc}");
+}

--- a/tests/binary-size/src/main.rs
+++ b/tests/binary-size/src/main.rs
@@ -3,7 +3,7 @@
 
 //! Minimal crypto surface binary for size measurement.
 //!
-//! Exercises SHA-256, AES-256-GCM, and ECDSA-P256 — the same surface used in
+//! Exercises SHA-256, AES-256-GCM, and ECDSA-P256 -- the same surface used in
 //! the binary-size investigation. The accumulator prevents dead-code
 //! elimination from stripping the crypto operations.
 


### PR DESCRIPTION
### Issues:
Addresses #745, P353434599

### Description of changes:

Consumers targeting constrained environments (embedded, Lambda, size-sensitive containers) currently have no straightforward way to reduce the AWS-LC footprint. This PR has the builder opt into AWS-LC's size-optimized configuration automatically whenever Cargo is already building for size (`opt-level=s` or `z`), so the smaller footprint comes along with the profile the consumer has already chosen. It can also be forced on or off explicitly, independent of opt-level.

Under the hood this enables AWS-LC's `OPENSSL_SMALL` configuration, which trades large, fast implementations (most notably the AVX-512 assembly on x86_64) for smaller generic ones. No algorithms are removed and outputs are unchanged -- the cost is slower elliptic-curve performance. The optimization is wired through both the cc and cmake builders across Linux, macOS, and Windows.


### Call-outs:

- The size defines are applied differently depending on the compilation path (C/`.S`, raw NASM, and FIPS), which can look inconsistent in the diff but is intentional. For C/`.S` the AVX-512 gate is derived automatically from `OPENSSL_SMALL` (via `target.h`), whereas raw NASM never includes that header and has to be told explicitly; prebuilt NASM objects cannot be reconfigured at all and instead emit a warning.
- FIPS builds are not excluded but emit a warning, consistent with how we treat other user-controlled settings that could affect the module.
- Related AWS-LC PRs: 
  - aws/aws-lc#3319
  - aws/aws-lc#3320

### Testing:

Full test suite passes with size-optimized paths active (`opt-level=z`), builder unit tests cover the new option handling, and a non-required CI job asserts a meaningful size reduction on x86_64 Linux.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
