### PR TITLE
fix: prevent underflow panic in KeyWrap::unwrap for short ciphertexts

### DIFF
--- a/aws-lc-rs/src/key_wrap.rs
+++ b/aws-lc-rs/src/key_wrap.rs
@@ -267,7 +267,7 @@ impl KeyWrap for KeyEncryptionKey<AesBlockCipher> {
         ciphertext: &[u8],
         output: &'output mut [u8],
     ) -> Result<&'output mut [u8], Unspecified> {
-        if output.len() < ciphertext.len() - 8 {
+        if ciphertext.len() < 8 || output.len() < ciphertext.len() - 8 {
             return Err(Unspecified);
         }
 

--- a/aws-lc-rs/src/key_wrap/tests.rs
+++ b/aws-lc-rs/src/key_wrap/tests.rs
@@ -627,6 +627,11 @@ macro_rules! unwrap_input_output_invalid_test {
 // Input length < 24
 unwrap_input_output_invalid_test!(unwrap_input_len_smaller_than_min, 16, 16);
 
+// Input length < 8: previously caused `ciphertext.len() - 8` to underflow, panicking
+// (instead of returning Err) when built with `overflow-checks = true`.
+unwrap_input_output_invalid_test!(unwrap_input_len_zero, 0, 64);
+unwrap_input_output_invalid_test!(unwrap_input_len_less_than_eight, 7, 64);
+
 // Input length % 8 != 0
 unwrap_input_output_invalid_test!(unwrap_input_len_not_multiple_of_eight, 31, 31);
 


### PR DESCRIPTION
### Description of changes:
The output-size check in `KeyEncryptionKey<AesBlockCipher>::unwrap` computes `ciphertext.len() - 8` without first verifying `ciphertext.len() >= 8`. Since the ciphertext is untrusted input, a caller handing it a blob shorter than 8 bytes triggers an integer underflow: in builds with `overflow-checks = true` this panics instead of returning the documented `Err(Unspecified)`. With the default release profile the subtraction wraps and the function happens to still return `Err`, so behavior there is unchanged. The change adds a `ciphertext.len() < 8` condition ahead of the subtraction.

### Call-outs:
* The output-size check can't be dropped in favor of AWS-LC's own input validation (as the padded variant does): `AES_unwrap_key` has no `max_out` parameter and writes `in_len - 8` bytes to the output buffer unconditionally once its input checks pass, so the Rust-side guard is the only thing protecting `output`. 
* The multiple-of-8 and minimum-length (24 bytes) requirements, on the other hand, are enforced by the C layer and intentionally remain there.

### Testing:
Added regression tests for 0- and 7-byte ciphertexts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
