### PR TITLE
Clarify representations of PqdsaKeyPair in serialized forms

### DIFF
--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -47,6 +47,8 @@ pub struct PqdsaPrivateKey<'a>(pub(crate) &'a PqdsaKeyPair);
 impl AsDer<Pkcs8V1Der<'static>> for PqdsaPrivateKey<'_> {
     /// Serializes the key to PKCS#8 v1 DER.
     ///
+    /// See [`PqdsaKeyPair::to_pkcs8`] for the chosen representation of the private key.
+    ///
     /// # Errors
     /// Returns `Unspecified` if serialization fails.
     fn as_der(&self) -> Result<Pkcs8V1Der<'static>, Unspecified> {
@@ -60,6 +62,9 @@ impl AsDer<Pkcs8V1Der<'static>> for PqdsaPrivateKey<'_> {
 }
 
 impl AsRawBytes<PqdsaPrivateKeyRaw<'static>> for PqdsaPrivateKey<'_> {
+    /// Serializes the expanded raw private key.
+    ///
+    /// This can be passed back to [`PqdsaKeyPair::from_raw_private_key`].
     fn as_raw_bytes(&self) -> Result<PqdsaPrivateKeyRaw<'static>, Unspecified> {
         Ok(PqdsaPrivateKeyRaw::new(
             self.0.evp_pkey.as_const().marshal_raw_private_key()?,
@@ -84,6 +89,9 @@ impl PqdsaKeyPair {
 
     /// Constructs a key pair from the parsing of PKCS#8.
     ///
+    /// This accepts either the seed or expanded private key encodings. If both are present in the
+    /// input, they are validated to agree with each other.
+    ///
     /// # Errors
     /// Returns `Unspecified` if the key is not valid for the specified signing algorithm.
     pub fn from_pkcs8(
@@ -101,6 +109,8 @@ impl PqdsaKeyPair {
     }
 
     /// Constructs a key pair from raw private key bytes.
+    ///
+    /// This expects the expanded form of the raw private key bytes.
     ///
     /// # Errors
     /// Returns `Unspecified` if the key is not valid for the specified signing algorithm.
@@ -135,10 +145,15 @@ impl PqdsaKeyPair {
     /// of the private key. Callers are responsible for generating seeds from a
     /// cryptographically secure random source and protecting them accordingly.
     ///
-    /// This method expands the seed into the full private key internally. The seed
-    /// itself is not retained in the returned [`PqdsaKeyPair`]; the expanded key material
-    /// is stored instead. The expanded private key can be retrieved via
-    /// [`Self::private_key`] and serialized via [`Self::to_pkcs8`] or
+    /// The seed should be produced from random entropy such as through [`crate::rand::fill`].
+    /// However, for users requiring FIPS, the seed must be produced from
+    /// [`Self::generate`]. The [`Self::to_pkcs8`] method serializes the private key in seed form.
+    /// AWS-LC keeps the seed in the internal representation when possible, but if [`PqdsaKeyPair`]
+    /// is constructed from the expanded form (via [`Self::from_raw_private_key`]) the seed cannot
+    /// be obtained and [`Self::to_pkcs8`] will fail.
+    ///
+    /// This method expands the seed into the full private key internally. The expanded private key
+    /// can be retrieved via [`Self::private_key`] and serialized via
     /// [`PqdsaPrivateKey::as_raw_bytes`].
     ///
     /// # Errors
@@ -174,6 +189,11 @@ impl PqdsaKeyPair {
     }
 
     /// Serializes the private key to PKCS#8 v1 DER.
+    ///
+    /// This currently serializes the seed. If the seed is not available (for example when this
+    /// [`PqdsaKeyPair`] was constructed from the expanded private key via
+    /// [`Self::from_raw_private_key`]), serialization fails and this currently returns an error. A
+    /// future implementation may encode the expanded form of the key instead.
     ///
     /// # Errors
     /// Returns `Unspecified` if serialization fails.
@@ -409,6 +429,97 @@ mod tests {
             kp_65.public_key().as_ref().len(),
             kp_87.public_key().as_ref().len()
         );
+    }
+
+    // `from_raw_private_key` documents that it expects the *expanded* form of the
+    // raw private key bytes, not the 32-byte seed. Feeding it a seed-sized input
+    // must be rejected rather than silently misinterpreted.
+    #[test]
+    fn test_from_raw_private_key_rejects_seed() {
+        for &alg in TEST_ALGORITHMS {
+            // A 32-byte seed is far smaller than any expanded private key, so it
+            // must not be accepted as an expanded key.
+            assert!(PqdsaKeyPair::from_raw_private_key(alg, &[7u8; 32]).is_err());
+        }
+    }
+
+    // `to_pkcs8` documents that it prefers serializing just the seed. When a key
+    // pair is created from a seed, the PKCS#8 output must therefore be the compact
+    // seed encoding, which is dramatically smaller than the expanded private key.
+    #[test]
+    fn test_from_seed_pkcs8_is_seed_form() {
+        for &alg in TEST_ALGORITHMS {
+            let kp = PqdsaKeyPair::from_seed(alg, &[3u8; 32]).unwrap();
+            let pkcs8 = kp.to_pkcs8().unwrap();
+            let raw_expanded = kp.private_key().as_raw_bytes().unwrap();
+            // The seed-form PKCS#8 wraps only the 32-byte seed (plus ASN.1
+            // framing), so it is far smaller than the expanded private key.
+            assert!(
+                pkcs8.as_ref().len() < raw_expanded.as_ref().len(),
+                "seed-form pkcs8 ({}) should be smaller than expanded key ({})",
+                pkcs8.as_ref().len(),
+                raw_expanded.as_ref().len(),
+            );
+            assert!(
+                pkcs8.as_ref().len() < 128,
+                "seed-form pkcs8 should be compact, got {}",
+                pkcs8.as_ref().len(),
+            );
+        }
+    }
+
+    // `from_seed` documents that if a `PqdsaKeyPair` is constructed from the
+    // expanded form the seed cannot be obtained. AWS-LC's PKCS#8 encoding only
+    // emits the seed, so a key pair with no seed available cannot be serialized to
+    // PKCS#8 at all -- `to_pkcs8` returns an error rather than falling back to the
+    // expanded encoding.
+    #[test]
+    fn test_expanded_key_pkcs8_unavailable() {
+        for &alg in TEST_ALGORITHMS {
+            // Round-trip through the raw (expanded) encoding to drop the seed.
+            let seed_kp = PqdsaKeyPair::from_seed(alg, &[4u8; 32]).unwrap();
+            let raw = seed_kp.private_key().as_raw_bytes().unwrap();
+            let expanded_kp = PqdsaKeyPair::from_raw_private_key(alg, raw.as_ref()).unwrap();
+
+            // The expanded-form key pair still signs and exposes the expanded raw
+            // bytes...
+            assert!(expanded_kp.private_key().as_raw_bytes().is_ok());
+            // ...but the seed is gone, so PKCS#8 serialization is unavailable.
+            assert!(
+                expanded_kp.to_pkcs8().is_err(),
+                "expanded-only key unexpectedly serialized to PKCS#8",
+            );
+        }
+    }
+
+    // `from_pkcs8` documents that it accepts the seed encoding, and `to_pkcs8`
+    // documents that it prefers the seed. A seed -> PKCS#8 -> key pair -> PKCS#8
+    // round-trip must therefore preserve the seed form byte-for-byte.
+    #[test]
+    fn test_from_seed_pkcs8_roundtrip_preserves_seed_form() {
+        for &alg in TEST_ALGORITHMS {
+            let kp = PqdsaKeyPair::from_seed(alg, &[8u8; 32]).unwrap();
+            let pkcs8 = kp.to_pkcs8().unwrap();
+            let reparsed = PqdsaKeyPair::from_pkcs8(alg, pkcs8.as_ref()).unwrap();
+            let pkcs8_again = reparsed.to_pkcs8().unwrap();
+            // Seed is retained through parsing, so re-serialization is identical.
+            assert_eq!(pkcs8.as_ref(), pkcs8_again.as_ref());
+            // And the reconstructed key pair is the same key.
+            assert_eq!(kp.public_key().as_ref(), reparsed.public_key().as_ref());
+        }
+    }
+
+    // `PqdsaPrivateKey::as_der` documents that it uses the representation chosen by
+    // `to_pkcs8`. For a seed-derived key that representation is the seed form, so
+    // `as_der` and `to_pkcs8` must agree.
+    #[test]
+    fn test_from_seed_as_der_matches_to_pkcs8() {
+        for &alg in TEST_ALGORITHMS {
+            let kp = PqdsaKeyPair::from_seed(alg, &[11u8; 32]).unwrap();
+            let pkcs8 = kp.to_pkcs8().unwrap();
+            let der = kp.private_key().as_der().unwrap();
+            assert_eq!(pkcs8.as_ref(), der.as_ref());
+        }
     }
 
     // Additional test for the algorithm getter


### PR DESCRIPTION
### Description of changes:

* Note how to use PqdsaKeyPair::from_seed in a FIPS setting. We discussed offline adding an accessor for the seed form (32-bytes) but at least until a future FIPS validation that will require parsing it, so not adding it here. Most callers are likely happy with the PKCS representation which contains just the seed.
* Note that constructing from an expanded form will fail PKCS serialization (this is counter to my expectations but is the current behavior -- see added tests).

### Testing:

I believe all new assertions made are reflected in the added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
