### PR TITLE
Support exporting build vars from -sys crates to build depending C code

### DIFF
--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -8,6 +8,14 @@ on these bindings.
 
 [Documentation](https://github.com/aws/aws-lc).
 
+## Native build metadata
+
+Downstream Cargo build scripts that compile additional C code against this
+AWS-LC FIPS build can use the exported `include`, `libdir`, `libcrypto_path`,
+and `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is
+also exported. Cargo exposes these values to direct dependents as versioned
+`DEP_AWS_LC_FIPS_*` environment variables.
+
 ## FIPS
 
 The aws-lc-fips-sys crate provides bindings to the latest version of the AWS-LC-FIPS module that

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -12,6 +12,14 @@ See our [User Guide](https://aws.github.io/aws-lc-rs/) for guidance on installin
 
 [Documentation](https://github.com/aws/aws-lc).
 
+## Native build metadata
+
+Downstream Cargo build scripts that compile additional C code against this
+AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`, and
+`link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is also
+exported. Cargo exposes these values to direct dependents as versioned
+`DEP_AWS_LC_*` environment variables.
+
 ## Build Support
 
 This crate pulls in the source code of AWS-LC to build with it. Bindings for popular platforms are pre-generated.

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -1046,6 +1046,12 @@ impl crate::Builder for CcBuilder {
         let sources = crate::cc_builder::identify_sources();
         self.build_library(sources.as_slice());
 
+        crate::emit_source_library_metadata(
+            &self.out_dir,
+            self.output_lib_type,
+            &self.build_prefix,
+        );
+
         crate::emit_source_build_metadata(&self.manifest_dir);
 
         Ok(())

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -694,6 +694,12 @@ impl crate::Builder for CmakeBuilder {
     fn build(&self) -> Result<(), String> {
         self.build_library();
 
+        crate::emit_source_library_metadata(
+            &self.artifact_output_dir(),
+            self.output_lib_type,
+            &self.build_prefix,
+        );
+
         println!(
             "cargo:rustc-link-search=native={}",
             self.artifact_output_dir().display()

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -342,6 +342,19 @@ impl OutputLibType {
             Self::Dynamic => "dynamic",
         }
     }
+
+    fn library_filename(self, name: &str) -> String {
+        match (target_os().as_str(), target_env().as_str(), self) {
+            ("windows", "msvc", _) => format!("{name}.lib"),
+            ("windows", _, Self::Dynamic) => format!("lib{name}.dll.a"),
+            ("windows", _, Self::Static) => format!("lib{name}.a"),
+            ("macos" | "ios" | "tvos" | "watchos" | "visionos", _, Self::Dynamic) => {
+                format!("lib{name}.dylib")
+            }
+            (_, _, Self::Dynamic) => format!("lib{name}.so"),
+            (_, _, Self::Static) => format!("lib{name}.a"),
+        }
+    }
 }
 
 impl OutputLib {
@@ -1397,6 +1410,37 @@ pub(crate) fn emit_source_build_metadata(manifest_dir: &Path) {
     }
 
     println!("cargo:rerun-if-changed=aws-lc/");
+}
+
+/// Exports stable, absolute native-library locations for downstream build
+/// scripts that need to compile additional C code against this AWS-LC build.
+pub(crate) fn emit_source_library_metadata(
+    lib_dir: &Path,
+    output_lib_type: OutputLibType,
+    build_prefix: &Option<String>,
+) {
+    let crypto_path =
+        lib_dir.join(output_lib_type.library_filename(&OutputLib::Crypto.libname(build_prefix)));
+    assert!(
+        crypto_path.is_file(),
+        "AWS-LC libcrypto artifact not found: {}",
+        crypto_path.display()
+    );
+
+    println!("cargo:libdir={}", lib_dir.display());
+    println!("cargo:libcrypto_path={}", crypto_path.display());
+    println!("cargo:link_kind={}", output_lib_type.rust_lib_type());
+
+    if cfg!(feature = "ssl") {
+        let ssl_path =
+            lib_dir.join(output_lib_type.library_filename(&OutputLib::Ssl.libname(build_prefix)));
+        assert!(
+            ssl_path.is_file(),
+            "AWS-LC libssl artifact not found: {}",
+            ssl_path.display()
+        );
+        println!("cargo:libssl_path={}", ssl_path.display());
+    }
 }
 
 fn setup_include_paths(out_dir: &Path, manifest_dir: &Path) -> PathBuf {

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -347,7 +347,6 @@ impl OutputLibType {
         match (target_os().as_str(), target_env().as_str(), self) {
             ("windows", "msvc", _) => format!("{name}.lib"),
             ("windows", _, Self::Dynamic) => format!("lib{name}.dll.a"),
-            ("windows", _, Self::Static) => format!("lib{name}.a"),
             ("macos" | "ios" | "tvos" | "watchos" | "visionos", _, Self::Dynamic) => {
                 format!("lib{name}.dylib")
             }

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -389,11 +389,15 @@ impl SystemLib {
         let optional_ssl_lib = self.ssl_lib.borrow();
         let kind = crypto_lib.lib_type.rust_lib_type();
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:libdir={}", lib_dir.display());
         println!("cargo:libcrypto={}", crypto_lib.name);
+        println!("cargo:libcrypto_path={}", crypto_lib.path.display());
+        println!("cargo:link_kind={kind}");
         println!("cargo:rustc-link-lib={kind}={}", crypto_lib.name);
         if let Some(ssl_lib) = optional_ssl_lib.as_ref() {
             println!("cargo:rustc-link-lib={kind}={}", ssl_lib.name);
             println!("cargo:libssl={}", ssl_lib.name);
+            println!("cargo:libssl_path={}", ssl_lib.path.display());
             println!("cargo:rerun-if-changed={}", ssl_lib.path.display());
         }
 

--- a/links-testing/build.rs
+++ b/links-testing/build.rs
@@ -31,19 +31,37 @@ fn main() {
 }
 
 fn build_and_link(links: &str, target_name: &str) {
+    let links = links.to_uppercase();
+
     // ensure that the include path is exported and set up correctly
     cc::Build::new()
-        .include(env(format!("DEP_{}_INCLUDE", links.to_uppercase())))
+        .include(env(format!("DEP_{links}_INCLUDE")))
         .file("src/testing.c")
         .compile(&format!("testing_{target_name}"));
 
     // make sure the root was exported
-    let root = env(format!("DEP_{}_ROOT", links.to_uppercase()));
+    let root = env(format!("DEP_{links}_ROOT"));
     println!("cargo:rustc-link-search={root}");
 
     // ensure the libcrypto artifact is linked
-    let libcrypto = env(format!("DEP_{}_LIBCRYPTO", links.to_uppercase()));
+    let libcrypto = env(format!("DEP_{links}_LIBCRYPTO"));
     println!("cargo:rustc-link-lib={libcrypto}");
+
+    // ensure downstream native builds receive the exact artifact location
+    let libdir = std::path::PathBuf::from(env(format!("DEP_{links}_LIBDIR")));
+    let libcrypto_path = std::path::PathBuf::from(env(format!("DEP_{links}_LIBCRYPTO_PATH")));
+    assert!(
+        libdir.is_dir(),
+        "exported libdir does not exist: {libdir:?}"
+    );
+    assert!(
+        libcrypto_path.is_file(),
+        "exported libcrypto path does not exist: {libcrypto_path:?}"
+    );
+    assert_eq!(libcrypto_path.parent(), Some(libdir.as_path()));
+
+    let link_kind = env(format!("DEP_{links}_LINK_KIND"));
+    assert!(matches!(link_kind.as_str(), "static" | "dylib"));
 }
 
 fn get_package_links_property(cargo_toml_path: &str) -> String {


### PR DESCRIPTION
## Description of changes:

Currently, the sys crates export include directories and linker directives, but downstream Cargo build scripts cannot reliably determine the exact native library artifacts produced by AWS-LC. This is especially problematic when compiling additional C code against AWS-LC because source builds use version-prefixed library names.

This change exports additional build metadata from `aws-lc-sys` and `aws-lc-fips-sys`:

- `libdir`
- `libcrypto_path`
- `libssl_path` when the `ssl` feature is enabled
- `link_kind`

The metadata is emitted consistently for CC builds, CMake builds, and system-library builds. Platform-aware artifact naming is included for static and dynamic libraries on Unix, Apple platforms, MinGW, and MSVC.

This enables downstream build scripts to pass AWS-LC’s exact headers and libraries to native build systems such as CMake, without rebuilding AWS-LC or guessing version-prefixed artifact names.

## Call-outs:

The new metadata becomes an interface consumed by direct Cargo dependents through versioned `DEP_AWS_LC_*` and `DEP_AWS_LC_FIPS_*` environment variables.

Exact absolute artifact paths are exported intentionally because the existing logical library names are insufficient for native build systems that require a concrete library file.

Special review attention would be helpful for:

- Cross-platform library filename mapping.
- Static versus dynamic `link_kind` reporting.
- Consistency between CC, CMake, and system-library builders.
- Conditional export of `libssl_path` when the `ssl` feature is enabled.

Existing Rust linker directives and linking behavior are unchanged.

## Testing:

The `links-testing` crate now verifies that:

- The exported library directory exists.
- The exported `libcrypto` path exists.
- The artifact belongs to the exported library directory.
- The linkage kind is either `static` or `dylib`.

The metadata was tested with:

- `aws-lc-sys` using the CC builder.
- `aws-lc-sys` using the CMake builder.
- `aws-lc-fips-sys` using its CMake build.
- A downstream native librdkafka build consuming the exported AWS-LC headers and exact library paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.