### PR TITLE
Publish script fixes: cargo clean failure, and verify aws-lc-rs against minimum published sys crates

### DIFF
--- a/scripts/publish/_prepublish_checks.sh
+++ b/scripts/publish/_prepublish_checks.sh
@@ -38,12 +38,10 @@ pushd "${CRATE_DIR}" &>/dev/null
 
 export GOPROXY=direct
 
-cargo clean --target-dir "${TEMP_TARGET_DIR}"
 cargo +nightly clippy --fix --allow-no-vcs
 cargo fmt
 cargo test --target-dir "${TEMP_TARGET_DIR}" # sanity check
 cargo package --target-dir "${TEMP_TARGET_DIR}" --allow-dirty # checks if published package will build.
-cargo clean --target-dir "${TEMP_TARGET_DIR}"
 
 popd &>/dev/null # "${CRATE_DIR}"
 

--- a/scripts/publish/_publish_tools.sh
+++ b/scripts/publish/_publish_tools.sh
@@ -70,6 +70,64 @@ function sanity_check_sys_crate {
   echo Sanity check: SUCCESS
 }
 
+# Verifies that the packaged crate builds and tests against the dependency
+# versions currently published on crates.io. The manifest in the packaged
+# .crate has all `path` entries stripped, so dependency resolution comes from
+# the registry rather than the local workspace. Direct dependencies are pinned
+# to the *minimum* versions allowed by Cargo.toml to verify that the declared
+# version requirements are actually sufficient.
+#
+# This catches the failure that occurred with aws-lc-rs v1.17.2, which
+# depended on symbols only available in a not-yet-published aws-lc-fips-sys.
+# Local checks passed (path deps), but the published crate failed to build
+# with the `fips` feature.
+#
+# Usage: verify_crate_with_published_deps RELATIVE_CRATE_PATH CARGO_ARGS...
+#   Each CARGO_ARGS element is a (space-separated) set of arguments appended
+#   to `cargo test` for one build configuration.
+function verify_crate_with_published_deps {
+  local RELATIVE_CRATE_PATH=$1
+  shift
+  local FEATURE_CONFIGS=("$@")
+
+  local REPO_ROOT CRATE_DIR
+  REPO_ROOT=$(git rev-parse --show-toplevel)
+  CRATE_DIR="${REPO_ROOT}/${RELATIVE_CRATE_PATH}"
+
+  local TEMP_TARGET_DIR TEMP_UNPACK_DIR
+  TEMP_TARGET_DIR=$(mktemp -d)
+  TEMP_UNPACK_DIR=$(mktemp -d)
+
+  pushd "${CRATE_DIR}" &>/dev/null
+  cargo package --no-verify --allow-dirty --target-dir "${TEMP_TARGET_DIR}"
+  popd &>/dev/null # "${CRATE_DIR}"
+
+  local CRATE_FILES UNPACKED_CRATE_DIRS
+  CRATE_FILES=("${TEMP_TARGET_DIR}"/package/*.crate)
+  tar xzf "${CRATE_FILES[0]}" -C "${TEMP_UNPACK_DIR}"
+  UNPACKED_CRATE_DIRS=("${TEMP_UNPACK_DIR}"/*)
+
+  pushd "${UNPACKED_CRATE_DIRS[0]}" &>/dev/null
+
+  export GOPROXY=direct
+
+  # Pin direct dependencies to the minimum versions allowed by Cargo.toml.
+  # This fails if a dependency version requirement has not been published yet.
+  cargo +nightly update -Zdirect-minimal-versions
+
+  local CONFIG
+  for CONFIG in "${FEATURE_CONFIGS[@]}"; do
+    # shellcheck disable=SC2086
+    cargo test --target-dir "${TEMP_TARGET_DIR}" ${CONFIG}
+  done
+
+  popd &>/dev/null # "${UNPACKED_CRATE_DIRS[0]}"
+
+  rm -rf "${TEMP_TARGET_DIR}" "${TEMP_UNPACK_DIR}" &>/dev/null || true
+
+  echo Published dependency check: SUCCESS
+}
+
 function run_prepublish_checks {
   local SCRIPT_DIR
   SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)

--- a/scripts/publish/publish-aws-lc-rs.sh
+++ b/scripts/publish/publish-aws-lc-rs.sh
@@ -16,5 +16,11 @@ publish_options "$@"
 
 pushd "${CRATE_DIR}" &>/dev/null
 run_prepublish_checks -c "${RELATIVE_CRATE_PATH}"
+# Verify the packaged crate builds/tests against the sys crate versions
+# currently available on crates.io, resolved to the minimum versions allowed
+# by our Cargo.toml. Checks both the default (non-FIPS) and FIPS builds.
+verify_crate_with_published_deps "${RELATIVE_CRATE_PATH}" \
+  "" \
+  "--no-default-features --features fips"
 publish_crate "${RELATIVE_CRATE_PATH}" ${PUBLISH}
 popd &>/dev/null


### PR DESCRIPTION
### Description of changes:
Two fixes to the publishing scripts:

1. **Remove unnecessary `cargo clean` calls from prepublish checks.** Newer cargo (1.97+) refuses to clean a directory lacking a `CACHEDIR.TAG` file, which the first `cargo clean` tripped by running against a fresh mktemp dir. Both calls were unnecessary anyway.

2. **Verify aws-lc-rs builds against the minimum published sys crate versions before publishing.** This closes the gap behind the v1.17.2 yank: local checks resolve the sys crates via `path` dependencies, and `cargo package` verification only builds default features -- so the `fips` build was never tested against a registry-resolved aws-lc-fips-sys. The new check extracts the packaged `.crate` (path deps stripped), pins direct deps to their minimum allowed versions via `cargo +nightly update -Zdirect-minimal-versions`, and builds/tests both the default and `fips` configurations.

### Call-outs:
* `-Zdirect-minimal-versions` is nightly-only, but these scripts already assume nightly for `clippy --fix`. It pins only direct deps; full `-Zminimal-versions` is too fragile due to understated bounds in transitive crates.
* This adds a full AWS-LC FIPS build (~minutes) to the aws-lc-rs publish flow.

### Testing:
* Manually ran the new check against v1.17.3: sys crates resolve from the registry (0.43.0 / 0.13.16) and both configurations build.
* Ran it against the yanked v1.17.2: aws-lc-fips-sys resolves to v0.13.1 and the fips build fails -- it would have blocked the bad release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
