### PR TITLE
fix: restore cc default flags in memcmp probe; only fail build on confirmed bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -953,7 +953,8 @@ jobs:
     # Reproduces the default Fedora/RHEL `rpmbuild` environment: %build exports
     # CFLAGS/CXXFLAGS/LDFLAGS from the redhat-rpm-config macros evaluated below.
     # These split PIE hardening across CFLAGS (-fPIE) and LDFLAGS (-pie), which
-    # broke the memcmp probe (it drops CFLAGS but honors LDFLAGS).
+    # historically broke the memcmp probe: it dropped all cc-computed compile
+    # flags (losing the default -fPIC) while honoring LDFLAGS.
     # See: https://github.com/aws/aws-lc-rs/issues/1168
     name: rpmbuild hardened environment
     runs-on: ubuntu-latest
@@ -986,6 +987,47 @@ jobs:
           echo "CXXFLAGS=$CXXFLAGS"
           echo "LDFLAGS=$LDFLAGS"
           cargo test -p aws-lc-rs --all-targets
+
+  memcmp-bug-detection:
+    if: github.repository_owner == 'aws'
+    # Asserts the memcmp probe's detection path end-to-end using GCC releases that
+    # actually contain GCC bug 95189: the probe must build, run, detect the
+    # miscompilation, and fail the build. All other CI jobs use fixed compilers,
+    # where the probe is skipped by its version gate.
+    # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+    name: memcmp bug detection (GCC ${{ matrix.gcc_version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc_version:
+          - '9.3'
+          - '10.1'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      # The gcc:9.3/10.1 images are Debian Buster based -- too old to host
+      # modern actions (node) in a job container, so run the build via docker.
+      - name: Build must fail with COMPILER BUG DETECTED
+        run: |
+          docker run --rm -v "$PWD:/repo" gcc:${{ matrix.gcc_version }} bash -c '
+            set -e
+            curl --proto "=https" --tlsv1.2 -fL --retry 5 --retry-delay 5 -sS https://sh.rustup.rs -o /tmp/rustup-init.sh
+            sh /tmp/rustup-init.sh -y --default-toolchain stable --profile minimal >/dev/null
+            export PATH="$HOME/.cargo/bin:$PATH"
+            cd /repo
+            set +e
+            output=$(CARGO_TARGET_DIR=/tmp/target cargo build -p aws-lc-sys 2>&1)
+            status=$?
+            set -e
+            echo "$output" | tail -n 40
+            if [ "$status" -eq 0 ]; then
+              echo "ERROR: build succeeded with a compiler known to miscompile memcmp"
+              exit 1
+            fi
+            echo "$output" | grep -q "COMPILER BUG DETECTED"
+          '
 
   symlinked-includes:
     if: github.repository_owner == 'aws'

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -796,49 +796,62 @@ impl CcBuilder {
         ret_val
     }
 
