### PR TITLE
Export native library build metadata from the -sys crates

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -128,11 +128,29 @@ jobs:
     if: github.repository_owner == 'aws'
     name: sys crate tests
     runs-on: ${{ matrix.os }}
+    env:
+      # 'default' leaves the linkage choice to the builder; 'dynamic' forces a
+      # shared-library build so the exported artifact-path metadata is
+      # validated for both link kinds.
+      AWS_LC_SYS_STATIC: ${{ (matrix.linkage == 'dynamic' && '0') || '' }}
+      AWS_LC_FIPS_SYS_STATIC: ${{ (matrix.linkage == 'dynamic' && '0') || '' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-15-intel, macos-latest, windows-latest ]
-        features: [ aws-lc-rs, aws-lc-rs-fips, aws-lc-sys, aws-lc-fips-sys ]
+        features: [ aws-lc-rs, aws-lc-rs-fips, aws-lc-sys, aws-lc-fips-sys, aws-lc-sys-ssl, aws-lc-fips-sys-ssl ]
+        linkage: [ default, dynamic ]
+        include:
+          # MinGW dynamic builds produce `lib*.dll.a` import libraries;
+          # exercise the exported artifact-path metadata on windows-gnu.
+          - os: windows-latest
+            features: aws-lc-sys
+            linkage: default
+            target: x86_64-pc-windows-gnu
+          - os: windows-latest
+            features: aws-lc-sys
+            linkage: dynamic
+            target: x86_64-pc-windows-gnu
     steps:
       - uses: actions/checkout@v7
         with:
@@ -141,6 +159,9 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
+      - name: Install Rust target
+        if: ${{ matrix.target != '' }}
+        run: rustup target add ${{ matrix.target }}
       - name: Install NASM on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
@@ -152,10 +173,10 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@v6
       - name: Run cargo test
         working-directory: ./links-testing
-        run: cargo test --features ${{ matrix.features }} --no-default-features
+        run: cargo test --features ${{ matrix.features }} --no-default-features ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
       - name: Run cargo run
         working-directory: ./links-testing
-        run: cargo run --features ${{ matrix.features }} --no-default-features
+        run: cargo run --features ${{ matrix.features }} --no-default-features ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
 
   publish-dry-run-version-check:
     if: github.repository_owner == 'aws'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -131,7 +131,9 @@ jobs:
     env:
       # 'default' leaves the linkage choice to the builder; 'dynamic' forces a
       # shared-library build so the exported artifact-path metadata is
-      # validated for both link kinds.
+      # validated for both link kinds. 'default' sets these to the empty string
+      # (Actions cannot omit an env key conditionally), which the builder's
+      # `parse_to_bool` treats the same as unset.
       AWS_LC_SYS_STATIC: ${{ (matrix.linkage == 'dynamic' && '0') || '' }}
       AWS_LC_FIPS_SYS_STATIC: ${{ (matrix.linkage == 'dynamic' && '0') || '' }}
     strategy:
@@ -140,6 +142,24 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest, windows-latest ]
         features: [ aws-lc-rs, aws-lc-rs-fips, aws-lc-sys, aws-lc-fips-sys, aws-lc-sys-ssl, aws-lc-fips-sys-ssl ]
         linkage: [ default, dynamic ]
+        # Placeholder dimension: an `include` entry whose keys all match an
+        # existing combination is merged into it rather than adding a job. The
+        # `target` values below conflict with this one, so they create new jobs
+        # instead of silently retargeting the windows-msvc jobs. Do not remove.
+        target: [ '' ]
+        exclude:
+          # FIPS builds already default to a shared library everywhere except
+          # Linux (see `OutputLibType::default`), so 'dynamic' would rebuild
+          # exactly what 'default' builds on macOS and Windows.
+          - { os: macos-15-intel, features: aws-lc-rs-fips, linkage: dynamic }
+          - { os: macos-15-intel, features: aws-lc-fips-sys, linkage: dynamic }
+          - { os: macos-15-intel, features: aws-lc-fips-sys-ssl, linkage: dynamic }
+          - { os: macos-latest, features: aws-lc-rs-fips, linkage: dynamic }
+          - { os: macos-latest, features: aws-lc-fips-sys, linkage: dynamic }
+          - { os: macos-latest, features: aws-lc-fips-sys-ssl, linkage: dynamic }
+          - { os: windows-latest, features: aws-lc-rs-fips, linkage: dynamic }
+          - { os: windows-latest, features: aws-lc-fips-sys, linkage: dynamic }
+          - { os: windows-latest, features: aws-lc-fips-sys-ssl, linkage: dynamic }
         include:
           # MinGW dynamic builds produce `lib*.dll.a` import libraries;
           # exercise the exported artifact-path metadata on windows-gnu.
@@ -162,6 +182,18 @@ jobs:
       - name: Install Rust target
         if: ${{ matrix.target != '' }}
         run: rustup target add ${{ matrix.target }}
+      - name: Install MinGW toolchain
+        if: ${{ endsWith(matrix.target, '-windows-gnu') }}
+        uses: bwoodsend/setup-winlibs-action@v1
+        with:
+          architecture: x86_64
+      - name: Use Ninja for windows-gnu CMake builds
+        # The default generator for *-windows-gnu on a Windows host is "MinGW
+        # Makefiles", which CMake refuses to use when sh.exe is on PATH -- it
+        # always is here, via Git for Windows. Ninja is installed below.
+        if: ${{ endsWith(matrix.target, '-windows-gnu') }}
+        shell: bash
+        run: echo "CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
       - name: Install NASM on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1

