### PR TITLE
docs(signature): correct outdated note about signing a separate digest

### DIFF
--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -17,16 +17,19 @@
 //! reduce the risks of algorithm agility and to provide consistency with ECDSA
 //! and `EdDSA`.
 //!
-//! For most signing operations this module hashes the message as part of the
-//! signing operation, rather than accepting a separately-computed digest. The
-//! exception is ECDSA: [`EcdsaKeyPair::sign_digest`] signs a caller-provided
-//! digest (see [`Digest::import_less_safe`] for constructing one from external
-//! digest bytes), which is useful when the digest is produced elsewhere, such
-//! as by a TLS implementation offloading the private key operation.
+//! For most use cases, prefer passing the full message to the signing and
+//! verification APIs, which hash it as part of the operation. Signing and
+//! verifying a separately-computed digest is also supported for ECDSA and RSA:
+//! [`EcdsaKeyPair::sign_digest`] and [`RsaKeyPair::sign_digest`] sign a
+//! caller-provided digest, and [`ParsedPublicKey::verify_digest_sig`] (or
+//! [`VerificationAlgorithm::verify_digest_sig`]) verifies one. This is useful
+//! when the digest is produced elsewhere. Construct the `Digest` from the
+//! externally-computed bytes with [`Digest::import_less_safe`], which shifts to
+//! the caller the responsibility of ensuring the digest really is the hash of
+//! the intended message.
 //!
 //! This module is optimized for signing messages that are available in full,
-//! rather than streaming or incrementally-hashed large messages. An interface
-//! for efficiently supporting larger messages may be added later.
+//! rather than streaming or incrementally-hashed large messages.
 //!
 //!
 //! # Algorithm Details

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -17,11 +17,16 @@
 //! reduce the risks of algorithm agility and to provide consistency with ECDSA
 //! and `EdDSA`.
 //!
-//! Currently this module does not support digesting the message to be signed
-//! separately from the public key operation, as it is currently being
-//! optimized for Ed25519 and for the implementation of protocols that do not
-//! requiring signing large messages. An interface for efficiently supporting
-//! larger messages may be added later.
+//! For most signing operations this module hashes the message as part of the
+//! signing operation, rather than accepting a separately-computed digest. The
+//! exception is ECDSA: [`EcdsaKeyPair::sign_digest`] signs a caller-provided
+//! digest (see [`Digest::import_less_safe`] for constructing one from external
+//! digest bytes), which is useful when the digest is produced elsewhere, such
+//! as by a TLS implementation offloading the private key operation.
+//!
+//! This module is optimized for signing messages that are available in full,
+//! rather than streaming or incrementally-hashed large messages. An interface
+//! for efficiently supporting larger messages may be added later.
 //!
 //!
 //! # Algorithm Details


### PR DESCRIPTION
### Description of changes:
The module-level documentation for the `signature` module currently states:

> Currently this module does not support digesting the message to be signed separately from the public key operation [...]

This is no longer accurate as of #826 . `EcdsaKeyPair::sign_digest` signs a caller-provided digest, and `Digest::import_less_safe` constructs a `Digest` from externally computed digest bytes. Together these support exactly the "digest the message separately from the public key operation" workflow the doc says is unsupported. The prose predates `sign_digest` and was never updated, so the module intro now contradicts a method in the same module.

### Testing:
Documentation-only change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.