### PR TITLE
fix: zeroize KeyEncryptionKey key material on drop

### DIFF
--- a/aws-lc-rs/src/key_wrap.rs
+++ b/aws-lc-rs/src/key_wrap.rs
@@ -109,7 +109,7 @@ pub const AES_256: AesBlockCipher = AesBlockCipher {
 /// A Key Wrap (KW) algorithm implementation.
 #[allow(clippy::module_name_repetitions)]
 pub trait KeyWrap: Sealed {
-    /// Peforms the key wrap encryption algorithm using a block cipher.
+    /// Performs the key wrap encryption algorithm using a block cipher.
     /// It wraps `plaintext` and writes the corresponding ciphertext to `output`.
     ///
     /// # Errors
@@ -120,7 +120,7 @@ pub trait KeyWrap: Sealed {
         output: &'output mut [u8],
     ) -> Result<&'output mut [u8], Unspecified>;
 
-    /// Peforms the key wrap decryption algorithm using a block cipher.
+    /// Performs the key wrap decryption algorithm using a block cipher.
     /// It unwraps `ciphertext` and writes the corresponding plaintext to `output`.
     ///
     /// # Errors
@@ -135,7 +135,7 @@ pub trait KeyWrap: Sealed {
 /// A Key Wrap with Padding (KWP) algorithm implementation.
 #[allow(clippy::module_name_repetitions)]
 pub trait KeyWrapPadded: Sealed {
-    /// Peforms the key wrap padding encryption algorithm using a block cipher.
+    /// Performs the key wrap padding encryption algorithm using a block cipher.
     /// It wraps and pads `plaintext` writes the corresponding ciphertext to `output`.
     ///
     /// # Errors
@@ -146,7 +146,7 @@ pub trait KeyWrapPadded: Sealed {
         output: &'output mut [u8],
     ) -> Result<&'output mut [u8], Unspecified>;
 
-    /// Peforms the key wrap padding decryption algorithm using a block cipher.
+    /// Performs the key wrap padding decryption algorithm using a block cipher.
     /// It unwraps the padded `ciphertext` and writes the corresponding plaintext to `output`.
     ///
     /// # Errors
@@ -161,12 +161,12 @@ pub trait KeyWrapPadded: Sealed {
 /// AES Key Encryption Key.
 pub type AesKek = KeyEncryptionKey<AesBlockCipher>;
 
-/// The key-encryption key used with the selected cipher algorithn to wrap or unwrap a key.
+/// The key-encryption key used with the selected cipher algorithm to wrap or unwrap a key.
 ///
-/// Implements the NIST SP 800-38F key wrapping algoirthm.
+/// Implements the NIST SP 800-38F key wrapping algorithm.
 ///
 /// The NIST specification is similar to that of RFC 3394 but with the following caveats:
-/// * Specifies a maxiumum plaintext length that can be accepted.
+/// * Specifies a maximum plaintext length that can be accepted.
 /// * Allows implementations to specify a subset of valid lengths accepted.
 /// * Allows for the usage of other 128-bit block ciphers other than AES.
 pub struct KeyEncryptionKey<Cipher: BlockCipher> {
@@ -199,7 +199,7 @@ impl<Cipher: BlockCipher> KeyEncryptionKey<Cipher> {
 impl<Cipher: BlockCipher> Sealed for KeyEncryptionKey<Cipher> {}
 
 impl KeyWrap for KeyEncryptionKey<AesBlockCipher> {
-    /// Peforms the key wrap encryption algorithm using `KeyEncryptionKey`'s configured block cipher.
+    /// Performs the key wrap encryption algorithm using `KeyEncryptionKey`'s configured block cipher.
     /// It wraps `plaintext` and writes the corresponding ciphertext to `output`.
     ///
     /// # Validation
@@ -253,7 +253,7 @@ impl KeyWrap for KeyEncryptionKey<AesBlockCipher> {
         Ok(&mut output[..out_len])
     }
 
-    /// Peforms the key wrap decryption algorithm using `KeyEncryptionKey`'s configured block cipher.
+    /// Performs the key wrap decryption algorithm using `KeyEncryptionKey`'s configured block cipher.
     /// It unwraps `ciphertext` and writes the corresponding plaintext to `output`.
     ///
     /// # Validation
@@ -287,8 +287,8 @@ impl KeyWrap for KeyEncryptionKey<AesBlockCipher> {
         let aes_key = unsafe { aes_key.assume_init() };
 
         // AWS-LC validates the following:
-        // * in_len < INT_MAX
-        // * in_len > 24
+        // * in_len <= INT_MAX
+        // * in_len >= 24
         // * in_len % 8 == 0
         let out_len = indicator_check!(unsafe {
             AES_unwrap_key(
@@ -313,7 +313,7 @@ impl KeyWrap for KeyEncryptionKey<AesBlockCipher> {
 }
 
 impl KeyWrapPadded for KeyEncryptionKey<AesBlockCipher> {
-    /// Peforms the key wrap padding encryption algorithm using `KeyEncryptionKey`'s configured block cipher.
+    /// Performs the key wrap padding encryption algorithm using `KeyEncryptionKey`'s configured block cipher.
     /// It wraps and pads `plaintext` writes the corresponding ciphertext to `output`.
     ///
     /// # Validation
@@ -359,7 +359,7 @@ impl KeyWrapPadded for KeyEncryptionKey<AesBlockCipher> {
         Ok(&mut output[..out_len])
     }
 
-    /// Peforms the key wrap padding decryption algorithm using `KeyEncryptionKey`'s configured block cipher.
+    /// Performs the key wrap padding decryption algorithm using `KeyEncryptionKey`'s configured block cipher.
     /// It unwraps the padded `ciphertext` and writes the corresponding plaintext to `output`.
     ///
     /// # Sizing `output`

--- a/aws-lc-rs/src/key_wrap.rs
+++ b/aws-lc-rs/src/key_wrap.rs
@@ -42,6 +42,7 @@ use crate::sealed::Sealed;
 use core::fmt::Debug;
 use core::mem::MaybeUninit;
 use core::ptr::null;
+use zeroize::Zeroize;
 
 mod tests;
 
@@ -405,6 +406,12 @@ impl KeyWrapPadded for KeyEncryptionKey<AesBlockCipher> {
         }
 
         Ok(&mut output[..out_len])
+    }
+}
+
+impl<Cipher: BlockCipher> Drop for KeyEncryptionKey<Cipher> {
+    fn drop(&mut self) {
+        self.key.zeroize();
     }
 }
 

--- a/aws-lc-rs/src/key_wrap/tests.rs
+++ b/aws-lc-rs/src/key_wrap/tests.rs
@@ -654,7 +654,7 @@ macro_rules! wrap_with_padding_input_output_invalid_test {
 // Input length == 0
 wrap_with_padding_input_output_invalid_test!(wrap_with_padding_input_len_zero, 0, 16);
 
-// Output length is not sufficent for required padding
+// Output length is not sufficient for required padding
 // In this example an input length of 6 would require 2 additional bytes of padding, plus the additional
 // 8 bytes from the wrapping algorithm (So minimum of 16 bytes).
 wrap_with_padding_input_output_invalid_test!(wrap_with_padding_output_len_too_small, 6, 15);


### PR DESCRIPTION
### Description of changes:
`KeyEncryptionKey` stored the raw key-encryption-key bytes in a plain `Box<[u8]>` that was dropped without scrubbing, leaving key material behind in freed heap memory. Other key types in this crate (`SymmetricCipherKey`, `ChaCha20Key`, HKDF keys, owned `Buffer`s) zeroize their key material on drop; this adds a `Drop` impl to bring the `key_wrap` module in line with that practice.

A second commit fixes doc/comment nits in the same module: the comment describing `AES_unwrap_key`'s input validation had both bounds wrong (AWS-LC accepts `in_len == 24` and `in_len == INT_MAX`), plus a handful of spelling errors in doc comments.

### Call-outs:
No functional or API changes -- the `Drop` impl only affects what's left in memory after the key is dropped.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
