### PR TITLE
Fix memcmp compiler check on AIX

### DIFF
--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -826,6 +826,10 @@ impl CcBuilder {
         // requires -fuse-ld=lld). This matches the CMake build which only passes
         // CMAKE_C_FLAGS_RELEASE (-O3) to check_run().
         let mut memcmp_compile_args: Vec<std::ffi::OsString> = vec!["-O3".into()];
+        // AIX GCC defaults to 32-bit output; -maix64 selects the 64-bit ABI for the probe executable.
+        if target_os() == "aix" && target_arch() == "powerpc64" {
+            memcmp_compile_args.push("-maix64".into());
+        }
 
         // CFLAGS is ignored (above) but LDFLAGS is honored (below), so hardened
         // environments (e.g. RPM's redhat-rpm-config) can force -pie at link time


### PR DESCRIPTION
### Issues:
No open issues related to this as far as I know

### Description of changes: 
Fixes an unconditional error during crate compilation on `powerpc64`. The `memcmp_check` build was missing a required flag to build against 64-bit on AIX. This PR slots that in for the known architecture tuple of `aix` and `powerpc64`.

Following this change, I'm able to build the crate successfully on AIX 7.3. 🎉 

### Call-outs:
None that I'm aware of

### Testing:
No tests contributed in this PR. It doesn't seem like the repo has any ability to test against AIX machines, but if it does then please direct me to where I could add a smoke test for this compilation step working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
