### PR TITLE
fix: memcmp probe PIE mismatch and TARGET_* env leakage into host builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -948,6 +948,45 @@ jobs:
       - name: Run tests
         run: cargo test -p aws-lc-rs --all-targets
 
+  rpmbuild-hardened-environment:
+    if: github.repository_owner == 'aws'
+    # Reproduces the default Fedora/RHEL `rpmbuild` environment: %build exports
+    # CFLAGS/CXXFLAGS/LDFLAGS from the redhat-rpm-config macros evaluated below.
+    # These split PIE hardening across CFLAGS (-fPIE) and LDFLAGS (-pie), which
+    # broke the memcmp probe (it drops CFLAGS but honors LDFLAGS).
+    # See: https://github.com/aws/aws-lc-rs/issues/1168
+    name: rpmbuild hardened environment
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      # annobin-plugin-gcc is only a weak dependency of redhat-rpm-config but
+      # is required by the -specs=...redhat-annobin-cc1 flag in %build_cflags.
+      - name: Install OS dependencies
+        run: dnf install -y gcc gcc-c++ annobin-plugin-gcc redhat-rpm-config git golang perl
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -fL --retry 5 --retry-delay 5 -sS https://sh.rustup.rs -o /tmp/rustup-init.sh
+          sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal
+          rm /tmp/rustup-init.sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Run tests with rpmbuild hardened flags
+        run: |
+          export CFLAGS="$(rpm --eval '%{?build_cflags}')"
+          export CXXFLAGS="$(rpm --eval '%{?build_cxxflags}')"
+          export LDFLAGS="$(rpm --eval '%{?build_ldflags}')"
+          # Fail loudly if the macros ever stop resolving; an empty value
+          # would silently turn this job into a plain build.
+          test -n "$CFLAGS"
+          test -n "$LDFLAGS"
+          echo "CFLAGS=$CFLAGS"
+          echo "CXXFLAGS=$CXXFLAGS"
+          echo "LDFLAGS=$LDFLAGS"
+          cargo test -p aws-lc-rs --all-targets
+
   symlinked-includes:
     if: github.repository_owner == 'aws'
     name: Symlinked includes

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -20,9 +20,10 @@ mod win_x86_64;
 use crate::nasm_builder::NasmBuilder;
 use crate::{
     cargo_env, compiler_is_cl_like, emit_warning, env_var_to_bool, execute_command, find_clang_cl,
-    get_crate_cc, get_crate_cflags, get_crate_cxx, is_link_whole_archive, is_no_asm, out_dir,
-    requested_c_std, set_env_for_target, should_build_jitter_entropy, target, target_arch,
-    target_env, target_is_msvc, target_os, target_vendor, CStdRequested, EnvGuard, OutputLibType,
+    get_crate_cc, get_crate_cflags, get_crate_cxx, is_cross_compiling, is_link_whole_archive,
+    is_no_asm, out_dir, requested_c_std, set_env_for_target, should_build_jitter_entropy, target,
+    target_arch, target_env, target_is_msvc, target_os, target_vendor, CStdRequested, EnvGuard,
+    OutputLibType,
 };
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -805,7 +806,7 @@ impl CcBuilder {
         // (HOST != TARGET), we cannot execute the resulting binary, so we skip this check.
         // This also avoids linker configuration issues with cross-compilation toolchains
         // (e.g., cross-rs Darwin toolchains that set invalid -fuse-ld= flags in CFLAGS).
-        if cargo_env("HOST") != target() {
+        if is_cross_compiling() {
             return;
         }
 
@@ -825,6 +826,15 @@ impl CcBuilder {
         // requires -fuse-ld=lld). This matches the CMake build which only passes
         // CMAKE_C_FLAGS_RELEASE (-O3) to check_run().
         let mut memcmp_compile_args: Vec<std::ffi::OsString> = vec!["-O3".into()];
+
+        // CFLAGS is ignored (above) but LDFLAGS is honored (below), so hardened
+        // environments (e.g. RPM's redhat-rpm-config) can force -pie at link time
+        // without the matching -fPIE at compile time. -fPIE keeps the two
+        // consistent and is harmless when PIE is not requested at link time.
+        // See: https://github.com/aws/aws-lc-rs/issues/1168
+        if target_os() != "windows" {
+            memcmp_compile_args.push("-fPIE".into());
+        }
 
         // Respect LDFLAGS for custom linker configurations. This check produces
         // an executable, so the linker must be reachable. LDFLAGS may contain

--- a/builder/fips_probe.rs
+++ b/builder/fips_probe.rs
@@ -3,8 +3,8 @@
 
 use crate::system_library::ResolvedLib;
 use crate::{
-    cargo_env, compiler_is_cl_like, emit_warning, execute_command, is_lto_flag, out_dir, target,
-    target_os, OutputLibType,
+    compiler_is_cl_like, emit_warning, execute_command, is_cross_compiling, is_lto_flag, out_dir,
+    target, target_os, OutputLibType,
 };
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -173,8 +173,7 @@ const FIPS_MODE_OFF_EXIT_CODE: i32 = 42;
 
 /// Runs the probe when the host can launch a target binary.
 pub(crate) fn run_fips_probe(exec_path: &Path, crypto_lib: &ResolvedLib) -> Result<(), String> {
-    let invocation: Option<(std::ffi::OsString, Vec<std::ffi::OsString>)> = if cargo_env("HOST")
-        == target()
+    let invocation: Option<(std::ffi::OsString, Vec<std::ffi::OsString>)> = if !is_cross_compiling()
     {
         Some((exec_path.as_os_str().to_os_string(), Vec::new()))
     } else if let Some(mut runner) = target_runner() {

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -561,6 +561,10 @@ fn target() -> String {
     cargo_env("TARGET")
 }
 
+pub(crate) fn is_cross_compiling() -> bool {
+    cargo_env("HOST") != target()
+}
+
 fn crate_name() -> String {
     cargo_env("CARGO_PKG_NAME")
 }
@@ -1051,17 +1055,36 @@ fn use_no_u1_bindings() -> Option<bool> {
     unsafe { SYS_NO_U1_BINDINGS }
 }
 
+// Per the cc-rs convention, `TARGET_*` vars apply only when cross-compiling and
+// `HOST_*` vars only to native builds. This keeps cross-target flags out of the
+// host build when this crate is compiled for both in one cargo invocation
+// (e.g., as a transitive build-dependency).
+// See: https://github.com/aws/aws-lc-rs/issues/1169
 fn get_crate_cc() -> Option<String> {
-    optional_env_optional_crate_target("TARGET_CC").or(optional_env_optional_crate_target("CC"))
+    let host_or_target = if is_cross_compiling() {
+        optional_env_optional_crate_target("TARGET_CC")
+    } else {
+        optional_env_optional_crate_target("HOST_CC")
+    };
+    host_or_target.or(optional_env_optional_crate_target("CC"))
 }
 
 fn get_crate_cxx() -> Option<String> {
-    optional_env_optional_crate_target("TARGET_CXX").or(optional_env_optional_crate_target("CXX"))
+    let host_or_target = if is_cross_compiling() {
+        optional_env_optional_crate_target("TARGET_CXX")
+    } else {
+        optional_env_optional_crate_target("HOST_CXX")
+    };
+    host_or_target.or(optional_env_optional_crate_target("CXX"))
 }
 
 fn get_crate_cflags() -> Option<String> {
-    optional_env_optional_crate_target("TARGET_CFLAGS")
-        .or(optional_env_optional_crate_target("CFLAGS"))
+    let host_or_target = if is_cross_compiling() {
+        optional_env_optional_crate_target("TARGET_CFLAGS")
+    } else {
+        optional_env_optional_crate_target("HOST_CFLAGS")
+    };
+    host_or_target.or(optional_env_optional_crate_target("CFLAGS"))
 }
 
 fn use_prebuilt_nasm() -> bool {


### PR DESCRIPTION
### Issues:
Addresses:
* #1168
* #1169  



### Description of changes:

* **[#1168](https://github.com/aws/aws-lc-rs/issues/1168)** -- The memcmp probe ignores `CFLAGS` ([#1132](https://github.com/aws/aws-lc-rs/issues/1132)) but honors `LDFLAGS` ([#958](https://github.com/aws/aws-lc-rs/issues/958)). RPM hardened builds put `-fPIE` in `CFLAGS` (dropped) and force `-pie` via `LDFLAGS` (applied), so the probe linked a non-PIE object into a PIE executable and failed on x86_64. The probe now compiles with `-fPIE` on non-Windows targets; it's a no-op when PIE isn't requested at link time.
* **[#1169](https://github.com/aws/aws-lc-rs/issues/1169)** -- Per the cc-rs convention, `TARGET_CC`/`TARGET_CXX`/`TARGET_CFLAGS` apply only when cross-compiling, and `HOST_*` only to native builds. We consulted `TARGET_*` unconditionally and promoted the values into the highest-priority `CC_<target>`/`CFLAGS_<target>` vars, so when `aws-lc-sys` is also a build-dependency during a cross build, the cross toolchain leaked into the host-side build. `TARGET_*` is now gated on cross-compilation and `HOST_*` is honored for native builds.

Also adds an `rpmbuild-hardened-environment` CI job: a Fedora container with `CFLAGS`/`CXXFLAGS`/`LDFLAGS` exported from the redhat-rpm-config macros, exactly as `rpmbuild`'s `%build` does.

### Call-outs:

* Honoring `HOST_*` is load-bearing for [#1169](https://github.com/aws/aws-lc-rs/issues/1169): the reporter's `CC` also points at the cross compiler, and they rely on `HOST_CC` winning natively (as cc-rs itself does). Gating `TARGET_*` alone wouldn't fix their setup.
* No regressions on the prior fixes: the probe still ignores `CFLAGS` ([#1132](https://github.com/aws/aws-lc-rs/issues/1132)) and honors `LDFLAGS` ([#958](https://github.com/aws/aws-lc-rs/issues/958)); jitterentropy paths ([#1146](https://github.com/aws/aws-lc-rs/issues/1146), [#1137](https://github.com/aws/aws-lc-rs/issues/1137)) are untouched.
* I couldn't reproduce the RPM hardened toolchain locally; the new CI job is the proof for [#1168](https://github.com/aws/aws-lc-rs/issues/1168) -- it uses the exact flags/arch/compiler from the report.

### Testing:

* `cargo test -p aws-lc-sys` and `cargo test -p builder-test` pass; clippy (pedantic) and rustfmt clean.
* Simulated [#1169](https://github.com/aws/aws-lc-rs/issues/1169) natively: `TARGET_*` vars are now ignored and `HOST_CFLAGS` honored (previously failed); a cross build still picks up `TARGET_CFLAGS` as before.
* The new CI job validates the [#1168](https://github.com/aws/aws-lc-rs/issues/1168) fix on this PR's run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