--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -65,11 +65,15 @@ endforeach ()
 if (BORINGSSL_PREFIX)
     if (MSVC)
         set(TARGET_PREFIX "${BORINGSSL_PREFIX}")
-        set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()
+    # PREFIX renames the library artifact itself; IMPORT_PREFIX renames the
+    # import library generated for shared builds on DLL platforms (e.g.
+    # MinGW's lib*.dll.a), keeping it discoverable under the prefixed name.
+    # IMPORT_PREFIX is ignored on non-DLL platforms.
     set_my_target_properties(PREFIX ${TARGET_PREFIX})
+    set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
 
     # This BORINGSSL_PREFIX has an "_" appended, so we must remove it
     string(REGEX REPLACE "_$" "" BORINGSSL_PREFIX_MACRO ${BORINGSSL_PREFIX})

--- a/aws-lc-fips-sys/CMakeLists.txt
+++ b/aws-lc-fips-sys/CMakeLists.txt
@@ -68,10 +68,9 @@ if (BORINGSSL_PREFIX)
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()
-    # PREFIX renames the library artifact itself; IMPORT_PREFIX renames the
-    # import library generated for shared builds on DLL platforms (e.g.
-    # MinGW's lib*.dll.a), keeping it discoverable under the prefixed name.
-    # IMPORT_PREFIX is ignored on non-DLL platforms.
+    # PREFIX renames the library itself; IMPORT_PREFIX renames the import
+    # library produced for shared builds on DLL platforms (MinGW's lib*.dll.a),
+    # keeping it discoverable under the prefixed name. Ignored elsewhere.
     set_my_target_properties(PREFIX ${TARGET_PREFIX})
     set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
 

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -14,7 +14,10 @@ Downstream Cargo build scripts that compile additional C code against this
 AWS-LC FIPS build can use the exported `include`, `libdir`, `libcrypto_path`,
 and `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is
 also exported. Cargo exposes these values to direct dependents as versioned
-`DEP_AWS_LC_FIPS_*` environment variables.
+`DEP_AWS_LC_FIPS_*` environment variables. On Windows, `libcrypto_path` and
+`libssl_path` refer to the link-time artifact -- for dynamic builds this is the
+import library (`*.lib` for MSVC, `lib*.dll.a` for MinGW), not the runtime
+DLL; the DLL is located in `libdir`.
 
 ## FIPS
 

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -8,6 +8,14 @@ on these bindings.
 
 [Documentation](https://github.com/aws/aws-lc).
 
+## Native build metadata
+
+Downstream Cargo build scripts that compile additional C code against this
+AWS-LC FIPS build can use the exported `include`, `libdir`, `libcrypto_path`,
+and `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is
+also exported. Cargo exposes these values to direct dependents as versioned
+`DEP_AWS_LC_FIPS_*` environment variables.
+
 ## FIPS
 
 The aws-lc-fips-sys crate provides bindings to the latest version of the AWS-LC-FIPS module that

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -12,9 +12,17 @@ on these bindings.
 
 Downstream Cargo build scripts that compile additional C code against this
 AWS-LC FIPS build can use the exported `include`, `libdir`, `libcrypto_path`,