-    // This checks whether the compiler contains a critical bug that causes `memcmp` to erroneously
-    // consider two regions of memory to be equal when they're not.
-    // See GCC bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
-    // This should be kept in alignment with the same check performed by the CMake build.
-    // See: https://github.com/search?q=repo%3Aaws%2Faws-lc%20check_run&type=code
+    // Detects a GCC bug that causes `memcmp` to erroneously consider two unequal regions of
+    // memory to be equal. See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+    // Mirrors the `check_run` performed by AWS-LC's CMake build:
+    // https://github.com/search?q=repo%3Aaws%2Faws-lc%20check_run&type=code
+    //
+    // The check is layered so that only a high-confidence positive result can fail the build:
+    //   1. Skipped when cross-compiling (the probe must run on the build host).
+    //   2. Skipped for non-GCC compilers; the bug is GCC-specific, matching CMake's `if(GCC)`.
+    //   3. Skipped for GCC versions outside the affected range (9.0-9.3, 10.0-10.1).
+    //   4. A probe that fails to build or execute only warns, as in CMake, where `check_run`
+    //      compile failures were never fatal. Such failures have historically been
+    //      environmental (LTO in CFLAGS, PIE link flags, AIX ABI selection; see #1132,
+    //      #1168, #1170), not evidence of the bug.
+    //   5. Only a probe that builds, runs, and demonstrates the miscompilation fails the build.
     fn memcmp_check(&self) {
-        // This check compiles, links, and executes a test program. When cross-compiling
-        // (HOST != TARGET), we cannot execute the resulting binary, so we skip this check.
-        // This also avoids linker configuration issues with cross-compilation toolchains
-        // (e.g., cross-rs Darwin toolchains that set invalid -fuse-ld= flags in CFLAGS).
+        // (1) The probe binary must run on the build host.
         if is_cross_compiling() {
             return;
         }
 
-        let basename = "memcmp_invalid_stripped_check";
-        let exec_path = out_dir().join(basename);
-        let memcmp_build = cc::Build::default();
-        let memcmp_compiler = memcmp_build.get_compiler();
-        // The logic below assumes a Clang or GCC compiler; skip any other
-        // family (keyed on the compiler, not the target ABI).
-        if !memcmp_compiler.is_like_clang() && !memcmp_compiler.is_like_gnu() {
+        // User CFLAGS are intentionally excluded (#1132): they have no bearing on whether
+        // the compiler contains the bug and can break the probe's compile+link (e.g.,
+        // -flto=thin without -fuse-ld=lld). The cc crate's computed default flags ARE kept:
+        // dropping them broke hardened PIE builds (-fPIC, #1168) and AIX (-maix64, #1170).
+        // cc reads the CFLAGS env vars eagerly inside get_compiler(), so guarding them for
+        // just this call removes exactly the user-provided flags.
+        let memcmp_tool = {
+            let _cflags_guards = cflags_ignore_guards();
+            let mut probe_build = cc::Build::default();
+            // -O3 is required to trigger the bug; the build profile's opt level may be lower.
+            probe_build.opt_level(3);
+            probe_build.get_compiler()
+        };
+
+        // (2) The bug is GCC-specific.
+        if !memcmp_tool.is_like_gnu() {
             return;
         }
-        // Only pass -O3 to trigger the optimization bug. We intentionally ignore
-        // CFLAGS here — this check is about compiler behavior at high optimization
-        // levels, not about the user's build configuration. Arbitrary CFLAGS can
-        // cause unrelated compile/link failures (e.g., -flto=thin on Windows
-        // requires -fuse-ld=lld). This matches the CMake build which only passes
-        // CMAKE_C_FLAGS_RELEASE (-O3) to check_run().
-        let mut memcmp_compile_args: Vec<std::ffi::OsString> = vec!["-O3".into()];
 
-        // CFLAGS is ignored (above) but LDFLAGS is honored (below), so hardened
-        // environments (e.g. RPM's redhat-rpm-config) can force -pie at link time
-        // without the matching -fPIE at compile time. -fPIE keeps the two
-        // consistent and is harmless when PIE is not requested at link time.
-        // See: https://github.com/aws/aws-lc-rs/issues/1168
-        if target_os() != "windows" {
-            memcmp_compile_args.push("-fPIE".into());
+        // (3) Distributions backport fixes, so the version gate only decides whether to run
+        // the probe; the probe decides whether this compiler is actually affected.
+        if let Some(version) = gcc_version(&memcmp_tool) {
+            if !gcc_version_may_have_memcmp_bug(&version) {
+                return;
+            }
+            emit_warning(format!(
+                "GCC {version} may contain a memcmp-related bug \
+                (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189); probing the compiler."
+            ));
         }
 
-        // Respect LDFLAGS for custom linker configurations. This check produces
-        // an executable, so the linker must be reachable. LDFLAGS may contain
-        // necessary flags like library search paths or linker selection.
+        let basename = "memcmp_invalid_stripped_check";
+        let exec_path = out_dir().join(basename);
+        let mut memcmp_compile_args: Vec<std::ffi::OsString> = memcmp_tool.args().to_vec();
+
+        // The probe links an executable; honor LDFLAGS for linker configuration (#958).
         if let Ok(ldflags) = std::env::var("LDFLAGS") {
             for flag in ldflags.split_whitespace() {
                 memcmp_compile_args.push(flag.into());
@@ -861,38 +874,54 @@ impl CcBuilder {
             .map(std::ffi::OsString::as_os_str)
             .collect();
         let memcmp_compile_result =
-            execute_command(memcmp_compiler.path().as_os_str(), memcmp_args.as_slice());
-        assert!(
-            memcmp_compile_result.status,
-            "COMPILER: {}\
-            ARGS: {:?}\
-            EXECUTED: {}\
-            ERROR: {}\
-            OUTPUT: {}\
-            Failed to compile {basename}
-            ",
-            memcmp_compiler.path().display(),
-            memcmp_args.as_slice(),
-            memcmp_compile_result.executed,
-            memcmp_compile_result.stderr,
-            memcmp_compile_result.stdout
-        );
+            execute_command(memcmp_tool.path().as_os_str(), memcmp_args.as_slice());
+
+        // (4) A probe that fails to build only warns, matching CMake's `check_run`.
+        if !memcmp_compile_result.status {
+            emit_warning(format!(
+                "Unable to build the memcmp probe; skipping the GCC memcmp bug check \
+                (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189).\n\
+                COMPILER: {}\n\
+                ARGS: {:?}\n\
+                EXECUTED: {}\n\
+                ERROR: {}\n\
+                OUTPUT: {}\n\
+                ",
+                memcmp_tool.path().display(),
+                memcmp_args.as_slice(),
+                memcmp_compile_result.executed,
+                memcmp_compile_result.stderr,
+                memcmp_compile_result.stdout
+            ));
+            return;
+        }
 
         let result = execute_command(exec_path.as_os_str(), &[]);
-        assert!(
-            result.status,
-            "### COMPILER BUG DETECTED ###\nYour compiler ({}) is not supported due to a memcmp related bug reported in \
-            https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189. \
-            We strongly recommend against using this compiler. \n\
-            EXECUTED: {}\n\
-            ERROR: {}\n\
-            OUTPUT: {}\n\
-            ",
-            memcmp_compiler.path().display(),
-            memcmp_compile_result.executed,
-            memcmp_compile_result.stderr,
-            memcmp_compile_result.stdout
-        );
+        if result.executed {
+            // (5) The probe demonstrated the miscompilation; fail the build.
+            assert!(
+                result.status,
+                "### COMPILER BUG DETECTED ###\nYour compiler ({}) is not supported due to a memcmp related bug reported in \
+                https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189. \
+                We strongly recommend against using this compiler. \n\
+                EXIT CODE: {:?}\n\
+                ERROR: {}\n\
+                OUTPUT: {}\n\
+                ",
+                memcmp_tool.path().display(),
+                result.exit_code,
+                result.stderr,
+                result.stdout
+            );
+        } else {
+            // Failure to launch the probe (e.g., a noexec build directory) is
+            // environmental, not evidence of the bug.
+            emit_warning(format!(
+                "Unable to execute the memcmp probe; skipping the GCC memcmp bug check \
+                (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189). ERROR: {:?}",
+                result.spawn_error
+            ));
+        }
         let _ = fs::remove_file(exec_path);
     }
     fn run_compiler_checks(&self, cc_build: &mut cc::Build) {
@@ -925,6 +954,55 @@ impl CcBuilder {
             }
         }
         self.memcmp_check();
+    }
+}
+
+/// Temporarily removes every `CFLAGS`-family env var the cc crate consults (see its
+/// `target_envs`), so that `cc::Build::get_compiler()` computes only the target's
+/// default flags. Assumes HOST == TARGET (the memcmp probe only runs natively), where
+/// cc consults `HOST_CFLAGS` and never `TARGET_CFLAGS`.
+fn cflags_ignore_guards() -> Vec<EnvGuard> {
+    let target = target();
+    let target_u = target.replace(['-', '.'], "_");
+    [
+        format!("CFLAGS_{target}"),
+        format!("CFLAGS_{target_u}"),
+        "HOST_CFLAGS".to_string(),
+        "CFLAGS".to_string(),
+    ]
+    .iter()
+    .map(|name| EnvGuard::remove(name))
+    .collect()
+}
+
+/// Version reported by a GCC-like compiler, if determinable. Prefers `-dumpfullversion`
+/// (GCC 7+); `-dumpversion` may report only the major version.
+fn gcc_version(compiler: &cc::Tool) -> Option<String> {
+    for flag in ["-dumpfullversion", "-dumpversion"] {
+        let result = execute_command(compiler.path().as_os_str(), &[flag.as_ref()]);
+        if result.status {
+            let version = result.stdout.trim();
+            if !version.is_empty() {
+                return Some(version.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// GCC bug 95189 (`memcmp` wrongly folded like `strcmp`) was introduced in GCC 9 and fixed
+/// in the 9.4 and 10.2 releases; GCC 11+ never contained it.
+/// See: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189>
+fn gcc_version_may_have_memcmp_bug(version: &str) -> bool {
+    let mut parts = version.trim().split('.');
+    let major = parts.next().and_then(|v| v.parse::<u64>().ok());
+    let minor = parts.next().and_then(|v| v.parse::<u64>().ok());
+    match (major, minor) {
+        (Some(9), Some(minor)) => minor < 4,
+        (Some(10), Some(minor)) => minor < 2,
+        // Major-only version strings and unparseable output are conservatively probed.
+        (Some(9 | 10), None) | (None, _) => true,
+        (Some(_), _) => false,
     }
 }
 
@@ -998,6 +1076,66 @@ mod tests {
         assert!(!with_target_env("gnu", target_is_msvc));
         assert!(!with_target_env("musl", target_is_msvc));
         assert!(!with_target_env("", target_is_msvc));
+    }
+
+    // GCC bug 95189 affected the 9.0-9.3 and 10.0-10.1 releases; it was fixed in
+    // 9.4 and 10.2, and GCC 11+ never contained it.
+    #[test]
+    fn test_gcc_version_may_have_memcmp_bug() {
+        // Affected versions must be probed.
+        assert!(gcc_version_may_have_memcmp_bug("9"));
+        assert!(gcc_version_may_have_memcmp_bug("9.1.0"));
+        assert!(gcc_version_may_have_memcmp_bug("9.2.0"));
+        assert!(gcc_version_may_have_memcmp_bug("9.3.1"));
+        assert!(gcc_version_may_have_memcmp_bug("10"));
+        assert!(gcc_version_may_have_memcmp_bug("10.1.0"));
+        // Releases containing the fix are skipped.
+        assert!(!gcc_version_may_have_memcmp_bug("9.4.0"));
+        assert!(!gcc_version_may_have_memcmp_bug("9.5.0"));
+        assert!(!gcc_version_may_have_memcmp_bug("10.2.1"));
+        // Unaffected major versions are skipped.
+        assert!(!gcc_version_may_have_memcmp_bug("4.8.5"));
+        assert!(!gcc_version_may_have_memcmp_bug("8.5.0"));
+        assert!(!gcc_version_may_have_memcmp_bug("11.4.0"));
+        assert!(!gcc_version_may_have_memcmp_bug("12"));
+        assert!(!gcc_version_may_have_memcmp_bug("15.1.0"));
+        // Whitespace from command output is tolerated.
+        assert!(gcc_version_may_have_memcmp_bug("9.3.0\n"));
+        // Undeterminable versions are conservatively probed.
+        assert!(gcc_version_may_have_memcmp_bug(""));
+        assert!(gcc_version_may_have_memcmp_bug("unknown"));
+    }
+
+    // The memcmp probe must exclude user CFLAGS (#1132) while `cc` computes the
+    // compiler's default flags; every env var variant `cc` consults must be
+    // suppressed, and all must be restored when the guards drop.
+    #[test]
+    fn test_cflags_ignore_guards_suppress_and_restore() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _target_guard = EnvGuard::new("TARGET", "x86_64-unknown-linux-gnu");
+        let _g1 = EnvGuard::new("CFLAGS", "-flto=thin");
+        let _g2 = EnvGuard::new("CFLAGS_x86_64-unknown-linux-gnu", "-fdash-variant");
+        let _g3 = EnvGuard::new("CFLAGS_x86_64_unknown_linux_gnu", "-funderscore-variant");
+        let _g4 = EnvGuard::new("HOST_CFLAGS", "-fhost");
+        let _g5 = EnvGuard::new("TARGET_CFLAGS", "-ftarget");
+        {
+            let _guards = cflags_ignore_guards();
+            assert!(env::var("CFLAGS").is_err());
+            assert!(env::var("CFLAGS_x86_64-unknown-linux-gnu").is_err());
+            assert!(env::var("CFLAGS_x86_64_unknown_linux_gnu").is_err());
+            assert!(env::var("HOST_CFLAGS").is_err());
+            assert_eq!(env::var("TARGET_CFLAGS").unwrap(), "-ftarget");
+        }
+        assert_eq!(env::var("CFLAGS").unwrap(), "-flto=thin");
+        assert_eq!(
+            env::var("CFLAGS_x86_64-unknown-linux-gnu").unwrap(),
+            "-fdash-variant"
+        );
+        assert_eq!(
+            env::var("CFLAGS_x86_64_unknown_linux_gnu").unwrap(),
+            "-funderscore-variant"
+        );
+        assert_eq!(env::var("HOST_CFLAGS").unwrap(), "-fhost");
     }
 
     // Guards https://github.com/aws/aws-lc-rs/issues/1146: in cl driver mode

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -97,7 +97,6 @@ impl EnvGuard {
         }
     }
 
-    #[cfg(test)]
     fn remove(key: &str) -> Self {
         let original_value = env::var(key).ok();
         env::remove_var(key);


### PR DESCRIPTION
### Issues:
Addresses #1168, supersedes #1170

### Description of changes:
The memcmp probe (GCC bug 95189 check) has broken builds in unusual-but-legitimate environments three times (#1132, #1168, #1170). The root cause of the last two: #1134 dropped *all* cc-computed compiler flags to keep user CFLAGS out of the probe, which also discarded cc's target default flags (`-fPIC`, AIX's `-maix64`). This restores the computed defaults while still excluding user CFLAGS, by suppressing the CFLAGS env vars around `get_compiler()`.

The check is also now layered so only a confirmed bug can fail the build: it runs only for GCC (clang never had the bug), only for versions that may contain it (9.0-9.3, 10.0-10.1; the probe makes the final call since distros backport fixes), and a probe that fails to *build* only warns -- matching AWS-LC's CMake `check_run`. A probe that runs and demonstrates the miscompilation still fails the build.

### Call-outs:
* We remain intentionally stricter than CMake in one place: upstream only warns on a confirmed bug; we fail the build.
* No existing CI job exercises the detection path (all runners have fixed GCCs), so this adds a job that builds in `gcc:9.3`/`gcc:10.1` containers and asserts the build fails with `COMPILER BUG DETECTED`.

### Testing:
* New unit tests for the version gate and CFLAGS suppression (`cargo test -p builder-test`).
* Verified end-to-end in a `gcc:10.1` container: probe builds, detects the bug, build fails with the expected message.
* `cargo test -p aws-lc-sys`, clippy (pedantic), and rustfmt clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
