### PR TITLE
Harden GitHub Actions workflows against script injection

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -87,7 +87,10 @@ jobs:
       - name: Perform API Diff (Target Branch)
         if: matrix.diff_target == 'branch'
         working-directory: ${{ matrix.crate_dir }}
-        run: cargo public-api diff --deny changed --deny removed ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: cargo public-api diff --deny changed --deny removed "${BASE_SHA}..${HEAD_SHA}"
       - name: Perform API Diff (Published)
         if: matrix.diff_target == 'published'
         working-directory: ${{ matrix.crate_dir }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,9 +40,11 @@ jobs:
       - name: Build Documentation
         run: cargo doc --features fips,unstable --no-deps --workspace
       - name: Copy docs
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          mkdir -p book/book/rustdocs/${{ github.ref_name }}
-          cp --recursive target/doc -t book/book/rustdocs/${{ github.ref_name }}
+          mkdir -p "book/book/rustdocs/${REF_NAME}"
+          cp --recursive target/doc -t "book/book/rustdocs/${REF_NAME}"
       - name: Deploy Docs
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -32,13 +32,17 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Check PR description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # License statement we want present.
           LICENSE_STATEMENT="By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license."
 
           # Fetches the PR description.
-          PR_DESCRIPTION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r .body)
+          PR_DESCRIPTION=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" | jq -r .body)
 
           printf "PR description:\n%s" "${PR_DESCRIPTION}"
           echo ""


### PR DESCRIPTION
### Issues:
Addresses V2264309403

### Context
Several workflows interpolate GitHub Actions context expressions (`${{ ... }}`) directly into `run:` shell bodies. Actions splices those values into the script as text before the shell runs, so a value with shell metacharacters can break out and execute arbitrary code on the runner (see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections). 

### Description of changes:
This PR hoists each such expression into the step's `env:` block and references it as a shell variable, so the value is passed as data instead. Affected steps: `misc-tests.yml` (`Check PR description`), `analysis.yml` (`Perform API Diff (Target Branch)`), `deploy-docs.yml` (`Copy docs`). Behavior is otherwise unchanged.

### Call-outs:
`misc-tests.yml` is the primary motivation since it consumes external input; the other two are defense-in-depth. Note that git ref names can contain shell metacharacters, so the `env:` + path quoting in `deploy-docs.yml` matters despite that workflow only running on pushes to `main` and release tags.

### Testing:
CI config only, no product code impact. The `misc-tests.yml` and `analysis.yml` steps run on PRs and are exercised by this PR; `deploy-docs.yml` only runs on push to `main`/`v1.*` tags and was verified by inspection. All three files parse as valid YAML.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
