### PR TITLE
Stabilize ML-DSA signature API; FIPS 4.0 follow-ups

### DIFF
--- a/.github/workflows/system-lib-tests-fips.yml
+++ b/.github/workflows/system-lib-tests-fips.yml
@@ -307,9 +307,9 @@ jobs:
   # Proves the declared FIPS floor: build AWS-LC FIPS at the oldest branch that
   # both reports MINIMUM_FIPS_VERSION (see builder/system_library.rs) and can
   # emit Rust bindings, then run the suite against it with the version check
-  # enabled. The fips-2024-09-27 branch reports library version 3.x with no
+  # enabled. The fips-2025-09-12-lts branch reports library version 4.x with no
   # AWSLC_FIPS_VERSION_NUMBER macro, so resolve_fips_version() falls back to the
-  # version-string major and yields FIPS version 3 — exactly the floor. A
+  # version-string major and yields FIPS version 4 — exactly the floor. A
   # failure means the floor is unsupported and must be raised together with this
   # pin.
   # ---------------------------------------------------------------------------
@@ -323,7 +323,7 @@ jobs:
       # Keep in sync with MINIMUM_FIPS_VERSION in builder/system_library.rs: the
       # oldest FIPS branch that reports that module version and supports
       # -DGENERATE_RUST_BINDINGS=ON.
-      AWS_LC_FIPS_MIN_REF: "fips-2024-09-27"
+      AWS_LC_FIPS_MIN_REF: "fips-2025-09-12-lts"
     steps:
       # aws-lc-rs checkout WITHOUT the submodule (and remove its working tree),
       # so a from-source fallback is impossible (see test-fips-unix).

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -54,7 +54,7 @@ latest version of the AWS-LC-FIPS module that has completed FIPS validation test
 accredited lab and has been submitted to NIST for certification. This will continue to be the
 case as we periodically submit new versions of the AWS-LC-FIPS module to NIST for certification.
 Currently, aws-lc-fips-sys binds to