-and `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is
-also exported. Cargo exposes these values to direct dependents as versioned
-`DEP_AWS_LC_FIPS_*` environment variables.
+`link_kind`, and `system_libs` metadata. When the `ssl` feature is enabled,
+`libssl_path` is also exported. Cargo exposes these values to direct dependents
+as versioned `DEP_AWS_LC_FIPS_*` environment variables.
+
+`link_kind` is `static` or `dylib`, usable directly as the `<kind>` in a
+`cargo:rustc-link-lib=<kind>=<name>` directive.
+
+`system_libs` is a comma-separated (possibly empty) list of additional system
+libraries AWS-LC requires; a build script linking the static `libcrypto_path`
+artifact must link these too. On `*-windows-gnu` it is `bcrypt`, which MinGW/GCC
+does not pick up from AWS-LC's `#pragma comment(lib, "bcrypt.lib")`.
 
 On Windows, `libcrypto_path` and `libssl_path` refer to the link-time artifact
 -- for dynamic builds this is the import library (`*.lib` for MSVC,

--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -14,10 +14,14 @@ Downstream Cargo build scripts that compile additional C code against this
 AWS-LC FIPS build can use the exported `include`, `libdir`, `libcrypto_path`,
 and `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is
 also exported. Cargo exposes these values to direct dependents as versioned
-`DEP_AWS_LC_FIPS_*` environment variables. On Windows, `libcrypto_path` and
-`libssl_path` refer to the link-time artifact -- for dynamic builds this is the
-import library (`*.lib` for MSVC, `lib*.dll.a` for MinGW), not the runtime
-DLL; the DLL is located in `libdir`.
+`DEP_AWS_LC_FIPS_*` environment variables.
+
+On Windows, `libcrypto_path` and `libssl_path` refer to the link-time artifact
+-- for dynamic builds this is the import library (`*.lib` for MSVC,
+`lib*.dll.a` for MinGW), not the runtime DLL. For builds from source the DLL is
+placed alongside the import library in `libdir`; when linking against a
+pre-installed AWS-LC (`AWS_LC_FIPS_SYS_SYSTEM_DIR`) the DLL follows the CMake
+install layout and lives in `bin/` instead.
 
 ## FIPS
 

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -63,11 +63,15 @@ endforeach ()
 if (BORINGSSL_PREFIX)
     if (MSVC)
         set(TARGET_PREFIX "${BORINGSSL_PREFIX}")
-        set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()
+    # PREFIX renames the library artifact itself; IMPORT_PREFIX renames the
+    # import library generated for shared builds on DLL platforms (e.g.
+    # MinGW's lib*.dll.a), keeping it discoverable under the prefixed name.
+    # IMPORT_PREFIX is ignored on non-DLL platforms.
     set_my_target_properties(PREFIX ${TARGET_PREFIX})
+    set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
 
     # This BORINGSSL_PREFIX has an "_" appended, so we must remove it
     string(REGEX REPLACE "_$" "" BORINGSSL_PREFIX_MACRO ${BORINGSSL_PREFIX})

--- a/aws-lc-sys/CMakeLists.txt
+++ b/aws-lc-sys/CMakeLists.txt
@@ -66,10 +66,9 @@ if (BORINGSSL_PREFIX)
     else()
         set(TARGET_PREFIX "lib${BORINGSSL_PREFIX}")
     endif()
-    # PREFIX renames the library artifact itself; IMPORT_PREFIX renames the
-    # import library generated for shared builds on DLL platforms (e.g.
-    # MinGW's lib*.dll.a), keeping it discoverable under the prefixed name.
-    # IMPORT_PREFIX is ignored on non-DLL platforms.
+    # PREFIX renames the library itself; IMPORT_PREFIX renames the import
+    # library produced for shared builds on DLL platforms (MinGW's lib*.dll.a),
+    # keeping it discoverable under the prefixed name. Ignored elsewhere.
     set_my_target_properties(PREFIX ${TARGET_PREFIX})
     set_my_target_properties(IMPORT_PREFIX ${TARGET_PREFIX})
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -12,6 +12,14 @@ See our [User Guide](https://aws.github.io/aws-lc-rs/) for guidance on installin
 
 [Documentation](https://github.com/aws/aws-lc).
 
+## Native build metadata
+
+Downstream Cargo build scripts that compile additional C code against this
+AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`, and
+`link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is also
+exported. Cargo exposes these values to direct dependents as versioned
+`DEP_AWS_LC_*` environment variables.
+
 ## Build Support
 
 This crate pulls in the source code of AWS-LC to build with it. Bindings for popular platforms are pre-generated.

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -18,7 +18,10 @@ Downstream Cargo build scripts that compile additional C code against this
 AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`, and
 `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is also
 exported. Cargo exposes these values to direct dependents as versioned
-`DEP_AWS_LC_*` environment variables.
+`DEP_AWS_LC_*` environment variables. On Windows, `libcrypto_path` and
+`libssl_path` refer to the link-time artifact -- for dynamic builds this is the
+import library (`*.lib` for MSVC, `lib*.dll.a` for MinGW), not the runtime
+DLL; the DLL is located in `libdir`.
 
 ## Build Support
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -15,10 +15,18 @@ See our [User Guide](https://aws.github.io/aws-lc-rs/) for guidance on installin
 ## Native build metadata
 
 Downstream Cargo build scripts that compile additional C code against this
-AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`, and
-`link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is also
-exported. Cargo exposes these values to direct dependents as versioned
-`DEP_AWS_LC_*` environment variables.
+AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`,
+`link_kind`, and `system_libs` metadata. When the `ssl` feature is enabled,
+`libssl_path` is also exported. Cargo exposes these values to direct dependents
+as versioned `DEP_AWS_LC_*` environment variables.
+
+`link_kind` is `static` or `dylib`, usable directly as the `<kind>` in a
+`cargo:rustc-link-lib=<kind>=<name>` directive.
+
+`system_libs` is a comma-separated (possibly empty) list of additional system
+libraries AWS-LC requires; a build script linking the static `libcrypto_path`
+artifact must link these too. On `*-windows-gnu` it is `bcrypt`, which MinGW/GCC
+does not pick up from AWS-LC's `#pragma comment(lib, "bcrypt.lib")`.
 
 On Windows, `libcrypto_path` and `libssl_path` refer to the link-time artifact
 -- for dynamic builds this is the import library (`*.lib` for MSVC,

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -18,10 +18,14 @@ Downstream Cargo build scripts that compile additional C code against this
 AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`, and
 `link_kind` metadata. When the `ssl` feature is enabled, `libssl_path` is also
 exported. Cargo exposes these values to direct dependents as versioned
-`DEP_AWS_LC_*` environment variables. On Windows, `libcrypto_path` and
-`libssl_path` refer to the link-time artifact -- for dynamic builds this is the
-import library (`*.lib` for MSVC, `lib*.dll.a` for MinGW), not the runtime
-DLL; the DLL is located in `libdir`.
+`DEP_AWS_LC_*` environment variables.
+
+On Windows, `libcrypto_path` and `libssl_path` refer to the link-time artifact
+-- for dynamic builds this is the import library (`*.lib` for MSVC,
+`lib*.dll.a` for MinGW), not the runtime DLL. For builds from source the DLL is
+placed alongside the import library in `libdir`; when linking against a
+pre-installed AWS-LC (`AWS_LC_SYS_SYSTEM_DIR`) the DLL follows the CMake
+install layout and lives in `bin/` instead.
 
 ## Build Support
 

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -1046,6 +1046,12 @@ impl crate::Builder for CcBuilder {
         let sources = crate::cc_builder::identify_sources();
         self.build_library(sources.as_slice());
 
+        crate::emit_source_library_metadata(
+            &self.out_dir,
+            self.output_lib_type,
+            &self.build_prefix,
+        );
+
         crate::emit_source_build_metadata(&self.manifest_dir);
 
         Ok(())

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -1052,7 +1052,7 @@ impl crate::Builder for CcBuilder {
             &self.build_prefix,
         );
 
-        crate::emit_source_build_metadata(&self.manifest_dir);
+        crate::emit_source_build_metadata(&self.manifest_dir, &self.build_prefix);
 
         Ok(())
     }

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -694,6 +694,12 @@ impl crate::Builder for CmakeBuilder {
     fn build(&self) -> Result<(), String> {
         self.build_library();
 
+        crate::emit_source_library_metadata(
+            &self.artifact_output_dir(),
+            self.output_lib_type,
+            &self.build_prefix,
+        );
+
         println!(
             "cargo:rustc-link-search=native={}",
             self.artifact_output_dir().display()

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -719,7 +719,7 @@ impl crate::Builder for CmakeBuilder {
             );
         }
 
-        crate::emit_source_build_metadata(&self.manifest_dir);
+        crate::emit_source_build_metadata(&self.manifest_dir, &self.build_prefix);
 
         Ok(())
     }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -342,6 +342,19 @@ impl OutputLibType {
             Self::Dynamic => "dynamic",
         }
     }
+
+    fn library_filename(self, name: &str) -> String {
+        match (target_os().as_str(), target_env().as_str(), self) {
+            ("windows", "msvc", _) => format!("{name}.lib"),
+            ("windows", _, Self::Dynamic) => format!("lib{name}.dll.a"),
+            ("windows", _, Self::Static) => format!("lib{name}.a"),
+            ("macos" | "ios" | "tvos" | "watchos" | "visionos", _, Self::Dynamic) => {
+                format!("lib{name}.dylib")
+            }
+            (_, _, Self::Dynamic) => format!("lib{name}.so"),
+            (_, _, Self::Static) => format!("lib{name}.a"),
+        }
+    }
 }
 
 impl OutputLib {
@@ -1397,6 +1410,37 @@ pub(crate) fn emit_source_build_metadata(manifest_dir: &Path) {
     }
 
     println!("cargo:rerun-if-changed=aws-lc/");
+}
+
+/// Exports stable, absolute native-library locations for downstream build
+/// scripts that need to compile additional C code against this AWS-LC build.
+pub(crate) fn emit_source_library_metadata(
+    lib_dir: &Path,
+    output_lib_type: OutputLibType,
+    build_prefix: &Option<String>,
+) {
+    let crypto_path =
+        lib_dir.join(output_lib_type.library_filename(&OutputLib::Crypto.libname(build_prefix)));
+    assert!(
+        crypto_path.is_file(),
+        "AWS-LC libcrypto artifact not found: {}",
+        crypto_path.display()
+    );
+
+    println!("cargo:libdir={}", lib_dir.display());
+    println!("cargo:libcrypto_path={}", crypto_path.display());
+    println!("cargo:link_kind={}", output_lib_type.rust_lib_type());
+
+    if cfg!(feature = "ssl") {
+        let ssl_path =
+            lib_dir.join(output_lib_type.library_filename(&OutputLib::Ssl.libname(build_prefix)));
+        assert!(
+            ssl_path.is_file(),
+            "AWS-LC libssl artifact not found: {}",
+            ssl_path.display()
+        );
+        println!("cargo:libssl_path={}", ssl_path.display());
+    }
 }
 
 fn setup_include_paths(out_dir: &Path, manifest_dir: &Path) -> PathBuf {

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -347,7 +347,6 @@ impl OutputLibType {
         match (target_os().as_str(), target_env().as_str(), self) {
             ("windows", "msvc", _) => format!("{name}.lib"),
             ("windows", _, Self::Dynamic) => format!("lib{name}.dll.a"),
-            ("windows", _, Self::Static) => format!("lib{name}.a"),
             ("macos" | "ios" | "tvos" | "watchos" | "visionos", _, Self::Dynamic) => {
                 format!("lib{name}.dylib")
             }

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -1413,32 +1413,43 @@ pub(crate) fn emit_source_build_metadata(manifest_dir: &Path) {
 
 /// Exports stable, absolute native-library locations for downstream build
 /// scripts that need to compile additional C code against this AWS-LC build.
+///
+/// The artifact filenames are predicted from the target platform and link
+/// kind, so a wrong prediction is possible on configurations we don't
+/// exercise. If a predicted artifact is missing, the corresponding `*_path`
+/// key is skipped (with a warning) rather than failing the build; the
+/// `links-testing` crate asserts these exports are present for every
+/// configuration covered by CI.
 pub(crate) fn emit_source_library_metadata(
     lib_dir: &Path,
     output_lib_type: OutputLibType,
     build_prefix: &Option<String>,
 ) {
+    println!("cargo:libdir={}", lib_dir.display());
+    println!("cargo:link_kind={}", output_lib_type.rust_lib_type());
+
     let crypto_path =
         lib_dir.join(output_lib_type.library_filename(&OutputLib::Crypto.libname(build_prefix)));
-    assert!(
-        crypto_path.is_file(),
-        "AWS-LC libcrypto artifact not found: {}",
-        crypto_path.display()
-    );
-
-    println!("cargo:libdir={}", lib_dir.display());
-    println!("cargo:libcrypto_path={}", crypto_path.display());
-    println!("cargo:link_kind={}", output_lib_type.rust_lib_type());
+    if crypto_path.is_file() {
+        println!("cargo:libcrypto_path={}", crypto_path.display());
+    } else {
+        emit_warning(format!(
+            "AWS-LC libcrypto artifact not found: {}; not exporting libcrypto_path",
+            crypto_path.display()
+        ));
+    }
 
     if cfg!(feature = "ssl") {
         let ssl_path =
             lib_dir.join(output_lib_type.library_filename(&OutputLib::Ssl.libname(build_prefix)));
-        assert!(
-            ssl_path.is_file(),
-            "AWS-LC libssl artifact not found: {}",
-            ssl_path.display()
-        );
-        println!("cargo:libssl_path={}", ssl_path.display());
+        if ssl_path.is_file() {
+            println!("cargo:libssl_path={}", ssl_path.display());
+        } else {
+            emit_warning(format!(
+                "AWS-LC libssl artifact not found: {}; not exporting libssl_path",
+                ssl_path.display()
+            ));
+        }
     }
 }
 

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -1394,13 +1394,7 @@ pub(crate) fn emit_source_build_metadata(manifest_dir: &Path, build_prefix: &Opt
         system_library::emit_fips_version(&get_aws_lc_include_path(manifest_dir)).unwrap();
     }
 
-    // MinGW/GCC ignores `#pragma comment(lib, "bcrypt.lib")`, so we must
-    // link explicitly. The upstream CMakeLists.txt forces _WIN32_WINNT_WIN7
-    // for MINGW+GCC, activating the BCryptGenRandom codepath.
-    // See: https://github.com/aws/aws-lc/pull/3239
-    if target().contains("-windows-gnu") {
-        println!("cargo:rustc-link-lib=bcrypt");
-    }
+    emit_system_libs_metadata();
 
     println!(
         "cargo:include={}",
@@ -1418,6 +1412,35 @@ pub(crate) fn emit_source_build_metadata(manifest_dir: &Path, build_prefix: &Opt
     }
 
     println!("cargo:rerun-if-changed=aws-lc/");
+}
+
+/// System libraries that AWS-LC itself requires, beyond its own artifacts.
+///
+/// The `-windows-gnu` match also covers `-windows-gnullvm` (same MinGW ABI).
+fn required_system_libs(target: &str) -> Vec<&'static str> {
+    let mut libs = Vec::new();
+
+    // MinGW/GCC ignores `#pragma comment(lib, "bcrypt.lib")`, so we must
+    // link explicitly. The upstream CMakeLists.txt forces _WIN32_WINNT_WIN7
+    // for MINGW+GCC, activating the BCryptGenRandom codepath.
+    // See: https://github.com/aws/aws-lc/pull/3239
+    if target.contains("-windows-gnu") {
+        libs.push("bcrypt");
+    }
+
+    libs
+}
+
+/// Links the system libraries AWS-LC needs and exports the same list as
+/// `system_libs`, so the directives and the metadata cannot drift. Consumers
+/// cannot infer these from the artifact paths, and Cargo only propagates our
+/// directives to crates that link the sys crate's rlib.
+pub(crate) fn emit_system_libs_metadata() {
+    let libs = required_system_libs(&target());
+    for lib in &libs {
+        println!("cargo:rustc-link-lib={lib}");
+    }
+    println!("cargo:system_libs={}", libs.join(","));
 }
 
 /// Exports stable, absolute native-library locations for downstream build
@@ -1788,6 +1811,46 @@ mod tests {
         assert_eq!(parse_to_bool("invalid"), None);
         assert_eq!(parse_to_bool("maybe"), None);
         assert_eq!(parse_to_bool("   "), None);
+    }
+
+    // -------------------------------------------------------------------------
+    // required_system_libs tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_required_system_libs_mingw_targets_need_bcrypt() {
+        for target in [
+            "x86_64-pc-windows-gnu",
+            "i686-pc-windows-gnu",
+            // gnullvm shares the MinGW ABI, and the substring match covers it.
+            "aarch64-pc-windows-gnullvm",
+        ] {
+            assert_eq!(
+                required_system_libs(target),
+                ["bcrypt"],
+                "expected bcrypt for {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_required_system_libs_empty_elsewhere() {
+        for target in [
+            // MSVC gets bcrypt via `#pragma comment(lib, ...)`.
+            "x86_64-pc-windows-msvc",
+            "aarch64-pc-windows-msvc",
+            "aarch64-apple-darwin",
+            // Must not be confused by the unrelated `-gnu` environment.
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-musl",
+            "aarch64-linux-android",
+        ] {
+            assert!(
+                required_system_libs(target).is_empty(),
+                "unexpected system libs for {target}: {:?}",
+                required_system_libs(target)
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -1387,7 +1387,7 @@ fn main() {
 /// Emits the shared post-build cargo metadata for source-based builders
 /// (`CMake` and CC). This sets up include paths, exports library and
 /// configuration names for downstream crates, and registers rerun triggers.
-pub(crate) fn emit_source_build_metadata(manifest_dir: &Path) {
+pub(crate) fn emit_source_build_metadata(manifest_dir: &Path, build_prefix: &Option<String>) {
     // Only aws-lc-fips-sys consumes the generated FIPS-version constant; a
     // FIPS-flavored aws-lc-sys build reports a module version of 0.
     if is_fips_crate() {
@@ -1407,10 +1407,14 @@ pub(crate) fn emit_source_build_metadata(manifest_dir: &Path) {
         setup_include_paths(&out_dir(), manifest_dir).display()
     );
 
-    // export the artifact names
-    println!("cargo:libcrypto={}_crypto", prefix_string());
+    // Derive the artifact names from `build_prefix`, not `prefix_string()`:
+    // with `AWS_LC_SYS_NO_PREFIX` set the libraries are built unprefixed.
+    println!(
+        "cargo:libcrypto={}",
+        OutputLib::Crypto.libname(build_prefix)
+    );
     if cfg!(feature = "ssl") {
-        println!("cargo:libssl={}_ssl", prefix_string());
+        println!("cargo:libssl={}", OutputLib::Ssl.libname(build_prefix));
     }
 
     println!("cargo:rerun-if-changed=aws-lc/");

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -343,6 +343,11 @@ impl OutputLibType {
         }
     }
 
+    /// Returns the platform-specific filename for a library named `name`.
+    ///
+    /// On MSVC a static archive and a DLL import library are both `{name}.lib`,
+    /// so both linkages return the same name; `system_library::probe_lib`
+    /// disambiguates them via a sibling `../bin/{name}.dll`.
     fn library_filename(self, name: &str) -> String {
         match (target_os().as_str(), target_env().as_str(), self) {
             ("windows", "msvc", _) => format!("{name}.lib"),

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -389,11 +389,15 @@ impl SystemLib {
         let optional_ssl_lib = self.ssl_lib.borrow();
         let kind = crypto_lib.lib_type.rust_lib_type();
         println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:libdir={}", lib_dir.display());
         println!("cargo:libcrypto={}", crypto_lib.name);
+        println!("cargo:libcrypto_path={}", crypto_lib.path.display());
+        println!("cargo:link_kind={kind}");
         println!("cargo:rustc-link-lib={kind}={}", crypto_lib.name);
         if let Some(ssl_lib) = optional_ssl_lib.as_ref() {
             println!("cargo:rustc-link-lib={kind}={}", ssl_lib.name);
             println!("cargo:libssl={}", ssl_lib.name);
+            println!("cargo:libssl_path={}", ssl_lib.path.display());
             println!("cargo:rerun-if-changed={}", ssl_lib.path.display());
         }
 

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -395,6 +395,18 @@ impl SystemLib {
         println!("cargo:link_kind={kind}");
         println!("cargo:rustc-link-lib={kind}={}", crypto_lib.name);
         if let Some(ssl_lib) = optional_ssl_lib.as_ref() {
+            // `link_kind` (above) describes libcrypto. Without a requested
+            // lib type, resolution could in principle land on differing types
+            // for the two libraries; surface that instead of exporting
+            // misleading metadata.
+            if ssl_lib.lib_type != crypto_lib.lib_type {
+                emit_warning(format!(
+                    "libcrypto ({}) and libssl ({}) resolved to different library types; \
+                     the exported link_kind describes libcrypto only",
+                    crypto_lib.lib_type.description(),
+                    ssl_lib.lib_type.description(),
+                ));
+            }
             println!("cargo:rustc-link-lib={kind}={}", ssl_lib.name);
             println!("cargo:libssl={}", ssl_lib.name);
             println!("cargo:libssl_path={}", ssl_lib.path.display());

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -395,10 +395,9 @@ impl SystemLib {
         println!("cargo:link_kind={kind}");
         println!("cargo:rustc-link-lib={kind}={}", crypto_lib.name);
         if let Some(ssl_lib) = optional_ssl_lib.as_ref() {
-            // `link_kind` (above) describes libcrypto. Without a requested
-            // lib type, resolution could in principle land on differing types
-            // for the two libraries; surface that instead of exporting
-            // misleading metadata.
+            // `link_kind` (above) describes libcrypto. Without a requested lib
+            // type the two libraries could in principle resolve to different
+            // types; warn rather than export misleading metadata.
             if ssl_lib.lib_type != crypto_lib.lib_type {
                 emit_warning(format!(
                     "libcrypto ({}) and libssl ({}) resolved to different library types; \
@@ -712,9 +711,12 @@ fn is_msvc() -> bool {
 /// `{name}.lib`. The two are disambiguated by `msvc_has_sibling_dll`: if
 /// `../bin/{name}.dll` exists, the `.lib` is an import library (dynamic);
 /// otherwise it is a real static archive.
+///
+/// On MinGW, the runtime DLL is installed to `bin/` rather than `lib_dir`, so
+/// the import library `lib{name}.dll.a` is the only artifact to look for here.
 fn probe_lib(lib_dir: &Path, name: &str, lib_type: OutputLibType) -> Option<PathBuf> {
     let want_dynamic = matches!(lib_type, OutputLibType::Dynamic);
-    let path = lib_dir.join(lib_filename(name, lib_type));
+    let path = lib_dir.join(lib_type.library_filename(name));
     if !path.exists() {
         return None;
     }
@@ -726,34 +728,10 @@ fn probe_lib(lib_dir: &Path, name: &str, lib_type: OutputLibType) -> Option<Path
     Some(path)
 }
 
-/// Returns the platform-specific filename for a library named `base` of the
-/// given linkage type.
-///
-/// On MSVC, both real static archives and DLL import libraries are named
-/// `{base}.lib`, so this function returns that name for either linkage. The
-/// two are disambiguated at probe time inside `probe_lib` via the sibling
-/// `../bin/{base}.dll` check.
-fn lib_filename(base: &str, lib_type: OutputLibType) -> String {
-    if is_msvc() {
-        return format!("{base}.lib");
-    }
-
-    match lib_type {
-        OutputLibType::Static => format!("lib{base}.a"),
-        OutputLibType::Dynamic => match target_os().as_str() {
-            // MinGW: the runtime DLL lives in bin/, not lib_dir. The import
-            // library lib{base}.dll.a is the only artifact in lib_dir.
-            "windows" => format!("lib{base}.dll.a"),
-            "macos" | "ios" | "tvos" => format!("lib{base}.dylib"),
-            _ => format!("lib{base}.so"),
-        },
-    }
-}
-
 /// Comma-separated list of platform-appropriate filenames the resolver looks
-/// for. Used purely for error messages. Note that on MSVC `lib_filename`
-/// produces the same `{base}.lib` for either linkage, so the `filter`
-/// argument doesn't change the resulting list there (deduplicated below).
+/// for. Used purely for error messages. On MSVC `library_filename` returns the
+/// same `{base}.lib` for either linkage, so `filter` doesn't change the
+/// resulting list there (deduplicated below).
 fn expected_lib_filenames(candidates: &[&str], filter: Option<OutputLibType>) -> String {
     let lib_types: &[OutputLibType] = match filter {
         Some(OutputLibType::Static) => &[OutputLibType::Static],
@@ -763,7 +741,7 @@ fn expected_lib_filenames(candidates: &[&str], filter: Option<OutputLibType>) ->
     let mut names: Vec<String> = Vec::new();
     for &lt in lib_types {
         for base in candidates {
-            let name = lib_filename(base, lt);
+            let name = lt.library_filename(base);
             if !names.contains(&name) {
                 names.push(name);
             }

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -412,6 +412,10 @@ impl SystemLib {
             println!("cargo:rerun-if-changed={}", ssl_lib.path.display());
         }
 
+        // After the libcrypto/libssl directives: GNU ld needs the providers to
+        // follow the archive that references them.
+        crate::emit_system_libs_metadata();
+
         println!("cargo:include={}", include_dir.display());
 
         println!("cargo:rerun-if-changed={}", include_dir.display());

--- a/links-testing/Cargo.toml
+++ b/links-testing/Cargo.toml
@@ -10,7 +10,9 @@ default = ["aws-lc-sys"]
 aws-lc-rs = ["dep:aws-lc-rs"]
 aws-lc-rs-fips = ["aws-lc-rs", "aws-lc-rs/fips"]
 aws-lc-sys = ["dep:aws-lc-sys"]
+aws-lc-sys-ssl = ["aws-lc-sys", "aws-lc-sys/ssl"]
 aws-lc-fips-sys = ["dep:aws-lc-fips-sys"]
+aws-lc-fips-sys-ssl = ["aws-lc-fips-sys", "aws-lc-fips-sys/ssl"]
 
 [dependencies]
 aws-lc-rs = { path = "../aws-lc-rs", optional = true }

--- a/links-testing/build.rs
+++ b/links-testing/build.rs
@@ -62,6 +62,24 @@ fn build_and_link(links: &str, target_name: &str) {
 
     let link_kind = env(format!("DEP_{links}_LINK_KIND"));
     assert!(matches!(link_kind.as_str(), "static" | "dylib"));
+    if link_kind == "static" {
+        // a static artifact must be an archive (`.a`) or MSVC library (`.lib`)
+        let extension = libcrypto_path.extension().and_then(|e| e.to_str());
+        assert!(
+            matches!(extension, Some("a" | "lib")),
+            "unexpected static libcrypto artifact: {libcrypto_path:?}"
+        );
+    }
+
+    // when libssl is built, its exact artifact location must be exported too
+    if optional_env(format!("DEP_{links}_LIBSSL")).is_some() {
+        let libssl_path = std::path::PathBuf::from(env(format!("DEP_{links}_LIBSSL_PATH")));
+        assert!(
+            libssl_path.is_file(),
+            "exported libssl path does not exist: {libssl_path:?}"
+        );
+        assert_eq!(libssl_path.parent(), Some(libdir.as_path()));
+    }
 }
 
 fn get_package_links_property(cargo_toml_path: &str) -> String {
@@ -75,6 +93,11 @@ fn get_package_links_property(cargo_toml_path: &str) -> String {
 
 fn env<S: AsRef<str>>(s: S) -> String {
     let s = s.as_ref();
+    optional_env(s).unwrap_or_else(|| panic!("missing env var {s}"))
+}
+
+fn optional_env<S: AsRef<str>>(s: S) -> Option<String> {
+    let s = s.as_ref();
     println!("cargo:rerun-if-env-changed={s}");
-    std::env::var(s).unwrap_or_else(|_| panic!("missing env var {s}"))
+    std::env::var(s).ok()
 }

--- a/links-testing/build.rs
+++ b/links-testing/build.rs
@@ -31,19 +31,37 @@ fn main() {
 }
 
 fn build_and_link(links: &str, target_name: &str) {
+    let links = links.to_uppercase();
+
     // ensure that the include path is exported and set up correctly
     cc::Build::new()
-        .include(env(format!("DEP_{}_INCLUDE", links.to_uppercase())))
+        .include(env(format!("DEP_{links}_INCLUDE")))
         .file("src/testing.c")
         .compile(&format!("testing_{target_name}"));
 
     // make sure the root was exported
-    let root = env(format!("DEP_{}_ROOT", links.to_uppercase()));
+    let root = env(format!("DEP_{links}_ROOT"));
     println!("cargo:rustc-link-search={root}");
 
     // ensure the libcrypto artifact is linked
-    let libcrypto = env(format!("DEP_{}_LIBCRYPTO", links.to_uppercase()));
+    let libcrypto = env(format!("DEP_{links}_LIBCRYPTO"));
     println!("cargo:rustc-link-lib={libcrypto}");
+
+    // ensure downstream native builds receive the exact artifact location
+    let libdir = std::path::PathBuf::from(env(format!("DEP_{links}_LIBDIR")));
+    let libcrypto_path = std::path::PathBuf::from(env(format!("DEP_{links}_LIBCRYPTO_PATH")));
+    assert!(
+        libdir.is_dir(),
+        "exported libdir does not exist: {libdir:?}"
+    );
+    assert!(
+        libcrypto_path.is_file(),
+        "exported libcrypto path does not exist: {libcrypto_path:?}"
+    );
+    assert_eq!(libcrypto_path.parent(), Some(libdir.as_path()));
+
+    let link_kind = env(format!("DEP_{links}_LINK_KIND"));
+    assert!(matches!(link_kind.as_str(), "static" | "dylib"));
 }
 
 fn get_package_links_property(cargo_toml_path: &str) -> String {

--- a/links-testing/build.rs
+++ b/links-testing/build.rs
@@ -47,6 +47,13 @@ fn build_and_link(links: &str, target_name: &str) {
     let libcrypto = env(format!("DEP_{links}_LIBCRYPTO"));
     println!("cargo:rustc-link-lib={libcrypto}");
 
+    // The sys crate's own directives never reach us -- nothing here references
+    // its rlib -- so the required system libraries come from the metadata.
+    let system_libs = env(format!("DEP_{links}_SYSTEM_LIBS"));
+    for lib in system_libs.split(',').filter(|lib| !lib.is_empty()) {
+        println!("cargo:rustc-link-lib={lib}");
+    }
+
     // ensure downstream native builds receive the exact artifact location
     let libdir = std::path::PathBuf::from(env(format!("DEP_{links}_LIBDIR")));
     let libcrypto_path = std::path::PathBuf::from(env(format!("DEP_{links}_LIBCRYPTO_PATH")));

--- a/links-testing/build.rs
+++ b/links-testing/build.rs
@@ -61,7 +61,10 @@ fn build_and_link(links: &str, target_name: &str) {
     assert_eq!(libcrypto_path.parent(), Some(libdir.as_path()));
 
     let link_kind = env(format!("DEP_{links}_LINK_KIND"));
-    assert!(matches!(link_kind.as_str(), "static" | "dylib"));
+    assert!(
+        matches!(link_kind.as_str(), "static" | "dylib"),
+        "unexpected exported link_kind: {link_kind:?}"
+    );
     if link_kind == "static" {
         // a static artifact must be an archive (`.a`) or MSVC library (`.lib`)
         let extension = libcrypto_path.extension().and_then(|e| e.to_str());


### PR DESCRIPTION
### Issues:
Supersedes #1184 (includes @glebpom's original commits).

### Description of changes:
Downstream build scripts compiling C code against AWS-LC can't reliably locate our native library artifacts, since source builds use version-prefixed names. This exports `libdir`, `libcrypto_path`, `link_kind`, and (with `ssl`) `libssl_path` from the sys crates as `DEP_AWS_LC_*` / `DEP_AWS_LC_FIPS_*` env vars, consistently across the CC, CMake, and system-library build paths. Existing linker directives are unchanged.

Follow-up commits on top of #1184:

- Apply `IMPORT_PREFIX` for all toolchains (previously MSVC-only) so MinGW shared builds produce the version-prefixed import library the metadata predicts.
- Skip the `*_path` exports with a `cargo:warning` when a predicted artifact is missing, instead of `assert!`-failing every consumer's build; `links-testing` enforces presence in CI instead.
- Add ssl-enabled features to `links-testing` that assert `DEP_*_LIBSSL_PATH`.
- Extend the `links-crate-tests` CI matrix: dynamic linkage, ssl, and windows-gnu.

### Call-outs:
The new keys become a versioned public interface for direct dependents. Exact paths are exported intentionally: logical names are insufficient for native build systems that need a concrete library file. On Windows, `*_path` values are the link-time artifact (import library), not the runtime DLL.

The `links-crate-tests` matrix grows from 16 to 50 jobs and exercises some configurations for the first time (ssl on macOS/Windows, windows-gnu dynamic); if these surface unrelated failures, we can trim with excludes.

### Testing:
- `links-testing` verified locally on macOS for: static (CC), dynamic (CMake), ssl static/dynamic, FIPS ssl, and the `aws-lc-rs` forwarding path.
- The expanded CI matrix validates the exports across all platforms, both linkages, and ssl; the windows-gnu entries are the first CI coverage for MinGW dynamic builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
```