### PR TITLE
fix: align PQDSA API with signature module conventions

### DIFF
--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -44,10 +44,16 @@ impl KeyPair for PqdsaKeyPair {
 /// A PQDSA private key.
 pub struct PqdsaPrivateKey<'a>(pub(crate) &'a PqdsaKeyPair);
 
+impl Debug for PqdsaPrivateKey<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("PqdsaPrivateKey({:?})", self.0.algorithm.0.id))
+    }
+}
+
 impl AsDer<Pkcs8V1Der<'static>> for PqdsaPrivateKey<'_> {
     /// Serializes the key to PKCS#8 v1 DER.
     ///
-    /// See [`PqdsaKeyPair::to_pkcs8`] for the chosen representation of the private key.
+    /// See [`PqdsaKeyPair::to_pkcs8v1`] for the chosen representation of the private key.
     ///
     /// # Errors
     /// Returns `Unspecified` if serialization fails.
@@ -76,7 +82,10 @@ impl PqdsaKeyPair {
     /// Generates a new PQDSA key pair for the specified algorithm.
     ///
     /// # Errors
-    /// Returns `Unspecified` is the key generation fails.
+    /// Returns `Unspecified` if the key generation fails.
+    //
+    // # FIPS
+    // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
     pub fn generate(algorithm: &'static PqdsaSigningAlgorithm) -> Result<Self, Unspecified> {
         let evp_pkey = evp_key_pqdsa_generate(algorithm.0.id.nid())?;
         let pubkey = PublicKey::from_private_evp_pkey(&evp_pkey)?;
@@ -147,10 +156,10 @@ impl PqdsaKeyPair {
     ///
     /// The seed should be produced from random entropy such as through [`crate::rand::fill`].
     /// However, for users requiring FIPS, the seed must be produced from
-    /// [`Self::generate`]. The [`Self::to_pkcs8`] method serializes the private key in seed form.
+    /// [`Self::generate`]. The [`Self::to_pkcs8v1`] method serializes the private key in seed form.
     /// AWS-LC keeps the seed in the internal representation when possible, but if [`PqdsaKeyPair`]
     /// is constructed from the expanded form (via [`Self::from_raw_private_key`]) the seed cannot
-    /// be obtained and [`Self::to_pkcs8`] will fail.
+    /// be obtained and [`Self::to_pkcs8v1`] will fail.
     ///
     /// This method expands the seed into the full private key internally. The expanded private key
     /// can be retrieved via [`Self::private_key`] and serialized via
@@ -197,7 +206,7 @@ impl PqdsaKeyPair {
     ///
     /// # Errors
     /// Returns `Unspecified` if serialization fails.
-    pub fn to_pkcs8(&self) -> Result<Document, Unspecified> {
+    pub fn to_pkcs8v1(&self) -> Result<Document, Unspecified> {
         Ok(Document::new(
             self.evp_pkey
                 .as_const()
@@ -205,11 +214,28 @@ impl PqdsaKeyPair {
         ))
     }
 
-    /// Uses this key to sign the message provided. The signature is written to the `signature`
-    /// slice provided. It returns the length of the signature on success.
+    /// Deprecated alias for [`Self::to_pkcs8v1`].
+    ///
+    /// This method predates the stabilization of the ML-DSA API and is retained for
+    /// consumers of the `unstable` feature; it will be removed in a future release.
     ///
     /// # Errors
-    /// Returns `Unspecified` if signing fails.
+    /// Returns `Unspecified` if serialization fails.
+    #[cfg(feature = "unstable")]
+    #[deprecated(note = "use `PqdsaKeyPair::to_pkcs8v1`")]
+    pub fn to_pkcs8(&self) -> Result<Document, Unspecified> {
+        self.to_pkcs8v1()
+    }
+
+    /// Uses this key to sign the message provided. The signature is written to the `signature`
+    /// slice provided, which must be at least [`PqdsaSigningAlgorithm::signature_len`] bytes
+    /// long. It returns the length of the signature on success.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if `signature` is too small or if signing fails.
+    //
+    // # FIPS
+    // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
     pub fn sign(&self, msg: &[u8], signature: &mut [u8]) -> Result<usize, Unspecified> {
         let sig_length = self.algorithm.signature_len();
         if signature.len() < sig_length {
@@ -326,7 +352,7 @@ mod tests {
                 .verify(message, original_signature.as_ref())
                 .unwrap();
 
-            let pkcs8_1 = keypair.to_pkcs8().unwrap();
+            let pkcs8_1 = keypair.to_pkcs8v1().unwrap();
             let pkcs8_2 = keypair.private_key().as_der().unwrap();
             let raw = keypair.private_key().as_raw_bytes().unwrap();
 
@@ -347,9 +373,11 @@ mod tests {
             assert_eq!(kp.algorithm(), alg);
             // Verify key works for signing
             let msg = b"seed test";
-            let mut sig = vec![0; alg.signature_len()];
+            let mut sig = vec![0u8; alg.signature_len()];
             let sig_len = kp.sign(msg, &mut sig).unwrap();
             assert_eq!(sig_len, alg.signature_len());
+            let public_key = UnparsedPublicKey::new(alg.0, kp.public_key().as_ref());
+            public_key.verify(msg, &sig).unwrap();
         }
     }
 
@@ -408,7 +436,7 @@ mod tests {
         for &alg in TEST_ALGORITHMS {
             let seed = [77u8; 32];
             let kp = PqdsaKeyPair::from_seed(alg, &seed).unwrap();
-            let pkcs8 = kp.to_pkcs8().unwrap();
+            let pkcs8 = kp.to_pkcs8v1().unwrap();
             let kp2 = PqdsaKeyPair::from_pkcs8(alg, pkcs8.as_ref()).unwrap();
             assert_eq!(kp.public_key().as_ref(), kp2.public_key().as_ref());
         }
@@ -444,14 +472,14 @@ mod tests {
         }
     }
 
-    // `to_pkcs8` documents that it prefers serializing just the seed. When a key
+    // `to_pkcs8v1` documents that it prefers serializing just the seed. When a key
     // pair is created from a seed, the PKCS#8 output must therefore be the compact
     // seed encoding, which is dramatically smaller than the expanded private key.
     #[test]
     fn test_from_seed_pkcs8_is_seed_form() {
         for &alg in TEST_ALGORITHMS {
             let kp = PqdsaKeyPair::from_seed(alg, &[3u8; 32]).unwrap();
-            let pkcs8 = kp.to_pkcs8().unwrap();
+            let pkcs8 = kp.to_pkcs8v1().unwrap();
             let raw_expanded = kp.private_key().as_raw_bytes().unwrap();
             // The seed-form PKCS#8 wraps only the 32-byte seed (plus ASN.1
             // framing), so it is far smaller than the expanded private key.
@@ -472,7 +500,7 @@ mod tests {
     // `from_seed` documents that if a `PqdsaKeyPair` is constructed from the
     // expanded form the seed cannot be obtained. AWS-LC's PKCS#8 encoding only
     // emits the seed, so a key pair with no seed available cannot be serialized to
-    // PKCS#8 at all -- `to_pkcs8` returns an error rather than falling back to the
+    // PKCS#8 at all -- `to_pkcs8v1` returns an error rather than falling back to the
     // expanded encoding.
     #[test]
     fn test_expanded_key_pkcs8_unavailable() {
@@ -487,22 +515,22 @@ mod tests {
             assert!(expanded_kp.private_key().as_raw_bytes().is_ok());
             // ...but the seed is gone, so PKCS#8 serialization is unavailable.
             assert!(
-                expanded_kp.to_pkcs8().is_err(),
+                expanded_kp.to_pkcs8v1().is_err(),
                 "expanded-only key unexpectedly serialized to PKCS#8",
             );
         }
     }
 
-    // `from_pkcs8` documents that it accepts the seed encoding, and `to_pkcs8`
+    // `from_pkcs8` documents that it accepts the seed encoding, and `to_pkcs8v1`
     // documents that it prefers the seed. A seed -> PKCS#8 -> key pair -> PKCS#8
     // round-trip must therefore preserve the seed form byte-for-byte.
     #[test]
     fn test_from_seed_pkcs8_roundtrip_preserves_seed_form() {
         for &alg in TEST_ALGORITHMS {
             let kp = PqdsaKeyPair::from_seed(alg, &[8u8; 32]).unwrap();
-            let pkcs8 = kp.to_pkcs8().unwrap();
+            let pkcs8 = kp.to_pkcs8v1().unwrap();
             let reparsed = PqdsaKeyPair::from_pkcs8(alg, pkcs8.as_ref()).unwrap();
-            let pkcs8_again = reparsed.to_pkcs8().unwrap();
+            let pkcs8_again = reparsed.to_pkcs8v1().unwrap();
             // Seed is retained through parsing, so re-serialization is identical.
             assert_eq!(pkcs8.as_ref(), pkcs8_again.as_ref());
             // And the reconstructed key pair is the same key.
@@ -511,13 +539,13 @@ mod tests {
     }
 
     // `PqdsaPrivateKey::as_der` documents that it uses the representation chosen by
-    // `to_pkcs8`. For a seed-derived key that representation is the seed form, so
-    // `as_der` and `to_pkcs8` must agree.
+    // `to_pkcs8v1`. For a seed-derived key that representation is the seed form, so
+    // `as_der` and `to_pkcs8v1` must agree.
     #[test]
-    fn test_from_seed_as_der_matches_to_pkcs8() {
+    fn test_from_seed_as_der_matches_to_pkcs8v1() {
         for &alg in TEST_ALGORITHMS {
             let kp = PqdsaKeyPair::from_seed(alg, &[11u8; 32]).unwrap();
-            let pkcs8 = kp.to_pkcs8().unwrap();
+            let pkcs8 = kp.to_pkcs8v1().unwrap();
             let der = kp.private_key().as_der().unwrap();
             assert_eq!(pkcs8.as_ref(), der.as_ref());
         }
@@ -532,7 +560,34 @@ mod tests {
         }
     }
 
-    // Additional test for the algorithm getter
+    #[test]
+    fn test_algorithm_lengths() {
+        for (alg, signature_len, public_key_len) in [
+            (&ML_DSA_44_SIGNING, 2420, 1312),
+            (&ML_DSA_65_SIGNING, 3309, 1952),
+            (&ML_DSA_87_SIGNING, 4627, 2592),
+        ] {
+            assert_eq!(alg.signature_len(), signature_len);
+            assert_eq!(alg.public_key_len(), public_key_len);
+            assert_eq!(alg.seed_len(), 32);
+        }
+    }
+
+    // The deprecated `to_pkcs8` alias is retained for consumers of the `unstable`
+    // feature; it must produce the same encoding as `to_pkcs8v1`.
+    #[cfg(feature = "unstable")]
+    #[allow(deprecated)]
+    #[test]
+    fn test_to_pkcs8_deprecated_alias() {
+        for &alg in TEST_ALGORITHMS {
+            let kp = PqdsaKeyPair::from_seed(alg, &[9u8; 32]).unwrap();
+            assert_eq!(
+                kp.to_pkcs8().unwrap().as_ref(),
+                kp.to_pkcs8v1().unwrap().as_ref()
+            );
+        }
+    }
+
     #[test]
     fn test_debug() {
         for &alg in TEST_ALGORITHMS {
@@ -545,6 +600,11 @@ mod tests {
             assert!(
                 format!("{pubkey:?}").starts_with("PqdsaPublicKey("),
                 "{pubkey:?}"
+            );
+            let privkey = keypair.private_key();
+            assert!(
+                format!("{privkey:?}").starts_with("PqdsaPrivateKey("),
+                "{privkey:?}"
             );
         }
     }

--- a/aws-lc-rs/src/pqdsa/signature.rs
+++ b/aws-lc-rs/src/pqdsa/signature.rs
@@ -16,7 +16,7 @@ use core::fmt::{Debug, Formatter};
 #[cfg(feature = "ring-sig-verify")]
 use untrusted::Input;
 
-/// An PQDSA verification algorithm.
+/// A PQDSA verification algorithm.
 #[derive(Debug, Eq, PartialEq)]
 pub struct PqdsaVerificationAlgorithm {
     pub(crate) id: &'static AlgorithmID,
@@ -24,7 +24,7 @@ pub struct PqdsaVerificationAlgorithm {
 
 impl sealed::Sealed for PqdsaVerificationAlgorithm {}
 
-/// An PQDSA signing algorithm.
+/// A PQDSA signing algorithm.
 #[derive(Debug, Eq, PartialEq)]
 pub struct PqdsaSigningAlgorithm(pub(crate) &'static PqdsaVerificationAlgorithm);
 
@@ -33,6 +33,20 @@ impl PqdsaSigningAlgorithm {
     #[must_use]
     pub fn signature_len(&self) -> usize {
         self.0.id.signature_size_bytes()
+    }
+
+    /// Returns the size of the raw public key in bytes.
+    #[must_use]
+    pub fn public_key_len(&self) -> usize {
+        self.0.id.pub_key_size_bytes()
+    }
+
+    /// Returns the size of the seed in bytes.
+    ///
+    /// See [`crate::signature::PqdsaKeyPair::from_seed`].
+    #[must_use]
+    pub fn seed_len(&self) -> usize {
+        self.0.id.seed_size_bytes()
     }
 }
 
@@ -69,17 +83,20 @@ impl ParsedVerificationAlgorithm for PqdsaVerificationAlgorithm {
 
     fn parsed_verify_digest_sig(
         &self,
-        public_key: &ParsedPublicKey,
-        digest: &Digest,
-        signature: &[u8],
+        _public_key: &ParsedPublicKey,
+        _digest: &Digest,
+        _signature: &[u8],
     ) -> Result<(), Unspecified> {
-        let evp_pkey = public_key.key();
-        evp_pkey.verify_digest_sig(digest, No_EVP_PKEY_CTX_consumer, signature)
+        // ML-DSA does not support digest-then-verify. Verifying a signature over
+        // externally hashed input is not an operation defined by FIPS 204: "pure"
+        // ML-DSA signs the message itself, and the pre-hash variant (HashML-DSA)
+        // uses a distinct domain separator that this API does not implement.
+        Err(Unspecified)
     }
 }
 
 impl VerificationAlgorithm for PqdsaVerificationAlgorithm {
-    /// Verifies the the signature of `msg` using the public key `public_key`.
+    /// Verifies the signature of `msg` using the public key `public_key`.
     ///
     /// # Errors
     /// `error::Unspecified` if the signature is invalid.
@@ -101,6 +118,9 @@ impl VerificationAlgorithm for PqdsaVerificationAlgorithm {
     ///
     /// # Errors
     /// `error::Unspecified` if the signature is invalid.
+    //
+    // # FIPS
+    // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
     fn verify_sig(
         &self,
         public_key: &[u8],
@@ -112,7 +132,8 @@ impl VerificationAlgorithm for PqdsaVerificationAlgorithm {
         evp_pkey.verify(msg, None, No_EVP_PKEY_CTX_consumer, signature)
     }
 
-    /// DO NOT USE. This function is required by `VerificationAlgorithm` but cannot be used w/ Ed25519.
+    /// DO NOT USE. This function is required by `VerificationAlgorithm` but cannot be used
+    /// with ML-DSA. See `parsed_verify_digest_sig` for why digest-then-verify is unsupported.
     ///
     /// # Errors
     /// Always returns `Unspecified`.

--- a/aws-lc-rs/src/pqdsa/signature.rs
+++ b/aws-lc-rs/src/pqdsa/signature.rs
@@ -87,10 +87,13 @@ impl ParsedVerificationAlgorithm for PqdsaVerificationAlgorithm {
         _digest: &Digest,
         _signature: &[u8],
     ) -> Result<(), Unspecified> {
-        // ML-DSA does not support digest-then-verify. Verifying a signature over
-        // externally hashed input is not an operation defined by FIPS 204: "pure"
-        // ML-DSA signs the message itself, and the pre-hash variant (HashML-DSA)
-        // uses a distinct domain separator that this API does not implement.
+        // This API cannot be used with ML-DSA, because a `Digest` cannot represent the
+        // input that ML-DSA's digest-then-verify flow ("external mu") requires. That flow
+        // verifies against the 64-byte message representative
+        // mu = SHAKE256(SHAKE256(public_key) || 0x00 || len(ctx) || ctx || message),
+        // which is a key-dependent XOF output rather than a fixed-output hash of the
+        // message alone. Previously this path verified the digest bytes as if they were
+        // a pure ML-DSA message, which is not a construction defined by FIPS 204.
         Err(Unspecified)
     }
 }
@@ -133,7 +136,9 @@ impl VerificationAlgorithm for PqdsaVerificationAlgorithm {
     }
 
     /// DO NOT USE. This function is required by `VerificationAlgorithm` but cannot be used
-    /// with ML-DSA. See `parsed_verify_digest_sig` for why digest-then-verify is unsupported.
+    /// with ML-DSA: a `Digest` cannot represent `mu`, the key-dependent "message
+    /// representative" that ML-DSA's digest-then-verify flow ("external mu") operates on.
+    /// See `parsed_verify_digest_sig` for details.
     ///
     /// # Errors
     /// Always returns `Unspecified`.

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -97,6 +97,17 @@
 //! signature using the secure random number generator passed to `sign()`.
 //!
 //!
+//! ## `ML_DSA_*` Details: ML-DSA (FIPS 204) Signatures
+//!
+//! The signature is the raw ML-DSA signature encoding described in [FIPS 204].
+//! Signing and verification use the "pure" ML-DSA mode with an empty context
+//! string; the pre-hash (HashML-DSA) mode is not supported.
+//!
+//! The public key may be provided either as the raw public key bytes or as a
+//! DER-encoded X.509 `SubjectPublicKeyInfo` structure; both encodings are
+//! accepted by `UnparsedPublicKey` and `ParsedPublicKey`.
+//!
+//!
 //! [SEC 1: Elliptic Curve Cryptography, Version 2.0]:
 //!     http://www.secg.org/sec1-v2.pdf
 //! [NIST Special Publication 800-56A, revision 2]:
@@ -111,6 +122,8 @@
 //!     https://tools.ietf.org/html/rfc3447#section-8.1
 //! [RFC 3447 Appendix-A.1.1]:
 //!     https://tools.ietf.org/html/rfc3447#appendix-A.1.1
+//! [FIPS 204]:
+//!     https://csrc.nist.gov/pubs/fips/204/final
 //!
 //!
 //! # Examples
@@ -1156,6 +1169,9 @@ pub const ML_DSA_65_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_D
 
 /// Signing using ML-DSA-87.
 pub const ML_DSA_87_SIGNING: PqdsaSigningAlgorithm = PqdsaSigningAlgorithm(&ML_DSA_87);
+
+#[cfg(test)]
+mod parsed_public_key_tests;
 
 #[cfg(test)]
 mod tests {

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -101,7 +101,9 @@
 //!
 //! The signature is the raw ML-DSA signature encoding described in [FIPS 204].
 //! Signing and verification use the "pure" ML-DSA mode with an empty context
-//! string; the pre-hash (HashML-DSA) mode is not supported.
+//! string. The pre-hash (HashML-DSA) mode is not supported, and neither is the
+//! "external mu" variant, in which the message representative `mu` is computed
+//! separately and signed or verified in place of the message.
 //!
 //! The public key may be provided either as the raw public key bytes or as a
 //! DER-encoded X.509 `SubjectPublicKeyInfo` structure; both encodings are

--- a/aws-lc-rs/src/unstable/signature.rs
+++ b/aws-lc-rs/src/unstable/signature.rs
@@ -6,6 +6,11 @@
 //! Everything in this module is a deprecated alias for its stable counterpart in
 //! [`crate::signature`]. Aliases are used rather than re-exports so that usage
 //! produces deprecation warnings; type identity is unchanged.
+//!
+//! During stabilization, `PqdsaKeyPair::to_pkcs8` was renamed to
+//! [`crate::signature::PqdsaKeyPair::to_pkcs8v1`]. A deprecated `to_pkcs8` alias
+//! remains available while the `unstable` feature is enabled; it will be removed
+//! along with this module in a future release.
 
 use crate::signature;
 

--- a/aws-lc-rs/tests/pqdsa_test.rs
+++ b/aws-lc-rs/tests/pqdsa_test.rs
@@ -183,7 +183,7 @@ fn test_mldsa_seed_serialization_roundtrip() {
         let kp = PqdsaKeyPair::from_seed(signing_alg, &seed).unwrap();
 
         // PKCS#8 round-trip
-        let pkcs8 = kp.to_pkcs8().expect("to_pkcs8 should succeed");
+        let pkcs8 = kp.to_pkcs8v1().expect("to_pkcs8v1 should succeed");
         let kp_pkcs8 = PqdsaKeyPair::from_pkcs8(signing_alg, pkcs8.as_ref())
             .expect("from_pkcs8 should reconstruct the key");
         assert_eq!(


### PR DESCRIPTION
### Issues:
Follow-up to the ML-DSA stabilization in #1188. No issue is being resolved.

### Description of changes:
A batch of consistency fixes bringing the PQDSA (ML-DSA) API in line with the rest of the `signature` module:

* Renames `PqdsaKeyPair::to_pkcs8` to `to_pkcs8v1`. Elsewhere in the module (e.g. `Ed25519KeyPair`) the version-unqualified name means PKCS#8 v2, so the old name was misleading. A deprecated `to_pkcs8` alias remains available under the `unstable` feature, so existing consumers get a deprecation warning rather than a compile error.

* `PqdsaVerificationAlgorithm::parsed_verify_digest_sig` now always returns `Unspecified`. Digest-then-verify is not an operation defined by FIPS 204: pure ML-DSA signs the message itself, and the pre-hash variant (HashML-DSA) uses a distinct domain separator that this API does not implement. Previously this path would happily verify the digest bytes as if they were a pure ML-DSA message. This aligns the parsed path with the unparsed path and with Ed25519.

* Declares the `signature::parsed_public_key_tests` module. The file was added in #863 but the `mod` declaration was never added, so its 27 tests have silently not been compiling or running.

* Smaller additions: `Debug` for `PqdsaPrivateKey`, `public_key_len`/`seed_len` accessors on `PqdsaSigningAlgorithm`, FIPS annotations on keygen/sign/verify, an ML-DSA subsection in the signature module's Algorithm Details docs, and assorted doc fixes.

### Call-outs:
* The `parsed_verify_digest_sig` change is behavioral: anything that was verifying an externally-computed digest against an ML-DSA signature via `ParsedPublicKey` will now fail. That prior behavior was arguably a bug (it accepted a construction FIPS 204 doesn't define).

* Since `parsed_public_key_tests` hasn't been compiling since #863, this PR is effectively (re)introducing 27 tests.

### Testing:
Existing unit and integration tests, plus the newly-enabled `parsed_public_key_tests` module (27 tests). `pqdsa_test.rs` updated for the `to_pkcs8v1` rename.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.