-[AWS-LC-FIPS 3.0.x](https://github.com/aws/aws-lc/tree/fips-2024-09-27).
+[AWS-LC-FIPS 4.x](https://github.com/aws/aws-lc/tree/fips-2025-09-12-lts).
 
 Consult with your local FIPS compliance team to determine the version of AWS-LC-FIPS module that you require. Consumers
 needing to remain on a previous version of the AWS-LC-FIPS module should pin to specific versions of aws-lc-rs to avoid
@@ -65,7 +65,8 @@ on how to specify dependency versions.)
 | AWS-LC-FIPS module | aws-lc-rs |
 |--------------------|-----------|
 | 2.0.x              | \<1.12.0  |
-| 3.0.x              | *latest*  |
+| 3.0.x              | \<1.18.0  |
+| 4.x                | *latest*  |
 
 Refer to the
 [NIST Cryptographic Module Validation Program's Modules In Progress List](https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List)

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -12,7 +12,6 @@ use crate::aws_lc::{
     EVP_parse_private_key, EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, EVP_PKEY_ED25519,
     RSA,
 };
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 use crate::aws_lc::{
     EVP_PKEY_pqdsa_new_raw_private_key, EVP_PKEY_pqdsa_new_raw_public_key, EVP_PKEY_PQDSA,
     NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
@@ -260,7 +259,6 @@ impl LcPtr<EVP_PKEY> {
         bytes: &[u8],
         evp_pkey_type: c_int,
     ) -> Result<Self, KeyRejected> {
-        #[cfg(all(feature = "unstable", not(feature = "fips")))]
         if evp_pkey_type == EVP_PKEY_PQDSA {
             return match bytes.len() {
                 2560 => Self::new(unsafe {
@@ -287,7 +285,6 @@ impl LcPtr<EVP_PKEY> {
         bytes: &[u8],
         evp_pkey_type: c_int,
     ) -> Result<Self, KeyRejected> {
-        #[cfg(all(feature = "unstable", not(feature = "fips")))]
         if evp_pkey_type == EVP_PKEY_PQDSA {
             return match bytes.len() {
                 1312 => Self::new(unsafe {

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -6,15 +6,12 @@ use crate::aws_lc::{
     EVP_PKEY_CTX_new_id, EVP_PKEY_bits, EVP_PKEY_cmp, EVP_PKEY_derive, EVP_PKEY_derive_init,
     EVP_PKEY_derive_set_peer, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA,
     EVP_PKEY_get_raw_private_key, EVP_PKEY_get_raw_public_key, EVP_PKEY_id, EVP_PKEY_keygen,
-    EVP_PKEY_keygen_init, EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key, EVP_PKEY_sign,
+    EVP_PKEY_keygen_init, EVP_PKEY_new_raw_private_key, EVP_PKEY_new_raw_public_key,
+    EVP_PKEY_pqdsa_new_raw_private_key, EVP_PKEY_pqdsa_new_raw_public_key, EVP_PKEY_sign,
     EVP_PKEY_sign_init, EVP_PKEY_size, EVP_PKEY_up_ref, EVP_PKEY_verify, EVP_PKEY_verify_init,
     EVP_marshal_private_key, EVP_marshal_private_key_v2, EVP_marshal_public_key,
     EVP_parse_private_key, EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, EVP_PKEY_ED25519,
-    RSA,
-};
-use crate::aws_lc::{
-    EVP_PKEY_pqdsa_new_raw_private_key, EVP_PKEY_pqdsa_new_raw_public_key, EVP_PKEY_PQDSA,
-    NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
+    EVP_PKEY_PQDSA, NID_MLDSA44, NID_MLDSA65, NID_MLDSA87, RSA,
 };
 use crate::cbb::LcCBB;
 use crate::digest::digest_ctx::DigestContext;

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -281,7 +281,6 @@ pub mod iv;
 pub mod kdf;
 #[allow(clippy::module_name_repetitions)]
 pub mod kem;
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 mod pqdsa;
 mod ptr;
 pub mod rsa;

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -56,7 +56,7 @@
 //! accredited lab and has been submitted to NIST for certification. This will continue to be the
 //! case as we periodically submit new versions of the AWS-LC-FIPS module to NIST for certification.
 //! Currently, aws-lc-fips-sys binds to
-//! [AWS-LC-FIPS 3.0.x](https://github.com/aws/aws-lc/tree/fips-2024-09-27).
+//! [AWS-LC-FIPS 4.x](https://github.com/aws/aws-lc/tree/fips-2025-09-12-lts).
 //!
 //! Consult with your local FIPS compliance team to determine the version of AWS-LC-FIPS module that you require. Consumers
 //! needing to remain on a previous version of the AWS-LC-FIPS module should pin to specific versions of aws-lc-rs to avoid
@@ -67,7 +67,8 @@
 //! | AWS-LC-FIPS module | aws-lc-rs |
 //! |--------------------|-----------|
 //! | 2.0.x              | \<1.12.0  |
-//! | 3.0.x              | *latest*  |
+//! | 3.0.x              | \<1.18.0  |
+//! | 4.x                | *latest*  |
 //!
 //! Refer to the
 //! [NIST Cryptographic Module Validation Program's Modules In Progress List](https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/Modules-In-Process-List)
@@ -378,15 +379,6 @@ pub fn fips_cpu_jitter_entropy() {
 /// Return an error if the underlying implementation is not using CPU jitter entropy, otherwise Ok.
 pub fn try_fips_cpu_jitter_entropy() -> Result<(), &'static str> {
     init();
-    // TODO: Delete once FIPS_is_entropy_cpu_jitter() available on FIPS branch
-    // https://github.com/aws/aws-lc/pull/2088
-    #[cfg(feature = "fips")]
-    if aws_lc::CFG_CPU_JITTER_ENTROPY() {
-        Ok(())
-    } else {
-        Err("FIPS CPU Jitter Entropy not enabled!")
-    }
-    #[cfg(not(feature = "fips"))]
     match unsafe { aws_lc::FIPS_is_entropy_cpu_jitter() } {
         1 => Ok(()),
         _ => Err("FIPS CPU Jitter Entropy not enabled!"),
@@ -476,7 +468,7 @@ mod tests {
     #[cfg(feature = "fips")]
     #[test]
     fn test_fips_version() {
-        // Module versions are monotonic across FIPS branches; the pinned branch is 3.
-        assert!(crate::fips_version().unwrap() >= 3);
+        // Module versions are monotonic across FIPS branches; the pinned branch is 4.
+        assert!(crate::fips_version().unwrap() >= 4);
     }
 }

--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -252,8 +252,9 @@ pub(crate) fn evp_key_pqdsa_generate(nid: c_int) -> Result<LcPtr<EVP_PKEY>, Unsp
 mod tests {
     use super::*;
 
-    use crate::signature::UnparsedPublicKey;
-    use crate::signature::{ML_DSA_44_SIGNING, ML_DSA_65_SIGNING, ML_DSA_87_SIGNING};
+    use crate::signature::{
+        UnparsedPublicKey, ML_DSA_44_SIGNING, ML_DSA_65_SIGNING, ML_DSA_87_SIGNING,
+    };
 
     const TEST_ALGORITHMS: &[&PqdsaSigningAlgorithm] =
         &[&ML_DSA_44_SIGNING, &ML_DSA_65_SIGNING, &ML_DSA_87_SIGNING];

--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -248,12 +248,12 @@ pub(crate) fn evp_key_pqdsa_generate(nid: c_int) -> Result<LcPtr<EVP_PKEY>, Unsp
     LcPtr::<EVP_PKEY>::generate(EVP_PKEY_PQDSA, Some(params_fn))
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     use crate::signature::UnparsedPublicKey;
-    use crate::unstable::signature::{ML_DSA_44_SIGNING, ML_DSA_65_SIGNING, ML_DSA_87_SIGNING};
+    use crate::signature::{ML_DSA_44_SIGNING, ML_DSA_65_SIGNING, ML_DSA_87_SIGNING};
 
     const TEST_ALGORITHMS: &[&PqdsaSigningAlgorithm] =
         &[&ML_DSA_44_SIGNING, &ML_DSA_65_SIGNING, &ML_DSA_87_SIGNING];

--- a/aws-lc-rs/src/rsa/tests/fips.rs
+++ b/aws-lc-rs/src/rsa/tests/fips.rs
@@ -7,74 +7,13 @@ use crate::fips::{assert_fips_status_indicator, FipsServiceStatus};
 use crate::rsa::{KeyPair, KeySize, PrivateDecryptingKey};
 
 macro_rules! generate_key {
-    ($name:ident, KeyPair, $size:expr) => {
+    ($name:ident, $type:ident, $size:expr) => {
         #[test]
         fn $name() {
-            // Using the non-fips generator will not set the indicator
-            #[cfg(not(feature = "fips"))]
+            // Key generation should set the approved indicator
             let _ =
-                assert_fips_status_indicator!(KeyPair::generate($size), FipsServiceStatus::Unset)
+                assert_fips_status_indicator!($type::generate($size), FipsServiceStatus::Approved)
                     .expect("key generated");
-
-            // Using the fips generator should set the indicator
-            #[cfg(feature = "fips")]
-            let _ = assert_fips_status_indicator!(
-                KeyPair::generate($size),
-                FipsServiceStatus::Approved
-            )
-            .expect("key generated");
-        }
-    };
-    ($name:ident, PrivateDecryptingKey, $size:expr) => {
-        #[test]
-        fn $name() {
-            // Using the non-fips generator will not set the indicator
-            #[cfg(not(feature = "fips"))]
-            let _ = assert_fips_status_indicator!(
-                PrivateDecryptingKey::generate($size),
-                FipsServiceStatus::Unset
-            )
-            .expect("key generated");
-
-            // Using the fips generator should set the indicator
-            #[cfg(feature = "fips")]
-            let _ = assert_fips_status_indicator!(
-                PrivateDecryptingKey::generate($size),
-                FipsServiceStatus::Approved
-            )
-            .expect("key generated");
-        }
-    };
-    ($name:ident, KeyPair, $size:expr, false) => {
-        #[test]
-        fn $name() {
-            // Using the non-fips generator will not set the indicator
-            let _ =
-                assert_fips_status_indicator!(KeyPair::generate($size), FipsServiceStatus::Unset);
-
-            // Using the fips generator should set the indicator
-            let _ = assert_fips_status_indicator!(
-                KeyPair::generate_fips($size),
-                FipsServiceStatus::NonApproved
-            )
-            .expect_err("key size not allowed");
-        }
-    };
-    ($name:ident, PrivateDecryptingKey, $size:expr, false) => {
-        #[test]
-        fn $name() {
-            // Using the non-fips generator will not set the indicator
-            let _ = assert_fips_status_indicator!(
-                PrivateDecryptingKey::generate($size),
-                FipsServiceStatus::Unset
-            );
-
-            // Using the fips generator should set the indicator
-            let _ = assert_fips_status_indicator!(
-                PrivateDecryptingKey::generate_fips($size),
-                FipsServiceStatus::NonApproved
-            )
-            .expect_err("key size not allowed");
         }
     };
 }

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -147,6 +147,31 @@
 //! }
 //! ```
 //!
+//! ## Signing and verifying with ML-DSA-44
+//!
+//! ```
+//! use aws_lc_rs::encoding::AsDer;
+//! use aws_lc_rs::signature::{KeyPair, PqdsaKeyPair, UnparsedPublicKey, ML_DSA_44, ML_DSA_44_SIGNING};
+//!
+//! fn main() -> Result<(), aws_lc_rs::error::Unspecified> {
+//!     let signing_alg = &ML_DSA_44_SIGNING;
+//!     let key_pair = PqdsaKeyPair::generate(signing_alg)?;
+//!
+//!     // Sign the message "hello, world".
+//!     const MESSAGE: &[u8] = b"hello, world";
+//!     let mut signature = vec![0; signing_alg.signature_len()];
+//!     let signature_len = key_pair.sign(MESSAGE, &mut signature)?;
+//!     assert_eq!(signature_len, signature.len());
+//!
+//!     // Verify the signature.
+//!     let public_key_bytes = key_pair.public_key().as_der()?;
+//!     let public_key = UnparsedPublicKey::new(&ML_DSA_44, public_key_bytes.as_ref());
+//!     public_key.verify(MESSAGE, &signature)?;
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
 //! ## Signing and verifying with RSA (PKCS#1 1.5 padding)
 //!
 //! By default OpenSSL writes RSA public keys in `SubjectPublicKeyInfo` format,
@@ -258,14 +283,17 @@ pub use crate::ed25519::{
     Ed25519KeyPair, EdDSAParameters, PublicKey as Ed25519PublicKey, Seed as Ed25519Seed,
     ED25519_PUBLIC_KEY_LEN,
 };
+pub use crate::pqdsa::key_pair::{PqdsaKeyPair, PqdsaPrivateKey};
+pub use crate::pqdsa::signature::{
+    PqdsaSigningAlgorithm, PqdsaVerificationAlgorithm, PublicKey as PqdsaPublicKey,
+};
 
 use crate::digest::Digest;
 use crate::ec::encoding::parse_ec_public_key;
 use crate::ed25519::parse_ed25519_public_key;
 use crate::encoding::{AsDer, PublicKeyX509Der};
 use crate::error::{KeyRejected, Unspecified};
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
-use crate::pqdsa::{parse_pqdsa_public_key, signature::PqdsaVerificationAlgorithm};
+use crate::pqdsa::{parse_pqdsa_public_key, AlgorithmID as PqdsaAlgorithmID};
 use crate::ptr::LcPtr;
 use crate::rsa::key::parse_rsa_public_key;
 use crate::{digest, ec, error, hex, rsa, sealed};
@@ -672,20 +700,14 @@ pub(crate) fn parse_public_key(
             unsafe { &*(algorithm as *const dyn VerificationAlgorithm).cast::<RsaParameters>() };
         parsed_algorithm = rsa_alg;
         parse_rsa_public_key(bytes)?
+    } else if algorithm.type_id() == TypeId::of::<PqdsaVerificationAlgorithm>() {
+        #[allow(clippy::cast_ptr_alignment)]
+        let pqdsa_alg = unsafe {
+            &*(algorithm as *const dyn VerificationAlgorithm).cast::<PqdsaVerificationAlgorithm>()
+        };
+        parsed_algorithm = pqdsa_alg;
+        parse_pqdsa_public_key(bytes, pqdsa_alg.id)?
     } else {
-        #[cfg(all(feature = "unstable", not(feature = "fips")))]
-        if algorithm.type_id() == TypeId::of::<PqdsaVerificationAlgorithm>() {
-            #[allow(clippy::cast_ptr_alignment)]
-            let pqdsa_alg = unsafe {
-                &*(algorithm as *const dyn VerificationAlgorithm)
-                    .cast::<PqdsaVerificationAlgorithm>()
-            };
-            parsed_algorithm = pqdsa_alg;
-            parse_pqdsa_public_key(bytes, pqdsa_alg.id)?
-        } else {
-            unreachable!()
-        }
-        #[cfg(any(not(feature = "unstable"), feature = "fips"))]
         unreachable!()
     };
 
@@ -1110,6 +1132,30 @@ pub const ECDSA_P256K1_SHA3_256_ASN1_SIGNING: EcdsaSigningAlgorithm =
 
 /// Verification of Ed25519 signatures.
 pub const ED25519: EdDSAParameters = EdDSAParameters {};
+
+/// Verification of ML-DSA-44 signatures.
+pub const ML_DSA_44: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
+    id: &PqdsaAlgorithmID::ML_DSA_44,
+};
+
+/// Verification of ML-DSA-65 signatures.
+pub const ML_DSA_65: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
+    id: &PqdsaAlgorithmID::ML_DSA_65,
+};
+
+/// Verification of ML-DSA-87 signatures.
+pub const ML_DSA_87: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
+    id: &PqdsaAlgorithmID::ML_DSA_87,
+};
+
+/// Signing using ML-DSA-44.
+pub const ML_DSA_44_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_44);
+
+/// Signing using ML-DSA-65.
+pub const ML_DSA_65_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_65);
+
+/// Signing using ML-DSA-87.
+pub const ML_DSA_87_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_87);
 
 #[cfg(test)]
 mod tests {

--- a/aws-lc-rs/src/signature/parsed_public_key_tests.rs
+++ b/aws-lc-rs/src/signature/parsed_public_key_tests.rs
@@ -12,8 +12,7 @@ use crate::signature::{
 use crate::{rand, test};
 use std::any::Any;
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
-use crate::unstable::signature::{
+use crate::signature::{
     PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING, ML_DSA_87,
     ML_DSA_87_SIGNING,
 };
@@ -367,7 +366,6 @@ fn test_parsed_public_key_cross_verification() {
     }
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_ml_dsa_44() {
     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
@@ -386,7 +384,6 @@ fn test_parsed_public_key_ml_dsa_44() {
     assert!(parsed.verify_sig(b"wrong message", &signature).is_err());
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_ml_dsa_65() {
     let key_pair = PqdsaKeyPair::generate(&ML_DSA_65_SIGNING).unwrap();
@@ -405,7 +402,6 @@ fn test_parsed_public_key_ml_dsa_65() {
     assert!(parsed.verify_sig(b"wrong message", &signature).is_err());
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_ml_dsa_87() {
     let key_pair = PqdsaKeyPair::generate(&ML_DSA_87_SIGNING).unwrap();
@@ -424,7 +420,6 @@ fn test_parsed_public_key_ml_dsa_87() {
     assert!(parsed.verify_sig(b"wrong message", &signature).is_err());
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_pqdsa_with_x509_der() {
     use crate::encoding::AsDer;
@@ -442,7 +437,6 @@ fn test_parsed_public_key_pqdsa_with_x509_der() {
     assert!(parsed.verify_sig(message, &signature).is_ok());
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_pqdsa_invalid_key() {
     // Test with wrong size key for ML-DSA-44 (expects 1312 bytes)
@@ -453,7 +447,6 @@ fn test_parsed_public_key_pqdsa_invalid_key() {
     assert!(ParsedPublicKey::new(&ML_DSA_44, invalid_key).is_err());
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_pqdsa_algorithm_mismatch() {
     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
@@ -466,7 +459,6 @@ fn test_parsed_public_key_pqdsa_algorithm_mismatch() {
     assert!(ParsedPublicKey::new(&ED25519, public_key_bytes).is_err());
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_pqdsa_cross_verification() {
     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
@@ -493,7 +485,6 @@ fn test_parsed_public_key_pqdsa_cross_verification() {
     );
 }
 
-#[cfg(all(feature = "unstable", not(feature = "fips")))]
 #[test]
 fn test_parsed_public_key_pqdsa_verify_digest() {
     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();

--- a/aws-lc-rs/src/signature/tests/fips.rs
+++ b/aws-lc-rs/src/signature/tests/fips.rs
@@ -438,3 +438,49 @@ rsa_verify!(
     &TEST_MESSAGE_RSA_PKCS1_1024_SHA512,
     FipsServiceStatus::Approved
 );
+
+mod pqdsa {
+    use super::TEST_MESSAGE;
+    use crate::fips::{assert_fips_status_indicator, FipsServiceStatus};
+    use crate::signature::{
+        KeyPair, PqdsaKeyPair, VerificationAlgorithm, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65,
+        ML_DSA_65_SIGNING, ML_DSA_87, ML_DSA_87_SIGNING,
+    };
+
+    macro_rules! mldsa_generate_sign_verify {
+        ($name:ident, $sign_alg:expr, $verify_alg:expr) => {
+            #[test]
+            fn $name() {
+                let keypair = assert_fips_status_indicator!(
+                    PqdsaKeyPair::generate($sign_alg),
+                    FipsServiceStatus::Approved
+                )
+                .unwrap();
+
+                let mut signature = vec![0u8; $sign_alg.signature_len()];
+                let signature_len = assert_fips_status_indicator!(
+                    keypair.sign(TEST_MESSAGE.as_bytes(), &mut signature),
+                    FipsServiceStatus::Approved
+                )
+                .unwrap();
+                assert_eq!(signature_len, signature.len());
+
+                let public_key = keypair.public_key();
+
+                assert_fips_status_indicator!(
+                    $verify_alg.verify_sig(
+                        public_key.as_ref(),
+                        TEST_MESSAGE.as_bytes(),
+                        signature.as_ref()
+                    ),
+                    FipsServiceStatus::Approved
+                )
+                .unwrap();
+            }
+        };
+    }
+
+    mldsa_generate_sign_verify!(mldsa_44_generate_sign_verify, &ML_DSA_44_SIGNING, ML_DSA_44);
+    mldsa_generate_sign_verify!(mldsa_65_generate_sign_verify, &ML_DSA_65_SIGNING, ML_DSA_65);
+    mldsa_generate_sign_verify!(mldsa_87_generate_sign_verify, &ML_DSA_87_SIGNING, ML_DSA_87);
+}

--- a/aws-lc-rs/src/unstable.rs
+++ b/aws-lc-rs/src/unstable.rs
@@ -9,5 +9,5 @@
 //! The APIs under this module are not stable and may change in the future.
 //! They are not covered by semver guarantees.
 //!
-#[cfg(not(feature = "fips"))]
+#[deprecated(note = "use `aws_lc_rs::signature` instead")]
 pub mod signature;

--- a/aws-lc-rs/src/unstable/signature.rs
+++ b/aws-lc-rs/src/unstable/signature.rs
@@ -1,97 +1,78 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-//! This module contains unstable/experimental APIs.
+//! The ML-DSA signature APIs have been stabilized; use [`crate::signature`] instead.
 //!
-//! # ⚠️ Warning
-//! The APIs under this module are not stable and may change in the future.
-//! They are not covered by semver guarantees.
-//!
-//! # Signing and verifying with MLDSA-44
-//!
-//! ```rust
-//! # use std::error::Error;
-//! # fn main() -> Result<(), Box<dyn Error>> {
-//!     use aws_lc_rs::encoding::AsDer;
-//!     use aws_lc_rs::signature::{KeyPair, UnparsedPublicKey};
-//!     use aws_lc_rs::unstable::signature::{PqdsaKeyPair, MLDSA_44_SIGNING, MLDSA_44};
-//!
-//!     let signing_alg = &MLDSA_44_SIGNING;
-//!     let key_pair = PqdsaKeyPair::generate(signing_alg)?;
-//!
-//!     const MESSAGE: &'static [u8] = b"hello, world";
-//!     let mut signature = vec![0; signing_alg.signature_len()];
-//!
-//!     let signature_len = key_pair.sign(MESSAGE, &mut signature)?;
-//!     assert_eq!(signature_len, signature.len());
-//!
-//!     // Verify the signature.
-//!     let public_key_bytes = key_pair.public_key().as_der()?;
-//!     let public_key = UnparsedPublicKey::new(&MLDSA_44, public_key_bytes.as_ref());
-//!
-//!     assert!(public_key.verify(MESSAGE, &signature).is_ok());
-//! #   Ok(())
-//! # }
-//! ```
-//!
+//! Everything in this module is a deprecated alias for its stable counterpart in
+//! [`crate::signature`]. Aliases are used rather than re-exports so that usage
+//! produces deprecation warnings; type identity is unchanged.
 
-pub use crate::pqdsa::key_pair::{PqdsaKeyPair, PqdsaPrivateKey};
-pub use crate::pqdsa::signature::{
-    PqdsaSigningAlgorithm, PqdsaVerificationAlgorithm, PublicKey as PqdsaPublicKey,
-};
+use crate::signature;
 
-use crate::pqdsa::AlgorithmID;
+/// Deprecated alias for [`crate::signature::PqdsaKeyPair`].
+#[deprecated(note = "use aws_lc_rs::signature::PqdsaKeyPair")]
+pub type PqdsaKeyPair = signature::PqdsaKeyPair;
+
+/// Deprecated alias for [`crate::signature::PqdsaPrivateKey`].
+#[deprecated(note = "use aws_lc_rs::signature::PqdsaPrivateKey")]
+pub type PqdsaPrivateKey<'a> = signature::PqdsaPrivateKey<'a>;
+
+/// Deprecated alias for [`crate::signature::PqdsaPublicKey`].
+#[deprecated(note = "use aws_lc_rs::signature::PqdsaPublicKey")]
+pub type PqdsaPublicKey = signature::PqdsaPublicKey;
+
+/// Deprecated alias for [`crate::signature::PqdsaSigningAlgorithm`].
+#[deprecated(note = "use aws_lc_rs::signature::PqdsaSigningAlgorithm")]
+pub type PqdsaSigningAlgorithm = signature::PqdsaSigningAlgorithm;
+
+/// Deprecated alias for [`crate::signature::PqdsaVerificationAlgorithm`].
+#[deprecated(note = "use aws_lc_rs::signature::PqdsaVerificationAlgorithm")]
+pub type PqdsaVerificationAlgorithm = signature::PqdsaVerificationAlgorithm;
+
+/// Verification of ML-DSA-44 signatures.
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_44")]
+pub const ML_DSA_44: signature::PqdsaVerificationAlgorithm = signature::ML_DSA_44;
+
+/// Verification of ML-DSA-65 signatures.
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_65")]
+pub const ML_DSA_65: signature::PqdsaVerificationAlgorithm = signature::ML_DSA_65;
+
+/// Verification of ML-DSA-87 signatures.
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_87")]
+pub const ML_DSA_87: signature::PqdsaVerificationAlgorithm = signature::ML_DSA_87;
+
+/// Signing using ML-DSA-44.
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_44_SIGNING")]
+pub const ML_DSA_44_SIGNING: signature::PqdsaSigningAlgorithm = signature::ML_DSA_44_SIGNING;
+
+/// Signing using ML-DSA-65.
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_65_SIGNING")]
+pub const ML_DSA_65_SIGNING: signature::PqdsaSigningAlgorithm = signature::ML_DSA_65_SIGNING;
+
+/// Signing using ML-DSA-87.
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_87_SIGNING")]
+pub const ML_DSA_87_SIGNING: signature::PqdsaSigningAlgorithm = signature::ML_DSA_87_SIGNING;
 
 /// Verification of MLDSA-44 signatures
-#[deprecated(note = "Use ML_DSA_44")]
-pub const MLDSA_44: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
-    id: &AlgorithmID::ML_DSA_44,
-};
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_44")]
+pub const MLDSA_44: signature::PqdsaVerificationAlgorithm = signature::ML_DSA_44;
 
 /// Verification of MLDSA-65 signatures
-#[deprecated(note = "Use ML_DSA_65")]
-pub const MLDSA_65: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
-    id: &AlgorithmID::ML_DSA_65,
-};
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_65")]
+pub const MLDSA_65: signature::PqdsaVerificationAlgorithm = signature::ML_DSA_65;
 
 /// Verification of MLDSA-87 signatures
-#[deprecated(note = "Use ML_DSA_87")]
-pub const MLDSA_87: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
-    id: &AlgorithmID::ML_DSA_87,
-};
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_87")]
+pub const MLDSA_87: signature::PqdsaVerificationAlgorithm = signature::ML_DSA_87;
 
 /// Sign using MLDSA-44
-#[deprecated(note = "Use ML_DSA_44_SIGNING")]
-pub const MLDSA_44_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_44);
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_44_SIGNING")]
+pub const MLDSA_44_SIGNING: signature::PqdsaSigningAlgorithm = signature::ML_DSA_44_SIGNING;
 
 /// Sign using MLDSA-65
-#[deprecated(note = "Use ML_DSA_65_SIGNING")]
-pub const MLDSA_65_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_65);
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_65_SIGNING")]
+pub const MLDSA_65_SIGNING: signature::PqdsaSigningAlgorithm = signature::ML_DSA_65_SIGNING;
 
 /// Sign using MLDSA-87
-#[deprecated(note = "Use ML_DSA_87_SIGNING")]
-pub const MLDSA_87_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_87);
-
-/// Verification of ML-DSA-44 signatures
-pub const ML_DSA_44: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
-    id: &AlgorithmID::ML_DSA_44,
-};
-
-/// Verification of ML-DSA-65 signatures
-pub const ML_DSA_65: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
-    id: &AlgorithmID::ML_DSA_65,
-};
-
-/// Verification of ML-DSA-87 signatures
-pub const ML_DSA_87: PqdsaVerificationAlgorithm = PqdsaVerificationAlgorithm {
-    id: &AlgorithmID::ML_DSA_87,
-};
-
-/// Sign using ML-DSA-44
-pub const ML_DSA_44_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_44);
-
-/// Sign using ML-DSA-65
-pub const ML_DSA_65_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_65);
-
-/// Sign using ML-DSA-87
-pub const ML_DSA_87_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_87);
+#[deprecated(note = "use aws_lc_rs::signature::ML_DSA_87_SIGNING")]
+pub const MLDSA_87_SIGNING: signature::PqdsaSigningAlgorithm = signature::ML_DSA_87_SIGNING;

--- a/aws-lc-rs/tests/kdf_test.rs
+++ b/aws-lc-rs/tests/kdf_test.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-#![cfg(all(feature = "unstable", not(feature = "fips")))]
-
 use std::error::Error;
 
 use aws_lc_rs::kdf::{

--- a/aws-lc-rs/tests/pqdsa_test.rs
+++ b/aws-lc-rs/tests/pqdsa_test.rs
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
-#![cfg(all(not(feature = "fips"), feature = "unstable"))]
 
 use aws_lc_rs::encoding::{AsDer, AsRawBytes};
 use aws_lc_rs::signature::{KeyPair, ParsedPublicKey, VerificationAlgorithm};
-use aws_lc_rs::unstable::signature::{
+use aws_lc_rs::signature::{
     PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING, ML_DSA_87,
     ML_DSA_87_SIGNING,
 };

--- a/aws-lc-rs/tests/pqdsa_test.rs
+++ b/aws-lc-rs/tests/pqdsa_test.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use aws_lc_rs::encoding::{AsDer, AsRawBytes};
-use aws_lc_rs::signature::{KeyPair, ParsedPublicKey, VerificationAlgorithm};
 use aws_lc_rs::signature::{
-    PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING, ML_DSA_87,
-    ML_DSA_87_SIGNING,
+    KeyPair, ParsedPublicKey, PqdsaKeyPair, VerificationAlgorithm, ML_DSA_44, ML_DSA_44_SIGNING,
+    ML_DSA_65, ML_DSA_65_SIGNING, ML_DSA_87, ML_DSA_87_SIGNING,
 };
 use aws_lc_rs::{test, test_file};
 

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -421,8 +421,10 @@ const MINIMUM_AWS_LC_VERSION: &str = "1.68.0";
 /// the library version and increases monotonically across FIPS branches, so it
 /// is a stable basis for comparison.
 ///
-/// TODO: bump to `4` when switching to the `fips-2025-09-12-lts` branch.
-const MINIMUM_FIPS_VERSION: u32 = 3;
+/// FIPS 4.x (`fips-2025-09-12-lts`) is the floor: aws-lc-rs unconditionally
+/// references symbols (e.g. ML-DSA/PQDSA) that older FIPS modules do not
+/// provide.
+const MINIMUM_FIPS_VERSION: u32 = 4;
 
 /// Finds the first `#define <name> ...` line in `base.h` content and returns
 /// the value token following the macro name (or `""` for a bare `#define


### PR DESCRIPTION
### Issues:
Addresses: #964

### Description of changes:
With `aws-lc-fips-sys` now tracking the FIPS 4.0 branch (#1185), the FIPS module provides ML-DSA - which was why the PQDSA APIs were stuck behind the `unstable` feature. This PR stabilizes them and cleans up other workarounds the new branch makes unnecessary. Three commits:

* **chore:** remove the jitter-entropy build-time workaround (runtime `FIPS_is_entropy_cpu_jitter()` is now available), update FIPS version references in docs, un-gate the KDF tests, and delete dead code in the RSA FIPS indicator tests.
* **feat:** move `PqdsaKeyPair` and the `ML_DSA_*` algorithms into `aws_lc_rs::signature`, compile `pqdsa` unconditionally, turn `unstable::signature` into a deprecated shim, and add ML-DSA FIPS service-indicator tests (the module reports keygen/sign/verify as approved).
* **fix(builder):** raise the system-library FIPS floor to module version 4, with the CI pin updated in lockstep. We now reference ML-DSA symbols that FIPS 3.x libraries don't provide.

### Call-outs:
The `unstable::signature` shim uses deprecated type aliases and const copies instead of `pub use` re-exports - rustc doesn't propagate `#[deprecated]` through re-exports, while aliases preserve type identity and still warn. Existing consumers keep building with warnings; the whole module will be deleted in a later release.

ML-DSA context-string support (#1079 / #1084) is not blocked by this: those methods are additive and will stay behind the `unstable` feature flag, since the FIPS 4.0 module does not implement ML-DSA context strings (the operations fail at runtime under `fips`). #1084 will need a rebase over this change.


### Testing:
* `cargo test --all-targets` across all four feature configs (default, `unstable`, `fips`, `fips,unstable`), plus `--doc` and `cargo test -p builder-test`
* clippy (pedantic) and `cargo fmt --check` clean; each commit builds and tests independently
* Deprecation shim verified with a throwaway consumer test: compiles, runs, and warns with the stable path

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
