### PR TITLE
ci: fix mdbook test failure and run docs checks on PRs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -395,3 +395,27 @@ jobs:
             echo "SUCCESS: All object files have .note.GNU-stack section"
             exit 0
           fi
+
+  docs:
+    if: github.repository_owner == 'aws'
+    name: Build and test documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '>=1.18'
+      # Keep the mdbook version and commands in sync with deploy-docs.yml
+      - name: Build and Test User Guide
+        run: |
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./mdbook build book
+          ./mdbook test book
+      - name: Build Documentation
+        run: cargo doc --features fips,unstable --no-deps --workspace

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -81,7 +81,7 @@ AWS_LC_RS_DEV_TESTS_ONLY=1 cargo test
 Once enabled, you can implement `aws_lc_rs::rand::unsealed::SecureRandom` for your own type.
 A blanket implementation will automatically provide the public `SecureRandom` trait for your type:
 
-```rust
+```rust,ignore
 use aws_lc_rs::error::Unspecified;
 use aws_lc_rs::rand::{unsealed, SecureRandom};
 


### PR DESCRIPTION
### Description of changes:

The `deploy-user-guide` job fails on every push to `main` since #1050 added a Rust code block to the FAQ. `mdbook test` compiles code blocks with no crates linked, so `use aws_lc_rs::...` can never resolve. The job only runs on pushes to `main`, so PR CI never caught it.

* Mark the FAQ code block `rust,ignore`; the snippet is already compile-tested by `aws-lc-rs/tests/unsealed_rand_test.rs`.
* Add a `docs` job to `analysis.yml` mirroring `deploy-docs.yml` (`mdbook build`/`test` + `cargo doc`) so docs breakage surfaces on PRs.

### Call-outs:

Chose `rust,ignore` over linking the crate into `mdbook test` (`-L target/debug/deps`), which would require a full aws-lc-rs build in the docs job and is prone to stale-rlib flakiness.

### Testing:

`mdbook test book` passes locally (previously reproduced the CI failure). The `cargo doc` command is unchanged from `deploy-docs.yml`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
