### PR TITLE
Fix bindings copy from read-only prebuilt AWS-LC install

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -62,6 +62,22 @@ jobs:
         working-directory: ${{ matrix.crate_dir }}
         run: cargo clippy ${{ matrix.features }} --all-targets -- -W clippy::all -W clippy::pedantic -D warnings
 
+  # The clippy job above runs on Linux, so every #[cfg(windows)] block in the
+  # builder is cfg-stripped before lints run. builder-test compiles the builder
+  # as a plain lib, so this lints that code without building AWS-LC. `--lib`
+  # skips the builder's test modules, which have pre-existing findings.
+  clippy-builder-windows:
+    if: github.repository_owner == 'aws'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component clippy --no-self-update
+          rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+      - name: Run cargo clippy (builder)
+        run: cargo clippy -p builder-test --lib -- -W clippy::all -W clippy::pedantic -D warnings
+
   apidiff:
     if: github.repository_owner == 'aws' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/system-lib-tests.yml
+++ b/.github/workflows/system-lib-tests.yml
@@ -298,6 +298,131 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
+  # Regression test for https://github.com/aws/aws-lc-rs/issues/1193: repeated
+  # builds against a read-only install (e.g. the Nix store). The build-script
+  # rerun is forced via the existing `rerun-if-changed=builder/` directive and
+  # reuses the same OUT_DIR, which holds the previously copied bindings.
+  # ---------------------------------------------------------------------------
+  test-readonly-install-unix:
+    if: github.repository_owner == 'aws'
+    needs: build-aws-lc-unix
+    name: "Test: read-only install, repeated builds (${{ matrix.os }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-sys/aws-lc
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download AWS-LC install
+        uses: actions/download-artifact@v8
+        with:
+          name: aws-lc-install-${{ matrix.os }}
+          path: ${{ github.workspace }}/aws-lc-artifacts
+
+      - name: Make the AWS-LC install read-only
+        run: chmod -R a-w "${{ github.workspace }}/aws-lc-artifacts/install"
+
+      - name: Build twice against the read-only install
+        env:
+          AWS_LC_SYS_SYSTEM_DIR: ${{ github.workspace }}/aws-lc-artifacts/install
+          AWS_LC_SYS_STATIC: "1"
+        run: |
+          set -o pipefail
+
+          # First build: copies the pre-generated bindings into OUT_DIR.
+          cargo build -vv -p aws-lc-sys 2>&1 | tee cargo-run1.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo-run1.log; then
+            echo '::error::System-library code path was not entered on the first build.'
+            exit 1
+          fi
+
+          # Force a build-script rerun against the same OUT_DIR.
+          touch aws-lc-sys/builder/main.rs
+
+          # Second build: used to fail with EACCES overwriting the read-only copy.
+          cargo build -vv -p aws-lc-sys 2>&1 | tee cargo-run2.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo-run2.log; then
+            echo '::error::System-library code path was not entered on the second build.'
+            exit 1
+          fi
+
+      - name: Restore write permissions for runner cleanup
+        if: always()
+        run: chmod -R u+w "${{ github.workspace }}/aws-lc-artifacts" || true
+
+  # ---------------------------------------------------------------------------
+  # Windows variant: `fs::copy` propagates the read-only attribute and
+  # `remove_file` fails on read-only files, so this exercises the build
+  # script's attribute-clearing branch (dead code on Unix).
+  # ---------------------------------------------------------------------------
+  test-readonly-install-windows:
+    if: github.repository_owner == 'aws'
+    needs: build-aws-lc-windows
+    name: "Test: read-only install, repeated builds (windows-latest)"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Remove the AWS-LC submodule working tree
+        shell: bash
+        run: rm -rf aws-lc-sys/aws-lc
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Download AWS-LC install
+        uses: actions/download-artifact@v8
+        with:
+          name: aws-lc-install-windows-latest
+          path: ${{ github.workspace }}/aws-lc-artifacts
+
+      - name: Make the AWS-LC install read-only
+        shell: pwsh
+        # FILE_ATTRIBUTE_READONLY is what fs::copy propagates and remove_file rejects.
+        run: |
+          Get-ChildItem -Recurse -File "${{ github.workspace }}\aws-lc-artifacts\install" |
+            ForEach-Object { $_.IsReadOnly = $true }
+
+      - name: Build twice against the read-only install
+        shell: bash
+        env:
+          AWS_LC_SYS_SYSTEM_DIR: ${{ github.workspace }}/aws-lc-artifacts/install
+          AWS_LC_SYS_STATIC: "1"
+        run: |
+          set -o pipefail
+
+          # First build: copies the pre-generated bindings (read-only) into OUT_DIR.
+          cargo build -vv -p aws-lc-sys 2>&1 | tee cargo-run1.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo-run1.log; then
+            echo '::error::System-library code path was not entered on the first build.'
+            exit 1
+          fi
+
+          # Force a build-script rerun against the same OUT_DIR.
+          touch aws-lc-sys/builder/main.rs
+
+          # Second build: remove_file on the read-only copy fails without the fix.
+          cargo build -vv -p aws-lc-sys 2>&1 | tee cargo-run2.log
+          if ! grep -q 'Using system-installed AWS-LC from' cargo-run2.log; then
+            echo '::error::System-library code path was not entered on the second build.'
+            exit 1
+          fi
+
+      - name: Restore write permissions for runner cleanup
+        if: always()
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -File "${{ github.workspace }}\aws-lc-artifacts" |
+            ForEach-Object { $_.IsReadOnly = $false }
+
+  # ---------------------------------------------------------------------------
   # Proves the declared minimum: build AWS-LC at MINIMUM_AWS_LC_VERSION (see
   # builder/system_library.rs) and run the full test suite against it with the
   # version check enabled. A failure means the minimum is unsupported and must

