### PR TITLE
ci: Stop installing winehq-stable in cross windows-gnu pre-build

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,20 +1,19 @@
 [build.dockerfile]
 file = "./docker/linux-cross/Dockerfile"
 
+# The cross-rs windows-gnu images already ship WineHQ wine-stable with the
+# WineHQ apt repository configured. Do NOT `apt install winehq-stable` here:
+# upgrading across major wine versions (e.g. 10.0 -> 11.0) fails with a dpkg
+# file conflict between wine-stable and wine-stable-i386 (missing
+# Breaks/Replaces metadata in the WineHQ packages).
 [target.x86_64-pc-windows-gnu]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes nasm wget",
-    "mkdir -pm755 /etc/apt/keyrings",
-    "wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources",
-    "apt install --assume-yes --install-recommends winehq-stable",
+    "apt-get update && apt-get install --assume-yes nasm",
 ]
 
 [target.i686-pc-windows-gnu]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes nasm wget",
-    "mkdir -pm755 /etc/apt/keyrings",
-    "wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources",
-    "apt install --assume-yes --install-recommends winehq-stable",
+    "apt-get update && apt-get install --assume-yes nasm",
 ]
 
 [target.riscv64gc-unknown-linux-gnu.env]


### PR DESCRIPTION
### Description of changes:
The `cross` jobs for `x86_64-pc-windows-gnu` fail in the docker pre-build: upgrading WineHQ wine 10.0 -> 11.0 hits a dpkg file conflict between `wine-stable` and `wine-stable-i386` (a WineHQ packaging bug, missing `Breaks`/`Replaces`).

The cross-rs windows-gnu images now ship WineHQ `wine-stable` preinstalled, so our `apt install winehq-stable` pre-build step -- added back when the images had no usable wine -- now acts as a major-version upgrade and breaks. This removes the wine install from the pre-build (leaving just `nasm`) and uses the image's bundled wine instead.

### Call-outs:
Wine 11.0 is only needed for the FIPS `.CRT$XCU` self-test issue, and these targets run with FIPS disabled, so the bundled wine is sufficient.

### Testing:
Verified by the `cross` workflow on this PR; the pre-build failure isn't reproducible outside a Linux docker host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