--- a/builder/main.rs
+++ b/builder/main.rs
@@ -603,7 +603,63 @@ pub(crate) fn out_dir() -> PathBuf {
     out
 }
 
-/// On Windows, convert a path to its 8.3 short form to avoid MAX_PATH (260 char) limits
+/// Copies `src` over `dest`, leaving the copy writable.
+///
+/// `fs::copy` propagates the source's permission bits, so copying out of a
+/// read-only location (the Nix store, say) would otherwise leave a read-only
+/// file that the next overwrite cannot open (aws/aws-lc-rs#1193).
+pub(crate) fn copy_writable(src: &Path, dest: &Path) -> Result<(), String> {
+    // Removal needs write permission on the directory, overwriting in place on
+    // the file; try both.
+    if remove_existing(dest).is_err() {
+        grant_write_permission(dest);
+    }
+    std::fs::copy(src, dest).map_err(|e| {
+        format!(
+            "Failed to copy {} to {}: {e}",
+            src.display(),
+            dest.display()
+        )
+    })?;
+    // nasm -o and bindgen write these same paths without clearing read-only first.
+    grant_write_permission(dest);
+    Ok(())
+}
+
+fn remove_existing(path: &Path) -> std::io::Result<()> {
+    // Only Windows refuses to remove a read-only file -- through at least Rust
+    // 1.85; std fixed it by 1.90, but our MSRV is 1.71.
+    #[cfg(windows)]
+    grant_write_permission(path);
+    match std::fs::remove_file(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        result => result,
+    }
+}
+
+fn grant_write_permission(path: &Path) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    let mut permissions = metadata.permissions();
+    if !permissions.readonly() {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        // `set_readonly(false)` would widen this to 0o666.
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(permissions.mode() | 0o200);
+    }
+    #[cfg(windows)]
+    {
+        #[allow(clippy::permissions_set_readonly_false)]
+        permissions.set_readonly(false);
+    }
+    let _ = std::fs::set_permissions(path, permissions);
+}
+
+/// On Windows, convert a path to its 8.3 short form to avoid `MAX_PATH` (260 char) limits
 /// when cl.exe is invoked with deeply nested source trees (e.g. Bazel runfiles).
 #[cfg(windows)]
 fn to_short_path(path: &Path) -> PathBuf {
@@ -615,6 +671,7 @@ fn to_short_path(path: &Path) -> PathBuf {
             cchBuffer: u32,
         ) -> u32;
     }
+    const MAX_PATH: usize = 260;
     let wide: Vec<u16> = path
         .as_os_str()
         .encode_wide()
@@ -632,14 +689,12 @@ fn to_short_path(path: &Path) -> PathBuf {
     buf.truncate(result as usize);
     let short_path = PathBuf::from(std::ffi::OsString::from_wide(&buf));
 
-    const MAX_PATH: usize = 260;
     let original_len = wide.len() - 1;
     if original_len >= MAX_PATH && (result as usize) >= MAX_PATH {
         emit_warning(format!(
-            "Path length ({}) exceeds MAX_PATH ({}) and 8.3 short name conversion was ineffective. \
-             8.3 short names may be disabled on this volume. \
-             See: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-8dot3name",
-            original_len, MAX_PATH,
+            "Path length ({original_len}) exceeds MAX_PATH ({MAX_PATH}) and 8.3 short name \
+             conversion was ineffective. 8.3 short names may be disabled on this volume. \
+             See: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/fsutil-8dot3name"
         ));
     }
 
@@ -1417,9 +1472,9 @@ fn setup_include_paths(out_dir: &Path, manifest_dir: &Path) -> PathBuf {
     for path in include_paths {
         for child in std::fs::read_dir(path).into_iter().flatten().flatten() {
             if child.path().is_file() {
-                std::fs::copy(
-                    child.path(),
-                    include_dir.join(child.path().file_name().unwrap()),
+                copy_writable(
+                    &child.path(),
+                    &include_dir.join(child.path().file_name().unwrap()),
                 )
                 .expect("Failed to copy include file during build setup");
                 continue;

--- a/builder/nasm_builder.rs
+++ b/builder/nasm_builder.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use std::ffi::OsString;
-use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::{execute_command, target_arch, test_nasm_command, use_prebuilt_nasm};
+use crate::{copy_writable, execute_command, target_arch, test_nasm_command, use_prebuilt_nasm};
 
 #[derive(Debug)]
 pub(crate) struct NasmBuilder {
@@ -127,7 +126,7 @@ impl NasmBuilder {
                 let base_name = obj_name.strip_suffix(".obj").unwrap_or(&obj_name);
                 let prebuilt_src = prebuilt_dir.join(format!("{base_name}.obj"));
                 if prebuilt_src.exists() {
-                    fs::copy(&prebuilt_src, &obj_path)
+                    copy_writable(&prebuilt_src, &obj_path)
                         .expect("Failed to copy prebuilt NASM object");
                 } else {
                     panic!("Prebuilt NASM object not found: {}", prebuilt_src.display());

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -12,7 +12,7 @@
 
 use crate::fips_probe::verify_fips_install;
 use crate::{
-    crate_env_var_name, emit_rustc_cfg, emit_warning, is_fips_build, is_fips_crate,
+    copy_writable, crate_env_var_name, emit_rustc_cfg, emit_warning, is_fips_build, is_fips_crate,
     is_static_library, link_fips_runtime_check, out_dir, target_env, target_os, Builder,
     OutputLibType,
 };
@@ -349,29 +349,7 @@ impl SystemLib {
             .ok_or("libcrypto parent directory not found")?;
         let include_dir = &self.layout.include_dir;
 
-        let bindings_dest = out_dir().join("bindings.rs");
-        // `fs::copy` propagates a read-only source's permissions (issue #1193),
-        // so remove any stale copy before copying. Windows can't `remove_file`
-        // a read-only file, so clear the attribute first.
-        if bindings_dest.exists() {
-            if let Ok(metadata) = std::fs::metadata(&bindings_dest) {
-                let mut permissions = metadata.permissions();
-                if permissions.readonly() {
-                    #[allow(clippy::permissions_set_readonly_false)]
-                    permissions.set_readonly(false);
-                    let _ = std::fs::set_permissions(&bindings_dest, permissions);
-                }
-            }
-            std::fs::remove_file(&bindings_dest).map_err(|e| {
-                format!(
-                    "Failed to remove stale bindings at {}: {}",
-                    bindings_dest.display(),
-                    e
-                )
-            })?;
-        }
-        std::fs::copy(&bindings, &bindings_dest)
-            .map_err(|e| format!("Failed to copy bindings from {}: {}", bindings.display(), e))?;
+        copy_writable(&bindings, &out_dir().join("bindings.rs"))?;
         emit_warning(format!(
             "Using pre-generated bindings from: {}",
             bindings.display()

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -349,7 +349,28 @@ impl SystemLib {
             .ok_or("libcrypto parent directory not found")?;
         let include_dir = &self.layout.include_dir;
 
-        std::fs::copy(&bindings, out_dir().join("bindings.rs"))
+        let bindings_dest = out_dir().join("bindings.rs");
+        // `fs::copy` propagates a read-only source's permissions (issue #1193),
+        // so remove any stale copy before copying. Windows can't `remove_file`
+        // a read-only file, so clear the attribute first.
+        if bindings_dest.exists() {
+            if let Ok(metadata) = std::fs::metadata(&bindings_dest) {
+                let mut permissions = metadata.permissions();
+                if permissions.readonly() {
+                    #[allow(clippy::permissions_set_readonly_false)]
+                    permissions.set_readonly(false);
+                    let _ = std::fs::set_permissions(&bindings_dest, permissions);
+                }
+            }
+            std::fs::remove_file(&bindings_dest).map_err(|e| {
+                format!(
+                    "Failed to remove stale bindings at {}: {}",
+                    bindings_dest.display(),
+                    e
+                )
+            })?;
+        }
+        std::fs::copy(&bindings, &bindings_dest)
             .map_err(|e| format!("Failed to copy bindings from {}: {}", bindings.display(), e))?;
         emit_warning(format!(
             "Using pre-generated bindings from: {}",


### PR DESCRIPTION
### Issues:

Addresses: #1193

### Description of changes:

When linking against a prebuilt AWS-LC via `AWS_LC_SYS_SYSTEM_DIR`, the build script copies the pre-generated bindings into `OUT_DIR` with `fs::copy`, which propagates the source's permission bits. If the install is read-only (e.g. the Nix store), the copied `bindings.rs` is too, and the next build-script rerun fails with `Permission denied` trying to overwrite it.

Two other copies into `OUT_DIR` hit the same problem when the crate source is read-only, so all three now share a `copy_writable` helper that removes any stale destination before copying and leaves the fresh copy writable:

* `system_library.rs` -- the pre-generated bindings (the reported bug).
* `setup_include_paths` -- headers copied out of the crate source.
* `nasm_builder.rs` -- prebuilt NASM objects copied out of the crate source.

Removing first means an `OUT_DIR` already poisoned by an earlier build recovers without a `cargo clean`. Leaving the copy writable matters because other writers of these same paths don't clear read-only themselves -- `nasm -o` fails with `unable to open output file`, and `File::create` in the internal-bindgen path fails the same way.

### Call-outs:

* The error in the issue names the _source_ path, but the failing open is on the destination -- easy to misread when debugging.
* The include-header copy can fail within a single build, not just on rerun: unlike the sibling directory copy it has no `skip_exist`, so a header present in two include paths gets overwritten immediately.
* The read-only handling is asymmetric on purpose. `remove_file` rejects a read-only file on Windows through at least Rust 1.85 (std fixed it by 1.90, but our MSRV is 1.71), so the attribute is cleared first under `cfg(windows)`. On Unix removal depends on the parent directory's write bit, and `set_readonly(false)` there would widen the mode to `0o666` -- hence `mode | 0o200` instead.
* New `clippy-builder-windows` job. Clippy only runs on Linux today, so every `#[cfg(windows)]` block in the builder -- including the hand-rolled `GetShortPathNameW` FFI -- is cfg-stripped before lints run and has never been linted. Linting `-p builder-test --lib` covers it in a few seconds without building AWS-LC. It surfaced 3 pre-existing findings in `to_short_path`, fixed here. Scoped to `--lib` because `--all-targets` pulls in the builder's test modules, which have their own pre-existing findings; wiring those in is worth a follow-up.

### Testing:

New `test-readonly-install-{unix,windows}` CI jobs build `aws-lc-sys` twice against a read-only install, forcing a build-script rerun in between via the existing `rerun-if-changed=builder/` directive. The Windows job exercises the attribute-clearing branch, which is `cfg`'d out on Unix.

Verified locally that a source build against read-only include directories succeeds, succeeds again across a forced rerun, and recovers an `OUT_DIR` left read-only by a pre-fix build. Verified the Windows-specific behaviors on a Windows Server 2022 host across Rust 1.71/1.77/1.85/1.90: `fs::copy` propagates the read-only attribute, overwriting a read-only file fails, and `remove_file` behaves as described above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
