### PR TITLE
feat: support the ML-DSA "external mu" signing and verification variant

### DIFF
--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -247,7 +247,7 @@ impl EcdsaKeyPair {
     pub fn sign_digest(&self, digest: &Digest) -> Result<Signature, Unspecified> {
         let out_sig = self
             .evp_pkey
-            .sign_digest(digest, No_EVP_PKEY_CTX_consumer)?;
+            .sign_digest(digest.as_ref(), No_EVP_PKEY_CTX_consumer)?;
         if self.algorithm.digest != digest.algorithm() {
             return Err(Unspecified);
         }

--- a/aws-lc-rs/src/ec/key_pair.rs
+++ b/aws-lc-rs/src/ec/key_pair.rs
@@ -247,7 +247,7 @@ impl EcdsaKeyPair {
     pub fn sign_digest(&self, digest: &Digest) -> Result<Signature, Unspecified> {
         let out_sig = self
             .evp_pkey
-            .sign_digest(digest.as_ref(), No_EVP_PKEY_CTX_consumer)?;
+            .sign_digest(digest.into(), No_EVP_PKEY_CTX_consumer)?;
         if self.algorithm.digest != digest.algorithm() {
             return Err(Unspecified);
         }

--- a/aws-lc-rs/src/ec/signature.rs
+++ b/aws-lc-rs/src/ec/signature.rs
@@ -308,7 +308,7 @@ fn verify_asn1_digest_signature(
     public_key: &LcPtr<EVP_PKEY>,
     signature: &[u8],
 ) -> Result<(), Unspecified> {
-    public_key.verify_digest_sig(digest, No_EVP_PKEY_CTX_consumer, signature)
+    public_key.verify_digest_sig(digest.as_ref(), No_EVP_PKEY_CTX_consumer, signature)
 }
 
 #[inline]

--- a/aws-lc-rs/src/ec/signature.rs
+++ b/aws-lc-rs/src/ec/signature.rs
@@ -308,7 +308,7 @@ fn verify_asn1_digest_signature(
     public_key: &LcPtr<EVP_PKEY>,
     signature: &[u8],
 ) -> Result<(), Unspecified> {
-    public_key.verify_digest_sig(digest.as_ref(), No_EVP_PKEY_CTX_consumer, signature)
+    public_key.verify_digest_sig(digest.into(), No_EVP_PKEY_CTX_consumer, signature)
 }
 
 #[inline]

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -15,13 +15,52 @@ use crate::aws_lc::{
 };
 use crate::cbb::LcCBB;
 use crate::digest::digest_ctx::DigestContext;
+use crate::digest::Digest;
 use crate::error::{KeyRejected, Unspecified};
 use crate::fips::indicator_check;
+use crate::ml_dsa::ExternalMu;
 use crate::pkcs8::Version;
 use crate::ptr::{ConstPointer, LcPtr};
 use crate::{cbs, digest};
 use core::ffi::c_int;
 use std::ptr::{null, null_mut};
+
+/// Pre-hashed input to `EVP_PKEY_sign` / `EVP_PKEY_verify`.
+///
+/// Intentionally not constructible from an arbitrary `&[u8]`: it can only be built from a
+/// value whose length was validated against the algorithm that produced it -- a [`Digest`]
+/// or a [`crate::ml_dsa::ExternalMu`] -- so that invariant travels with the value.
+///
+/// That matters most for PQDSA keys. In `EVP_PKEY_sign`'s digest mode an ML-DSA key treats
+/// the input as `mu`, and the two AWS-LC pins disagree about who validates its length:
+/// aws-lc-sys rejects a wrong `message_len` at the EVP layer, but the aws-lc-fips-sys pin
+/// performs no such check and copies the caller-supplied length into a fixed 64-byte stack
+/// buffer (`ml_dsa_ref/sign.c`, both sign and verify paths). An over-long input there is a
+/// stack buffer overflow, so the length check must not be optional.
+#[derive(Clone, Copy)]
+pub(crate) struct PreHashedInput<'a>(&'a [u8]);
+
+impl PreHashedInput<'_> {
+    fn as_slice(&self) -> &[u8] {
+        self.0
+    }
+}
+
+impl<'a> From<&'a Digest> for PreHashedInput<'a> {
+    /// A `Digest`'s length is fixed by its `digest::Algorithm` at construction, including via
+    /// [`Digest::import_less_safe`].
+    fn from(digest: &'a Digest) -> Self {
+        Self(digest.as_ref())
+    }
+}
+
+impl<'a> From<&'a ExternalMu> for PreHashedInput<'a> {
+    /// An `ExternalMu`'s length is fixed by its ML-DSA algorithm at construction, including
+    /// via [`ExternalMu::import_less_safe`].
+    fn from(mu: &'a ExternalMu) -> Self {
+        Self(mu.as_ref())
+    }
+}
 
 impl PartialEq<Self> for LcPtr<EVP_PKEY> {
     /// Only compares params and public key
@@ -373,7 +412,7 @@ impl LcPtr<EVP_PKEY> {
 
     pub(crate) fn sign_digest<F>(
         &self,
-        digest: &[u8],
+        digest: PreHashedInput<'_>,
         padding_fn: Option<F>,
     ) -> Result<Box<[u8]>, Unspecified>
     where
@@ -389,7 +428,7 @@ impl LcPtr<EVP_PKEY> {
             pad_fn(pctx.as_mut_ptr())?;
         }
 
-        let msg_digest = digest;
+        let msg_digest = digest.as_slice();
         let mut sig_len = 0;
         if 1 != unsafe {
             EVP_PKEY_sign(
@@ -472,7 +511,7 @@ impl LcPtr<EVP_PKEY> {
 
     pub(crate) fn verify_digest_sig<F>(
         &self,
-        digest: &[u8],
+        digest: PreHashedInput<'_>,
         padding_fn: Option<F>,
         signature: &[u8],
     ) -> Result<(), Unspecified>
@@ -489,7 +528,7 @@ impl LcPtr<EVP_PKEY> {
             pad_fn(pctx.as_mut_ptr())?;
         }
 
-        let msg_digest = digest;
+        let msg_digest = digest.as_slice();
 
         if 1 == unsafe {
             indicator_check!(EVP_PKEY_verify(

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -15,7 +15,6 @@ use crate::aws_lc::{
 };
 use crate::cbb::LcCBB;
 use crate::digest::digest_ctx::DigestContext;
-use crate::digest::Digest;
 use crate::error::{KeyRejected, Unspecified};
 use crate::fips::indicator_check;
 use crate::pkcs8::Version;
@@ -374,7 +373,7 @@ impl LcPtr<EVP_PKEY> {
 
     pub(crate) fn sign_digest<F>(
         &self,
-        digest: &Digest,
+        digest: &[u8],
         padding_fn: Option<F>,
     ) -> Result<Box<[u8]>, Unspecified>
     where
@@ -390,7 +389,7 @@ impl LcPtr<EVP_PKEY> {
             pad_fn(pctx.as_mut_ptr())?;
         }
 
-        let msg_digest = digest.as_ref();
+        let msg_digest = digest;
         let mut sig_len = 0;
         if 1 != unsafe {
             EVP_PKEY_sign(
@@ -473,7 +472,7 @@ impl LcPtr<EVP_PKEY> {
 
     pub(crate) fn verify_digest_sig<F>(
         &self,
-        digest: &Digest,
+        digest: &[u8],
         padding_fn: Option<F>,
         signature: &[u8],
     ) -> Result<(), Unspecified>
@@ -490,7 +489,7 @@ impl LcPtr<EVP_PKEY> {
             pad_fn(pctx.as_mut_ptr())?;
         }
 
-        let msg_digest = digest.as_ref();
+        let msg_digest = digest;
 
         if 1 == unsafe {
             indicator_check!(EVP_PKEY_verify(

--- a/aws-lc-rs/src/lib.rs
+++ b/aws-lc-rs/src/lib.rs
@@ -281,6 +281,7 @@ pub mod iv;
 pub mod kdf;
 #[allow(clippy::module_name_repetitions)]
 pub mod kem;
+pub mod ml_dsa;
 mod pqdsa;
 mod ptr;
 pub mod rsa;

--- a/aws-lc-rs/src/ml_dsa.rs
+++ b/aws-lc-rs/src/ml_dsa.rs
@@ -16,23 +16,30 @@
 //! large, streamed, or simply not available where the key lives. NIST describes the
 //! acceptability of this usage in its [FIPS 204 FAQ].
 //!
-//! Because `mu` is derived from the public key, an external-mu signature is
-//! indistinguishable from, and interchangeable with, an ordinary ML-DSA signature over the
-//! same message. It is not a different signature scheme, only a different way of feeding the
-//! message in.
+//! Because `mu` is derived from the public key, an external-mu signature over a message is
+//! indistinguishable from, and interchangeable with, an ordinary ML-DSA signature over that
+//! same message *and the same context string*. It is not a different signature scheme, only a
+//! different way of feeding the message in.
 //!
-//! This support lives in its own module rather than on [`PqdsaKeyPair`] and friends because
-//! external mu is an ML-DSA-specific construction, while the `Pqdsa*` types are shared by
-//! the whole post-quantum signature family. [`ExternalMuSigner`] and [`ExternalMuVerifier`]
-//! can only be obtained for ML-DSA keys, so the algorithm check happens once, when the
-//! handle is created, rather than on every operation.
+//! ML-DSA keys, algorithms, and ordinary (non-external-mu) signing live in
+//! [`crate::signature`]: see [`PqdsaKeyPair`], [`ParsedPublicKey`], and the `ML_DSA_*`
+//! constants. This module holds only what is specific to ML-DSA rather than shared by the
+//! whole post-quantum signature family.
+//!
+//! # Deriving `mu`
+//!
+//! [`MuContext`] mirrors [`crate::digest::Context`]: build one from the public key, feed the
+//! message in with [`MuContext::update`] as many times as needed, and call
+//! [`MuContext::finish`]. Deriving `mu` needs only the *public* key, so a party that holds
+//! neither the signing key nor a verification role can do it.
+//! [`ExternalMuVerifier::compute_mu`] is a one-shot convenience for messages held in full.
 //!
 //! # Example
 //!
 //! ```
 //! # use std::error::Error;
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! use aws_lc_rs::ml_dsa::{ExternalMuSigner, ExternalMuVerifier};
+//! use aws_lc_rs::ml_dsa::{ExternalMuSigner, ExternalMuVerifier, MuContext};
 //! use aws_lc_rs::signature::{
 //!     KeyPair, ParsedPublicKey, PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING,
 //! };
@@ -40,15 +47,20 @@
 //! let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING)?;
 //! let public_key = ParsedPublicKey::new(&ML_DSA_44, key_pair.public_key().as_ref())?;
 //!
-//! // The signer derives mu and signs it.
-//! let signer = ExternalMuSigner::try_from(&key_pair)?;
-//! let mu = signer.compute_mu(b"hello, world")?;
+//! // Some party holding only the public key derives mu, streaming the message.
+//! let mut mu_context = MuContext::new(&public_key)?;
+//! mu_context.update(b"hello, ")?;
+//! mu_context.update(b"world")?;
+//! let mu = mu_context.finish()?;
+//!
+//! // The signing key holder signs mu without ever seeing the message.
+//! let signer = ExternalMuSigner::new(&key_pair)?;
 //! let mut signature = vec![0u8; key_pair.algorithm().signature_len()];
 //! let len = signer.sign(&mu, &mut signature)?;
 //! signature.truncate(len);
 //!
 //! // The verifier derives the same mu from the public key and checks the signature.
-//! let verifier = ExternalMuVerifier::try_from(&public_key)?;
+//! let verifier = ExternalMuVerifier::new(&public_key)?;
 //! assert_eq!(mu.as_ref(), verifier.compute_mu(b"hello, world")?.as_ref());
 //! verifier.verify(&mu, &signature)?;
 //!
@@ -62,75 +74,84 @@
 //!     https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf
 
 use crate::aws_lc::EVP_PKEY;
-use crate::error::Unspecified;
+use crate::error::{KeyRejected, Unspecified};
 use crate::evp_pkey::No_EVP_PKEY_CTX_consumer;
-use crate::pqdsa::{
-    compute_mu, compute_tr, external_representative_len, MAX_EXTERNAL_REPRESENTATIVE_LEN, TR_LEN,
-};
+use crate::pqdsa::{compute_tr, external_representative_len, MuHasher, TR_LEN};
 use crate::ptr::LcPtr;
 use crate::signature::{
     KeyPair, ParsedPublicKey, PqdsaKeyPair, PqdsaSigningAlgorithm, PqdsaVerificationAlgorithm,
 };
 use core::fmt::{Debug, Formatter};
 
-/// Returns the length in bytes of the `mu` value used by `algorithm`, or `None` if
-/// `algorithm` does not support the external mu variant.
+/// The length in bytes of the ML-DSA message representative `mu`.
 ///
-/// Every ML-DSA parameter set currently uses 64 bytes.
-#[must_use]
-pub fn external_mu_len(algorithm: &'static PqdsaVerificationAlgorithm) -> Option<usize> {
-    external_representative_len(algorithm.id)
-}
+/// FIPS 204 fixes this at `ML_DSA_CRHBYTES` (64) for every ML-DSA parameter set, so it is a
+/// property of the scheme rather than of any one algorithm.
+pub const MU_LEN: usize = 64;
 
 /// The FIPS 204 "message representative" `mu`, used by the "external mu" variant of ML-DSA.
 ///
-/// Obtain one with [`ExternalMuSigner::compute_mu`] or [`ExternalMuVerifier::compute_mu`],
-/// or, if it was derived elsewhere, with [`Self::import_less_safe`]. Use [`Self::as_ref`] to
-/// get the value as a `&[u8]`, and [`external_mu_len`] to ask an algorithm how long its `mu`
-/// is.
+/// Obtain one with [`MuContext`] or [`ExternalMuVerifier::compute_mu`], or, if it was
+/// derived elsewhere, with [`Self::import_less_safe`]. Use [`Self::as_ref`] to get the value
+/// as a `&[u8]`; it is always [`MU_LEN`] bytes.
+///
+/// A value produced by this crate remembers which public key it was derived under, so
+/// [`ExternalMuSigner::sign`] and [`ExternalMuVerifier::verify`] can reject a `mu` belonging
+/// to a different key. A value from [`Self::import_less_safe`] cannot carry that binding, and
+/// is checked only for algorithm and length.
 #[derive(Clone, Copy)]
 pub struct ExternalMu {
-    /// `Copy` cannot be implemented for a dynamically sized array, so this is a fixed buffer
-    /// large enough for any algorithm plus the length actually in use, matching
-    /// [`crate::digest::Digest`].
-    mu: [u8; MAX_EXTERNAL_REPRESENTATIVE_LEN],
+    /// A fixed buffer plus the length in use, matching [`crate::digest::Digest`], so the
+    /// type can be `Copy`. `external_representative_len` is the source of truth for `len`.
+    mu: [u8; MU_LEN],
     len: usize,
     algorithm: &'static PqdsaVerificationAlgorithm,
+    /// `tr` of the public key this `mu` was derived under, or `None` when it was imported and
+    /// therefore has no provenance we can check. See [`Self::import_less_safe`].
+    key_binding: Option<[u8; TR_LEN]>,
 }
 
 impl ExternalMu {
-    /// The largest `mu` length across all supported algorithms. Useful for sizing a buffer
-    /// when no specific algorithm is in hand; see [`external_mu_len`] for the exact length
-    /// used by a given algorithm.
-    pub const MAX_LEN: usize = MAX_EXTERNAL_REPRESENTATIVE_LEN;
-
     /// Imports a `mu` value provided by an external source. This allows for the signing of
     /// content that might not be directly accessible.
     ///
     /// WARNING: unlike a message digest, `mu` binds the message to a *specific public key*.
     /// Signing an attacker-influenced `mu` is a blind signing operation: it yields a valid
-    /// signature over a message the signer never saw and cannot inspect. Ensure the value
-    /// comes from a trusted source and was derived under `algorithm` and the key it will be
-    /// used with. When possible, prefer to compute `mu` directly with
-    /// [`ExternalMuSigner::compute_mu`] or [`ExternalMuVerifier::compute_mu`].
+    /// signature over a message the signer never saw and cannot inspect. Note also that
+    /// external-mu verification does not re-derive `mu` -- it takes the supplied value on
+    /// faith -- so a signature over a mismatched `mu` is accepted by
+    /// [`ExternalMuVerifier::verify`] even though it is not a valid signature over any message
+    /// under that key.
+    ///
+    /// Ensure the value comes from a trusted source and was derived under `algorithm` and the
+    /// key it will be used with. An imported value carries no record of the key it came from,
+    /// so [`ExternalMuSigner::sign`] and [`ExternalMuVerifier::verify`] cannot check that for
+    /// you, as they can for a value derived through [`MuContext`]. When possible, prefer
+    /// deriving `mu` directly.
     ///
     /// # Errors
     /// Returns `Unspecified` if `algorithm` does not support the external mu variant, or if
-    /// `mu` is not exactly [`external_mu_len`] bytes for `algorithm`.
+    /// `mu` is not exactly [`MU_LEN`] bytes.
     pub fn import_less_safe(
         mu: &[u8],
         algorithm: &'static PqdsaVerificationAlgorithm,
     ) -> Result<Self, Unspecified> {
-        let len = external_mu_len(algorithm).ok_or(Unspecified)?;
+        let len = external_representative_len(algorithm.id).ok_or(Unspecified)?;
         if mu.len() != len {
             return Err(Unspecified);
         }
-        let mut buffer = [0u8; MAX_EXTERNAL_REPRESENTATIVE_LEN];
-        buffer[..len].copy_from_slice(mu);
+        let mut buffer = [0u8; MU_LEN];
+        // `get_mut` rather than a slice index: a representative longer than `MU_LEN` is an
+        // error, not a panic.
+        buffer
+            .get_mut(..len)
+            .ok_or(Unspecified)?
+            .copy_from_slice(mu);
         Ok(Self {
             mu: buffer,
             len,
             algorithm,
+            key_binding: None,
         })
     }
 
@@ -138,17 +159,6 @@ impl ExternalMu {
     #[must_use]
     pub fn algorithm(&self) -> &'static PqdsaVerificationAlgorithm {
         self.algorithm
-    }
-
-    /// Fills a new `mu` of the length `algorithm` requires, via `fill`.
-    fn new<F>(algorithm: &'static PqdsaVerificationAlgorithm, fill: F) -> Result<Self, Unspecified>
-    where
-        F: FnOnce(&mut [u8]) -> Result<(), Unspecified>,
-    {
-        let len = external_mu_len(algorithm).ok_or(Unspecified)?;
-        let mut mu = [0u8; MAX_EXTERNAL_REPRESENTATIVE_LEN];
-        fill(&mut mu[..len])?;
-        Ok(Self { mu, len, algorithm })
     }
 }
 
@@ -167,11 +177,93 @@ impl Debug for ExternalMu {
     }
 }
 
+/// An in-progress derivation of an [`ExternalMu`], bound to a specific ML-DSA public key.
+///
+/// This mirrors [`crate::digest::Context`]: feed the message in with [`Self::update`] as many
+/// times as needed, then call [`Self::finish`]. Because deriving `mu` requires only the
+/// public key, a `MuContext` can be built by a party that holds neither the signing key nor a
+/// verification role -- which is the point of the external mu variant.
+///
+/// `mu` is derived with an empty context string, matching the rest of the ML-DSA API in this
+/// crate.
+#[derive(Clone)]
+pub struct MuContext {
+    algorithm: &'static PqdsaVerificationAlgorithm,
+    tr: [u8; TR_LEN],
+    hasher: MuHasher,
+}
+
+impl MuContext {
+    /// Starts deriving `mu` for a message to be signed or verified under `public_key`.
+    ///
+    /// # Errors
+    /// Returns `KeyRejected` if `public_key` is not an ML-DSA public key.
+    pub fn new(public_key: &ParsedPublicKey) -> Result<Self, KeyRejected> {
+        let (algorithm, tr) = ml_dsa_algorithm_and_tr(public_key)?;
+        Self::from_tr(algorithm, &tr).map_err(|_| KeyRejected::unexpected_error())
+    }
+
+    fn from_tr(
+        algorithm: &'static PqdsaVerificationAlgorithm,
+        tr: &[u8; TR_LEN],
+    ) -> Result<Self, Unspecified> {
+        Ok(Self {
+            algorithm,
+            tr: *tr,
+            hasher: MuHasher::new(tr, b"")?,
+        })
+    }
+
+    /// Absorbs the next chunk of the message. May be called any number of times, including
+    /// zero for an empty message.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if the computation fails.
+    pub fn update(&mut self, data: &[u8]) -> Result<(), Unspecified> {
+        self.hasher.update(data)
+    }
+
+    /// Finishes the derivation and returns `mu`.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if the computation fails.
+    pub fn finish(self) -> Result<ExternalMu, Unspecified> {
+        let len = external_representative_len(self.algorithm.id).ok_or(Unspecified)?;
+        let mut mu = [0u8; MU_LEN];
+        // See the corresponding note in `ExternalMu::import_less_safe`.
+        self.hasher.finish(mu.get_mut(..len).ok_or(Unspecified)?)?;
+        Ok(ExternalMu {
+            mu,
+            len,
+            algorithm: self.algorithm,
+            key_binding: Some(self.tr),
+        })
+    }
+
+    /// Returns the verification algorithm `mu` is being derived for.
+    #[must_use]
+    pub fn algorithm(&self) -> &'static PqdsaVerificationAlgorithm {
+        self.algorithm
+    }
+}
+
+impl Debug for MuContext {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MuContext")
+            .field("algorithm", &self.algorithm)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Signs pre-computed [`ExternalMu`] values with an ML-DSA key pair.
 ///
-/// Obtained by converting from a [`PqdsaKeyPair`]; the conversion fails for PQDSA algorithms
-/// that are not ML-DSA. Caches `tr = SHAKE256(public_key)` so that deriving `mu` for many
-/// messages under the same key does not re-hash the public key each time.
+/// Construct one with [`Self::new`]; it fails for PQDSA algorithms that are not ML-DSA, so
+/// the algorithm check happens once here rather than on every operation. Caches
+/// `tr = SHAKE256(public_key)` so that [`Self::sign`] can reject a `mu` derived under a
+/// different key.
+///
+/// A signer never needs the message: derive `mu` where the message lives, with
+/// [`MuContext`] or [`ExternalMuVerifier`], and pass only `mu` to [`Self::sign`].
 ///
 /// This holds its own counted reference to the signing key, so it remains usable after the
 /// originating [`PqdsaKeyPair`] is dropped.
@@ -189,18 +281,20 @@ unsafe impl Send for ExternalMuSigner {}
 unsafe impl Sync for ExternalMuSigner {}
 
 impl ExternalMuSigner {
-    /// Computes `mu` over `message` with an empty context string, bound to this key pair's
-    /// public key.
-    ///
-    /// The result may be signed with [`Self::sign`], or verified against a signature with
-    /// [`ExternalMuVerifier::verify`]. A signature over this `mu` is interchangeable with an
-    /// ordinary ML-DSA signature over `message`.
+    /// Builds an external-mu signer for `key_pair`.
     ///
     /// # Errors
-    /// Returns `Unspecified` if the computation fails.
-    pub fn compute_mu(&self, message: &[u8]) -> Result<ExternalMu, Unspecified> {
-        ExternalMu::new(self.algorithm.verification_algorithm(), |mu| {
-            compute_mu(&self.tr, b"", message, mu)
+    /// Returns `KeyRejected` if `key_pair` is not an ML-DSA key pair.
+    pub fn new(key_pair: &PqdsaKeyPair) -> Result<Self, KeyRejected> {
+        let algorithm = key_pair.algorithm();
+        if external_representative_len(algorithm.verification_algorithm().id).is_none() {
+            return Err(KeyRejected::wrong_algorithm());
+        }
+        Ok(Self {
+            evp_pkey: key_pair.evp_pkey().clone(),
+            algorithm,
+            tr: compute_tr(key_pair.public_key().as_ref())
+                .map_err(|_| KeyRejected::unexpected_error())?,
         })
     }
 
@@ -212,25 +306,21 @@ impl ExternalMuSigner {
     /// signature on success.
     ///
     /// # Errors
-    /// Returns `Unspecified` if `mu` was computed for a different ML-DSA algorithm than this
-    /// key pair uses, if `signature` is too small, or if signing fails.
+    /// Returns `Unspecified` if `mu` was computed for a different ML-DSA algorithm or a
+    /// different public key than this key pair's, if `signature` is too small, or if signing
+    /// fails.
     //
     // # FIPS
     // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
     pub fn sign(&self, mu: &ExternalMu, signature: &mut [u8]) -> Result<usize, Unspecified> {
-        // `mu` is bound to a public key, so a value computed for a different parameter set is
-        // never meaningful here. This does not (and cannot) detect a `mu` computed for a
-        // different key of the *same* parameter set.
-        if mu.algorithm() != self.algorithm.verification_algorithm() {
-            return Err(Unspecified);
-        }
+        check_mu(mu, self.algorithm.verification_algorithm(), &self.tr)?;
         let sig_length = self.algorithm.signature_len();
         if signature.len() < sig_length {
             return Err(Unspecified);
         }
         let sig_bytes = self
             .evp_pkey
-            .sign_digest(mu.as_ref(), No_EVP_PKEY_CTX_consumer)?;
+            .sign_digest(mu.into(), No_EVP_PKEY_CTX_consumer)?;
         signature[0..sig_length].copy_from_slice(&sig_bytes);
         Ok(sig_length)
     }
@@ -243,21 +333,14 @@ impl ExternalMuSigner {
 }
 
 impl TryFrom<&PqdsaKeyPair> for ExternalMuSigner {
-    type Error = Unspecified;
+    type Error = KeyRejected;
 
+    /// See [`ExternalMuSigner::new`].
+    ///
     /// # Errors
-    /// Returns `Unspecified` if `key_pair` is not an ML-DSA key pair, or if `tr` cannot be
-    /// computed.
+    /// Returns `KeyRejected` if `key_pair` is not an ML-DSA key pair.
     fn try_from(key_pair: &PqdsaKeyPair) -> Result<Self, Self::Error> {
-        let algorithm = key_pair.algorithm();
-        if external_mu_len(algorithm.verification_algorithm()).is_none() {
-            return Err(Unspecified);
-        }
-        Ok(Self {
-            evp_pkey: key_pair.evp_pkey().clone(),
-            algorithm,
-            tr: compute_tr(key_pair.public_key().as_ref())?,
-        })
+        Self::new(key_pair)
     }
 }
 
@@ -271,9 +354,9 @@ impl Debug for ExternalMuSigner {
 
 /// Verifies signatures over pre-computed [`ExternalMu`] values with an ML-DSA public key.
 ///
-/// Obtained by converting from a [`ParsedPublicKey`]; the conversion fails unless the key is
-/// an ML-DSA key. Caches `tr = SHAKE256(public_key)` so that deriving `mu` for many messages
-/// under the same key does not re-hash the public key each time.
+/// Construct one with [`Self::new`]; it fails unless the key is an ML-DSA key. Caches
+/// `tr = SHAKE256(public_key)` so that deriving `mu` for many messages under the same key
+/// does not re-hash the public key each time.
 pub struct ExternalMuVerifier {
     evp_pkey: LcPtr<EVP_PKEY>,
     algorithm: &'static PqdsaVerificationAlgorithm,
@@ -285,29 +368,50 @@ unsafe impl Send for ExternalMuVerifier {}
 unsafe impl Sync for ExternalMuVerifier {}
 
 impl ExternalMuVerifier {
-    /// Computes `mu` over `message` with an empty context string, bound to this public key.
+    /// Builds an external-mu verifier for `public_key`.
+    ///
+    /// # Errors
+    /// Returns `KeyRejected` if `public_key` is not an ML-DSA public key.
+    pub fn new(public_key: &ParsedPublicKey) -> Result<Self, KeyRejected> {
+        let (algorithm, tr) = ml_dsa_algorithm_and_tr(public_key)?;
+        Ok(Self {
+            evp_pkey: public_key.key().clone(),
+            algorithm,
+            tr,
+        })
+    }
+
+    /// Starts a streaming derivation of `mu` bound to this public key.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if the computation cannot be started.
+    pub fn mu_context(&self) -> Result<MuContext, Unspecified> {
+        MuContext::from_tr(self.algorithm, &self.tr)
+    }
+
+    /// Computes `mu` over `message` in one shot, with an empty context string, bound to this
+    /// public key. Use [`Self::mu_context`] for a message not held in full.
     ///
     /// # Errors
     /// Returns `Unspecified` if the computation fails.
     pub fn compute_mu(&self, message: &[u8]) -> Result<ExternalMu, Unspecified> {
-        ExternalMu::new(self.algorithm, |mu| compute_mu(&self.tr, b"", message, mu))
+        let mut context = self.mu_context()?;
+        context.update(message)?;
+        context.finish()
     }
 
     /// Verifies that `signature` is a valid ML-DSA signature over `mu`.
     ///
     /// # Errors
-    /// Returns `Unspecified` if `mu` was computed for a different ML-DSA algorithm than this
-    /// key uses, or if the signature is invalid.
+    /// Returns `Unspecified` if `mu` was computed for a different ML-DSA algorithm or a
+    /// different public key than this one, or if the signature is invalid.
     //
     // # FIPS
     // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
     pub fn verify(&self, mu: &ExternalMu, signature: &[u8]) -> Result<(), Unspecified> {
-        // See the corresponding check in `ExternalMuSigner::sign`.
-        if mu.algorithm() != self.algorithm {
-            return Err(Unspecified);
-        }
+        check_mu(mu, self.algorithm, &self.tr)?;
         self.evp_pkey
-            .verify_digest_sig(mu.as_ref(), No_EVP_PKEY_CTX_consumer, signature)
+            .verify_digest_sig(mu.into(), No_EVP_PKEY_CTX_consumer, signature)
     }
 
     /// Returns the verification algorithm associated with this verifier.
@@ -318,25 +422,14 @@ impl ExternalMuVerifier {
 }
 
 impl TryFrom<&ParsedPublicKey> for ExternalMuVerifier {
-    type Error = Unspecified;
+    type Error = KeyRejected;
 
+    /// See [`ExternalMuVerifier::new`].
+    ///
     /// # Errors
-    /// Returns `Unspecified` if `public_key` is not an ML-DSA public key, or if `tr` cannot
-    /// be computed.
+    /// Returns `KeyRejected` if `public_key` is not an ML-DSA public key.
     fn try_from(public_key: &ParsedPublicKey) -> Result<Self, Self::Error> {
-        let algorithm = public_key
-            .pqdsa_verification_algorithm()
-            .ok_or(Unspecified)?;
-        if external_mu_len(algorithm).is_none() {
-            return Err(Unspecified);
-        }
-        let evp_pkey = public_key.key().clone();
-        let raw_public_key = evp_pkey.as_const().marshal_raw_public_key()?;
-        Ok(Self {
-            evp_pkey,
-            algorithm,
-            tr: compute_tr(&raw_public_key)?,
-        })
+        Self::new(public_key)
     }
 }
 
@@ -346,4 +439,52 @@ impl Debug for ExternalMuVerifier {
             .field("algorithm", &self.algorithm)
             .finish_non_exhaustive()
     }
+}
+
+/// Checks that `public_key` is an ML-DSA key supporting the external mu variant, and returns
+/// its algorithm along with `tr`.
+///
+/// `tr` is computed from the *raw* public key encoding, re-marshalled here rather than taken
+/// from the caller's input, so that a key parsed from an X.509 `SubjectPublicKeyInfo` yields
+/// the same `tr` as the same key parsed from raw bytes.
+fn ml_dsa_algorithm_and_tr(
+    public_key: &ParsedPublicKey,
+) -> Result<(&'static PqdsaVerificationAlgorithm, [u8; TR_LEN]), KeyRejected> {
+    let algorithm = public_key
+        .pqdsa_verification_algorithm()
+        .ok_or_else(KeyRejected::wrong_algorithm)?;
+    if external_representative_len(algorithm.id).is_none() {
+        return Err(KeyRejected::wrong_algorithm());
+    }
+    let raw_public_key = public_key
+        .key()
+        .as_const()
+        .marshal_raw_public_key()
+        .map_err(|_| KeyRejected::unexpected_error())?;
+    let tr = compute_tr(&raw_public_key).map_err(|_| KeyRejected::unexpected_error())?;
+    Ok((algorithm, tr))
+}
+
+/// Rejects a `mu` that cannot belong to the key about to be used with it: derived for a
+/// different parameter set, or -- when it carries its key binding -- under a different key
+/// of the *same* parameter set, which is otherwise silent: signing it produces a signature
+/// that verifies under no key at all. `tr` is a hash of a public key, so a variable-time
+/// comparison is fine.
+///
+/// A `mu` from [`ExternalMu::import_less_safe`] carries no `tr`, and only the algorithm is
+/// checked -- that is the "less safe" part of importing one.
+fn check_mu(
+    mu: &ExternalMu,
+    algorithm: &'static PqdsaVerificationAlgorithm,
+    tr: &[u8; TR_LEN],
+) -> Result<(), Unspecified> {
+    if mu.algorithm != algorithm {
+        return Err(Unspecified);
+    }
+    if let Some(mu_tr) = &mu.key_binding {
+        if mu_tr != tr {
+            return Err(Unspecified);
+        }
+    }
+    Ok(())
 }

--- a/aws-lc-rs/src/ml_dsa.rs
+++ b/aws-lc-rs/src/ml_dsa.rs
@@ -1,0 +1,349 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+//! ML-DSA specific support: the "external mu" signing and verification variant.
+//!
+//! ML-DSA (FIPS 204) signs and verifies the message itself. Internally it first derives a
+//! 64-byte *message representative*
+//!
+//! ```text
+//! tr = SHAKE256(public_key, 64)
+//! mu = SHAKE256(tr || 0x00 || len(context) || context || message, 64)
+//! ```
+//!
+//! and signs `mu`. The "external mu" variant lets `mu` be derived by a different party, or
+//! at a different time, than the one holding the signing key -- useful when the message is
+//! large, streamed, or simply not available where the key lives. NIST describes the
+//! acceptability of this usage in its [FIPS 204 FAQ].
+//!
+//! Because `mu` is derived from the public key, an external-mu signature is
+//! indistinguishable from, and interchangeable with, an ordinary ML-DSA signature over the
+//! same message. It is not a different signature scheme, only a different way of feeding the
+//! message in.
+//!
+//! This support lives in its own module rather than on [`PqdsaKeyPair`] and friends because
+//! external mu is an ML-DSA-specific construction, while the `Pqdsa*` types are shared by
+//! the whole post-quantum signature family. [`ExternalMuSigner`] and [`ExternalMuVerifier`]
+//! can only be obtained for ML-DSA keys, so the algorithm check happens once, when the
+//! handle is created, rather than on every operation.
+//!
+//! # Example
+//!
+//! ```
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
+//! use aws_lc_rs::ml_dsa::{ExternalMuSigner, ExternalMuVerifier};
+//! use aws_lc_rs::signature::{
+//!     KeyPair, ParsedPublicKey, PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING,
+//! };
+//!
+//! let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING)?;
+//! let public_key = ParsedPublicKey::new(&ML_DSA_44, key_pair.public_key().as_ref())?;
+//!
+//! // The signer derives mu and signs it.
+//! let signer = ExternalMuSigner::try_from(&key_pair)?;
+//! let mu = signer.compute_mu(b"hello, world")?;
+//! let mut signature = vec![0u8; key_pair.algorithm().signature_len()];
+//! let len = signer.sign(&mu, &mut signature)?;
+//! signature.truncate(len);
+//!
+//! // The verifier derives the same mu from the public key and checks the signature.
+//! let verifier = ExternalMuVerifier::try_from(&public_key)?;
+//! assert_eq!(mu.as_ref(), verifier.compute_mu(b"hello, world")?.as_ref());
+//! verifier.verify(&mu, &signature)?;
+//!
+//! // The same signature verifies as an ordinary ML-DSA signature over the message.
+//! public_key.verify_sig(b"hello, world", &signature)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [FIPS 204 FAQ]:
+//!     https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf
+
+use crate::aws_lc::EVP_PKEY;
+use crate::error::Unspecified;
+use crate::evp_pkey::No_EVP_PKEY_CTX_consumer;
+use crate::pqdsa::{
+    compute_mu, compute_tr, external_representative_len, MAX_EXTERNAL_REPRESENTATIVE_LEN, TR_LEN,
+};
+use crate::ptr::LcPtr;
+use crate::signature::{
+    KeyPair, ParsedPublicKey, PqdsaKeyPair, PqdsaSigningAlgorithm, PqdsaVerificationAlgorithm,
+};
+use core::fmt::{Debug, Formatter};
+
+/// Returns the length in bytes of the `mu` value used by `algorithm`, or `None` if
+/// `algorithm` does not support the external mu variant.
+///
+/// Every ML-DSA parameter set currently uses 64 bytes.
+#[must_use]
+pub fn external_mu_len(algorithm: &'static PqdsaVerificationAlgorithm) -> Option<usize> {
+    external_representative_len(algorithm.id)
+}
+
+/// The FIPS 204 "message representative" `mu`, used by the "external mu" variant of ML-DSA.
+///
+/// Obtain one with [`ExternalMuSigner::compute_mu`] or [`ExternalMuVerifier::compute_mu`],
+/// or, if it was derived elsewhere, with [`Self::import_less_safe`]. Use [`Self::as_ref`] to
+/// get the value as a `&[u8]`, and [`external_mu_len`] to ask an algorithm how long its `mu`
+/// is.
+#[derive(Clone, Copy)]
+pub struct ExternalMu {
+    /// `Copy` cannot be implemented for a dynamically sized array, so this is a fixed buffer
+    /// large enough for any algorithm plus the length actually in use, matching
+    /// [`crate::digest::Digest`].
+    mu: [u8; MAX_EXTERNAL_REPRESENTATIVE_LEN],
+    len: usize,
+    algorithm: &'static PqdsaVerificationAlgorithm,
+}
+
+impl ExternalMu {
+    /// The largest `mu` length across all supported algorithms. Useful for sizing a buffer
+    /// when no specific algorithm is in hand; see [`external_mu_len`] for the exact length
+    /// used by a given algorithm.
+    pub const MAX_LEN: usize = MAX_EXTERNAL_REPRESENTATIVE_LEN;
+
+    /// Imports a `mu` value provided by an external source. This allows for the signing of
+    /// content that might not be directly accessible.
+    ///
+    /// WARNING: unlike a message digest, `mu` binds the message to a *specific public key*.
+    /// Signing an attacker-influenced `mu` is a blind signing operation: it yields a valid
+    /// signature over a message the signer never saw and cannot inspect. Ensure the value
+    /// comes from a trusted source and was derived under `algorithm` and the key it will be
+    /// used with. When possible, prefer to compute `mu` directly with
+    /// [`ExternalMuSigner::compute_mu`] or [`ExternalMuVerifier::compute_mu`].
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if `algorithm` does not support the external mu variant, or if
+    /// `mu` is not exactly [`external_mu_len`] bytes for `algorithm`.
+    pub fn import_less_safe(
+        mu: &[u8],
+        algorithm: &'static PqdsaVerificationAlgorithm,
+    ) -> Result<Self, Unspecified> {
+        let len = external_mu_len(algorithm).ok_or(Unspecified)?;
+        if mu.len() != len {
+            return Err(Unspecified);
+        }
+        let mut buffer = [0u8; MAX_EXTERNAL_REPRESENTATIVE_LEN];
+        buffer[..len].copy_from_slice(mu);
+        Ok(Self {
+            mu: buffer,
+            len,
+            algorithm,
+        })
+    }
+
+    /// The ML-DSA algorithm this `mu` was computed for.
+    #[must_use]
+    pub fn algorithm(&self) -> &'static PqdsaVerificationAlgorithm {
+        self.algorithm
+    }
+
+    /// Fills a new `mu` of the length `algorithm` requires, via `fill`.
+    fn new<F>(algorithm: &'static PqdsaVerificationAlgorithm, fill: F) -> Result<Self, Unspecified>
+    where
+        F: FnOnce(&mut [u8]) -> Result<(), Unspecified>,
+    {
+        let len = external_mu_len(algorithm).ok_or(Unspecified)?;
+        let mut mu = [0u8; MAX_EXTERNAL_REPRESENTATIVE_LEN];
+        fill(&mut mu[..len])?;
+        Ok(Self { mu, len, algorithm })
+    }
+}
+
+impl AsRef<[u8]> for ExternalMu {
+    fn as_ref(&self) -> &[u8] {
+        &self.mu[..self.len]
+    }
+}
+
+// Mirrors `Digest`'s Debug: the algorithm followed by the value as hex.
+impl Debug for ExternalMu {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ExternalMu({:?}:", self.algorithm)?;
+        crate::debug::write_hex_bytes(f, self.as_ref())?;
+        write!(f, ")")
+    }
+}
+
+/// Signs pre-computed [`ExternalMu`] values with an ML-DSA key pair.
+///
+/// Obtained by converting from a [`PqdsaKeyPair`]; the conversion fails for PQDSA algorithms
+/// that are not ML-DSA. Caches `tr = SHAKE256(public_key)` so that deriving `mu` for many
+/// messages under the same key does not re-hash the public key each time.
+///
+/// This holds its own counted reference to the signing key, so it remains usable after the
+/// originating [`PqdsaKeyPair`] is dropped.
+pub struct ExternalMuSigner {
+    evp_pkey: LcPtr<EVP_PKEY>,
+    algorithm: &'static PqdsaSigningAlgorithm,
+    tr: [u8; TR_LEN],
+}
+
+// This holds a counted reference to the same `EVP_PKEY` as the originating `PqdsaKeyPair`,
+// and only ever uses it through non-mutating operations (`EVP_PKEY_sign`), which AWS-LC
+// documents as safe to call concurrently from multiple threads. See the note on
+// `ParsedPublicKey` in `crate::signature` for the upstream documentation.
+unsafe impl Send for ExternalMuSigner {}
+unsafe impl Sync for ExternalMuSigner {}
+
+impl ExternalMuSigner {
+    /// Computes `mu` over `message` with an empty context string, bound to this key pair's
+    /// public key.
+    ///
+    /// The result may be signed with [`Self::sign`], or verified against a signature with
+    /// [`ExternalMuVerifier::verify`]. A signature over this `mu` is interchangeable with an
+    /// ordinary ML-DSA signature over `message`.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if the computation fails.
+    pub fn compute_mu(&self, message: &[u8]) -> Result<ExternalMu, Unspecified> {
+        ExternalMu::new(self.algorithm.verification_algorithm(), |mu| {
+            compute_mu(&self.tr, b"", message, mu)
+        })
+    }
+
+    /// Signs `mu`, producing a signature indistinguishable from an ordinary ML-DSA signature
+    /// over the message `mu` was derived from.
+    ///
+    /// The signature is written to `signature`, which must be at least
+    /// [`PqdsaSigningAlgorithm::signature_len`] bytes long. Returns the length of the
+    /// signature on success.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if `mu` was computed for a different ML-DSA algorithm than this
+    /// key pair uses, if `signature` is too small, or if signing fails.
+    //
+    // # FIPS
+    // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
+    pub fn sign(&self, mu: &ExternalMu, signature: &mut [u8]) -> Result<usize, Unspecified> {
+        // `mu` is bound to a public key, so a value computed for a different parameter set is
+        // never meaningful here. This does not (and cannot) detect a `mu` computed for a
+        // different key of the *same* parameter set.
+        if mu.algorithm() != self.algorithm.verification_algorithm() {
+            return Err(Unspecified);
+        }
+        let sig_length = self.algorithm.signature_len();
+        if signature.len() < sig_length {
+            return Err(Unspecified);
+        }
+        let sig_bytes = self
+            .evp_pkey
+            .sign_digest(mu.as_ref(), No_EVP_PKEY_CTX_consumer)?;
+        signature[0..sig_length].copy_from_slice(&sig_bytes);
+        Ok(sig_length)
+    }
+
+    /// Returns the signing algorithm associated with this signer.
+    #[must_use]
+    pub fn algorithm(&self) -> &'static PqdsaSigningAlgorithm {
+        self.algorithm
+    }
+}
+
+impl TryFrom<&PqdsaKeyPair> for ExternalMuSigner {
+    type Error = Unspecified;
+
+    /// # Errors
+    /// Returns `Unspecified` if `key_pair` is not an ML-DSA key pair, or if `tr` cannot be
+    /// computed.
+    fn try_from(key_pair: &PqdsaKeyPair) -> Result<Self, Self::Error> {
+        let algorithm = key_pair.algorithm();
+        if external_mu_len(algorithm.verification_algorithm()).is_none() {
+            return Err(Unspecified);
+        }
+        Ok(Self {
+            evp_pkey: key_pair.evp_pkey().clone(),
+            algorithm,
+            tr: compute_tr(key_pair.public_key().as_ref())?,
+        })
+    }
+}
+
+impl Debug for ExternalMuSigner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExternalMuSigner")
+            .field("algorithm", &self.algorithm)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Verifies signatures over pre-computed [`ExternalMu`] values with an ML-DSA public key.
+///
+/// Obtained by converting from a [`ParsedPublicKey`]; the conversion fails unless the key is
+/// an ML-DSA key. Caches `tr = SHAKE256(public_key)` so that deriving `mu` for many messages
+/// under the same key does not re-hash the public key each time.
+pub struct ExternalMuVerifier {
+    evp_pkey: LcPtr<EVP_PKEY>,
+    algorithm: &'static PqdsaVerificationAlgorithm,
+    tr: [u8; TR_LEN],
+}
+
+// See the corresponding comment on `ExternalMuSigner`.
+unsafe impl Send for ExternalMuVerifier {}
+unsafe impl Sync for ExternalMuVerifier {}
+
+impl ExternalMuVerifier {
+    /// Computes `mu` over `message` with an empty context string, bound to this public key.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if the computation fails.
+    pub fn compute_mu(&self, message: &[u8]) -> Result<ExternalMu, Unspecified> {
+        ExternalMu::new(self.algorithm, |mu| compute_mu(&self.tr, b"", message, mu))
+    }
+
+    /// Verifies that `signature` is a valid ML-DSA signature over `mu`.
+    ///
+    /// # Errors
+    /// Returns `Unspecified` if `mu` was computed for a different ML-DSA algorithm than this
+    /// key uses, or if the signature is invalid.
+    //
+    // # FIPS
+    // Approved for all supported algorithms: ML-DSA-44, ML-DSA-65, ML-DSA-87.
+    pub fn verify(&self, mu: &ExternalMu, signature: &[u8]) -> Result<(), Unspecified> {
+        // See the corresponding check in `ExternalMuSigner::sign`.
+        if mu.algorithm() != self.algorithm {
+            return Err(Unspecified);
+        }
+        self.evp_pkey
+            .verify_digest_sig(mu.as_ref(), No_EVP_PKEY_CTX_consumer, signature)
+    }
+
+    /// Returns the verification algorithm associated with this verifier.
+    #[must_use]
+    pub fn algorithm(&self) -> &'static PqdsaVerificationAlgorithm {
+        self.algorithm
+    }
+}
+
+impl TryFrom<&ParsedPublicKey> for ExternalMuVerifier {
+    type Error = Unspecified;
+
+    /// # Errors
+    /// Returns `Unspecified` if `public_key` is not an ML-DSA public key, or if `tr` cannot
+    /// be computed.
+    fn try_from(public_key: &ParsedPublicKey) -> Result<Self, Self::Error> {
+        let algorithm = public_key
+            .pqdsa_verification_algorithm()
+            .ok_or(Unspecified)?;
+        if external_mu_len(algorithm).is_none() {
+            return Err(Unspecified);
+        }
+        let evp_pkey = public_key.key().clone();
+        let raw_public_key = evp_pkey.as_const().marshal_raw_public_key()?;
+        Ok(Self {
+            evp_pkey,
+            algorithm,
+            tr: compute_tr(&raw_public_key)?,
+        })
+    }
+}
+
+impl Debug for ExternalMuVerifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExternalMuVerifier")
+            .field("algorithm", &self.algorithm)
+            .finish_non_exhaustive()
+    }
+}

--- a/aws-lc-rs/src/pqdsa.rs
+++ b/aws-lc-rs/src/pqdsa.rs
@@ -4,10 +4,24 @@
 pub(crate) mod key_pair;
 pub(crate) mod signature;
 
-use crate::aws_lc::{EVP_PKEY, EVP_PKEY_PQDSA, NID_MLDSA44, NID_MLDSA65, NID_MLDSA87};
+use crate::aws_lc::{
+    EVP_DigestFinalXOF, EVP_DigestInit_ex, EVP_DigestUpdate, EVP_shake256, EVP_PKEY,
+    EVP_PKEY_PQDSA, NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
+};
+use crate::digest::digest_ctx::DigestContext;
 use crate::error::{KeyRejected, Unspecified};
 use crate::ptr::LcPtr;
 use core::ffi::c_int;
+use core::ptr::null_mut;
+
+/// The largest external message representative length across all PQDSA algorithms.
+///
+/// Mirrors the role of [`crate::digest::MAX_OUTPUT_LEN`]: it sizes the fixed buffer inside
+/// the representative value type so one type can carry any algorithm's representative.
+pub(crate) const MAX_EXTERNAL_REPRESENTATIVE_LEN: usize = 64;
+
+/// The length in bytes of `tr = SHAKE256(public_key)` (`ML_DSA_TRBYTES`).
+pub(crate) const TR_LEN: usize = 64;
 
 #[derive(Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
@@ -90,6 +104,80 @@ pub(crate) fn parse_pqdsa_public_key(
             EVP_PKEY_PQDSA,
         ))
         .and_then(|key| validate_pqdsa_evp_key(&key, id).map(|()| key))
+}
+
+/// Returns the length in bytes of the external message representative that `id` signs and
+/// verifies, or `None` if `id` does not support signing a precomputed representative.
+///
+/// This mirrors AWS-LC's `PQDSA.digest_len`, which is a field on the family-level `PQDSA`
+/// struct rather than on any one algorithm: the ability to sign a precomputed representative
+/// is modelled as a per-algorithm capability that individual algorithms opt into.
+///
+/// For ML-DSA the representative is `mu`, of length `ML_DSA_CRHBYTES` (64) for every
+/// parameter set. A future algorithm can only support this if its representative is a
+/// deterministic function of public inputs alone -- that holds for ML-DSA, but not for
+/// schemes that mix signer-chosen randomness into the message hash before signing (SLH-DSA
+/// derives it through a secret-keyed PRF; FN-DSA draws a fresh salt).
+//
+// This is deliberately an exhaustive `match` with no wildcard arm. Every PQDSA algorithm
+// supported today is an ML-DSA parameter set, so there is no reachable `None` case; writing
+// it this way means adding an algorithm to `AlgorithmID` is a compile error here, forcing a
+// deliberate decision instead of silently claiming or denying support for it. The `Option`
+// is therefore always `Some` today, and is kept so that adding an algorithm that does not
+// support this is not a breaking change to every caller.
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) const fn external_representative_len(id: &AlgorithmID) -> Option<usize> {
+    match id {
+        AlgorithmID::ML_DSA_44 | AlgorithmID::ML_DSA_65 | AlgorithmID::ML_DSA_87 => Some(64),
+    }
+}
+
+/// Computes `tr = SHAKE256(public_key, 64)`, the public key hash that binds `mu` to a
+/// specific key. `raw_public_key` must be the raw (not X.509) public key encoding.
+pub(crate) fn compute_tr(raw_public_key: &[u8]) -> Result<[u8; TR_LEN], Unspecified> {
+    let mut tr = [0u8; TR_LEN];
+    shake256(&[raw_public_key], &mut tr)?;
+    Ok(tr)
+}
+
+/// Computes `mu`, the FIPS 204 "message representative", from a precomputed `tr`, squeezing
+/// `mu.len()` bytes:
+///
+/// ```text
+/// mu = SHAKE256(tr || 0x00 || len(context) || context || message, mu.len())
+/// ```
+///
+/// The `0x00` octet is the domain separator selecting "pure" ML-DSA (as opposed to
+/// HashML-DSA, which uses `0x01`).
+pub(crate) fn compute_mu(
+    tr: &[u8; TR_LEN],
+    context: &[u8],
+    message: &[u8],
+    mu: &mut [u8],
+) -> Result<(), Unspecified> {
+    // FIPS 204 limits the context string to 255 bytes, which is also what the single
+    // length octet below can encode.
+    let context_len = u8::try_from(context.len()).map_err(|_| Unspecified)?;
+
+    shake256(&[tr, &[0u8, context_len], context, message], mu)
+}
+
+/// Absorbs each element of `inputs` in order and squeezes `output.len()` bytes.
+fn shake256(inputs: &[&[u8]], output: &mut [u8]) -> Result<(), Unspecified> {
+    let mut md_ctx = DigestContext::new_uninit();
+    if 1 != unsafe { EVP_DigestInit_ex(md_ctx.as_mut_ptr(), EVP_shake256(), null_mut()) } {
+        return Err(Unspecified);
+    }
+    for input in inputs {
+        if 1 != unsafe { EVP_DigestUpdate(md_ctx.as_mut_ptr(), input.as_ptr().cast(), input.len()) }
+        {
+            return Err(Unspecified);
+        }
+    }
+    if 1 != unsafe { EVP_DigestFinalXOF(md_ctx.as_mut_ptr(), output.as_mut_ptr(), output.len()) } {
+        return Err(Unspecified);
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/aws-lc-rs/src/pqdsa.rs
+++ b/aws-lc-rs/src/pqdsa.rs
@@ -14,12 +14,6 @@ use crate::ptr::LcPtr;
 use core::ffi::c_int;
 use core::ptr::null_mut;
 
-/// The largest external message representative length across all PQDSA algorithms.
-///
-/// Mirrors the role of [`crate::digest::MAX_OUTPUT_LEN`]: it sizes the fixed buffer inside
-/// the representative value type so one type can carry any algorithm's representative.
-pub(crate) const MAX_EXTERNAL_REPRESENTATIVE_LEN: usize = 64;
-
 /// The length in bytes of `tr = SHAKE256(public_key)` (`ML_DSA_TRBYTES`).
 pub(crate) const TR_LEN: usize = 64;
 
@@ -109,22 +103,15 @@ pub(crate) fn parse_pqdsa_public_key(
 /// Returns the length in bytes of the external message representative that `id` signs and
 /// verifies, or `None` if `id` does not support signing a precomputed representative.
 ///
-/// This mirrors AWS-LC's `PQDSA.digest_len`, which is a field on the family-level `PQDSA`
-/// struct rather than on any one algorithm: the ability to sign a precomputed representative
-/// is modelled as a per-algorithm capability that individual algorithms opt into.
-///
-/// For ML-DSA the representative is `mu`, of length `ML_DSA_CRHBYTES` (64) for every
-/// parameter set. A future algorithm can only support this if its representative is a
-/// deterministic function of public inputs alone -- that holds for ML-DSA, but not for
-/// schemes that mix signer-chosen randomness into the message hash before signing (SLH-DSA
-/// derives it through a secret-keyed PRF; FN-DSA draws a fresh salt).
+/// This mirrors AWS-LC's family-level `PQDSA.digest_len`. For ML-DSA the representative is
+/// `mu`, of length `ML_DSA_CRHBYTES` (64) for every parameter set. A future algorithm can
+/// only support this if its representative is a deterministic function of public inputs
+/// alone -- true for ML-DSA, but not for SLH-DSA (secret-keyed PRF) or FN-DSA (fresh salt).
 //
-// This is deliberately an exhaustive `match` with no wildcard arm. Every PQDSA algorithm
-// supported today is an ML-DSA parameter set, so there is no reachable `None` case; writing
-// it this way means adding an algorithm to `AlgorithmID` is a compile error here, forcing a
-// deliberate decision instead of silently claiming or denying support for it. The `Option`
-// is therefore always `Some` today, and is kept so that adding an algorithm that does not
-// support this is not a breaking change to every caller.
+// Deliberately an exhaustive `match` with no wildcard arm: adding an `AlgorithmID` is a
+// compile error here, forcing a decision instead of silently claiming or denying support.
+// The `Option` never escapes the public API; the `crate::ml_dsa` handles can only be
+// constructed for a supporting algorithm.
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) const fn external_representative_len(id: &AlgorithmID) -> Option<usize> {
     match id {
@@ -132,52 +119,88 @@ pub(crate) const fn external_representative_len(id: &AlgorithmID) -> Option<usiz
     }
 }
 
+/// An incremental SHAKE256 absorb/squeeze, the XOF underlying both `tr` and `mu`.
+#[derive(Clone)]
+struct Shake256 {
+    md_ctx: DigestContext,
+}
+
+impl Shake256 {
+    fn new() -> Result<Self, Unspecified> {
+        let mut md_ctx = DigestContext::new_uninit();
+        if 1 != unsafe { EVP_DigestInit_ex(md_ctx.as_mut_ptr(), EVP_shake256(), null_mut()) } {
+            return Err(Unspecified);
+        }
+        Ok(Self { md_ctx })
+    }
+
+    fn update(&mut self, data: &[u8]) -> Result<(), Unspecified> {
+        if 1 != unsafe {
+            EVP_DigestUpdate(self.md_ctx.as_mut_ptr(), data.as_ptr().cast(), data.len())
+        } {
+            return Err(Unspecified);
+        }
+        Ok(())
+    }
+
+    fn finish(mut self, output: &mut [u8]) -> Result<(), Unspecified> {
+        if 1 != unsafe {
+            EVP_DigestFinalXOF(self.md_ctx.as_mut_ptr(), output.as_mut_ptr(), output.len())
+        } {
+            return Err(Unspecified);
+        }
+        Ok(())
+    }
+}
+
 /// Computes `tr = SHAKE256(public_key, 64)`, the public key hash that binds `mu` to a
 /// specific key. `raw_public_key` must be the raw (not X.509) public key encoding.
 pub(crate) fn compute_tr(raw_public_key: &[u8]) -> Result<[u8; TR_LEN], Unspecified> {
     let mut tr = [0u8; TR_LEN];
-    shake256(&[raw_public_key], &mut tr)?;
+    let mut shake = Shake256::new()?;
+    shake.update(raw_public_key)?;
+    shake.finish(&mut tr)?;
     Ok(tr)
 }
 
-/// Computes `mu`, the FIPS 204 "message representative", from a precomputed `tr`, squeezing
-/// `mu.len()` bytes:
+/// An in-progress computation of `mu`, the FIPS 204 "message representative":
 ///
 /// ```text
-/// mu = SHAKE256(tr || 0x00 || len(context) || context || message, mu.len())
+/// mu = SHAKE256(tr || 0x00 || len(context) || context || message, mu_len)
 /// ```
 ///
 /// The `0x00` octet is the domain separator selecting "pure" ML-DSA (as opposed to
-/// HashML-DSA, which uses `0x01`).
-pub(crate) fn compute_mu(
-    tr: &[u8; TR_LEN],
-    context: &[u8],
-    message: &[u8],
-    mu: &mut [u8],
-) -> Result<(), Unspecified> {
-    // FIPS 204 limits the context string to 255 bytes, which is also what the single
-    // length octet below can encode.
-    let context_len = u8::try_from(context.len()).map_err(|_| Unspecified)?;
-
-    shake256(&[tr, &[0u8, context_len], context, message], mu)
+/// HashML-DSA, which uses `0x01`). Everything up to and including `context` is absorbed by
+/// [`Self::new`], so the message itself can be supplied incrementally.
+#[derive(Clone)]
+pub(crate) struct MuHasher {
+    shake: Shake256,
 }
 
-/// Absorbs each element of `inputs` in order and squeezes `output.len()` bytes.
-fn shake256(inputs: &[&[u8]], output: &mut [u8]) -> Result<(), Unspecified> {
-    let mut md_ctx = DigestContext::new_uninit();
-    if 1 != unsafe { EVP_DigestInit_ex(md_ctx.as_mut_ptr(), EVP_shake256(), null_mut()) } {
-        return Err(Unspecified);
+impl MuHasher {
+    /// Starts a `mu` computation from a precomputed `tr`, absorbing the domain separator and
+    /// the context string.
+    pub(crate) fn new(tr: &[u8; TR_LEN], context: &[u8]) -> Result<Self, Unspecified> {
+        // FIPS 204 limits the context string to 255 bytes, which is also what the single
+        // length octet below can encode.
+        let context_len = u8::try_from(context.len()).map_err(|_| Unspecified)?;
+
+        let mut shake = Shake256::new()?;
+        shake.update(tr)?;
+        shake.update(&[0u8, context_len])?;
+        shake.update(context)?;
+        Ok(Self { shake })
     }
-    for input in inputs {
-        if 1 != unsafe { EVP_DigestUpdate(md_ctx.as_mut_ptr(), input.as_ptr().cast(), input.len()) }
-        {
-            return Err(Unspecified);
-        }
+
+    /// Absorbs the next chunk of the message.
+    pub(crate) fn update(&mut self, data: &[u8]) -> Result<(), Unspecified> {
+        self.shake.update(data)
     }
-    if 1 != unsafe { EVP_DigestFinalXOF(md_ctx.as_mut_ptr(), output.as_mut_ptr(), output.len()) } {
-        return Err(Unspecified);
+
+    /// Squeezes `mu.len()` bytes, consuming the hasher.
+    pub(crate) fn finish(self, mu: &mut [u8]) -> Result<(), Unspecified> {
+        self.shake.finish(mu)
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -257,6 +257,10 @@ impl PqdsaKeyPair {
     pub fn private_key(&self) -> PqdsaPrivateKey<'_> {
         PqdsaPrivateKey(self)
     }
+
+    pub(crate) fn evp_pkey(&self) -> &LcPtr<EVP_PKEY> {
+        &self.evp_pkey
+    }
 }
 
 unsafe impl Send for PqdsaKeyPair {}

--- a/aws-lc-rs/src/pqdsa/key_pair.rs
+++ b/aws-lc-rs/src/pqdsa/key_pair.rs
@@ -17,6 +17,10 @@ use core::fmt::{Debug, Formatter};
 use std::ffi::c_int;
 
 /// A PQDSA (Post-Quantum Digital Signature Algorithm) key pair, used for signing and verification.
+///
+/// For ML-DSA keys, [`crate::ml_dsa`] additionally supports the FIPS 204 "external mu"
+/// variant, in which the message representative is derived separately from the signing
+/// operation.
 #[allow(clippy::module_name_repetitions)]
 pub struct PqdsaKeyPair {
     algorithm: &'static PqdsaSigningAlgorithm,

--- a/aws-lc-rs/src/pqdsa/signature.rs
+++ b/aws-lc-rs/src/pqdsa/signature.rs
@@ -48,6 +48,10 @@ impl PqdsaSigningAlgorithm {
     pub fn seed_len(&self) -> usize {
         self.0.id.seed_size_bytes()
     }
+
+    pub(crate) fn verification_algorithm(&self) -> &'static PqdsaVerificationAlgorithm {
+        self.0
+    }
 }
 
 /// A PQDSA public key.

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -255,7 +255,7 @@ impl KeyPair {
             }
         });
 
-        let sig_bytes = self.evp_pkey.sign_digest(digest.as_ref(), padding_fn)?;
+        let sig_bytes = self.evp_pkey.sign_digest(digest.into(), padding_fn)?;
 
         signature.copy_from_slice(&sig_bytes);
         Ok(())

--- a/aws-lc-rs/src/rsa/key.rs
+++ b/aws-lc-rs/src/rsa/key.rs
@@ -255,7 +255,7 @@ impl KeyPair {
             }
         });
 
-        let sig_bytes = self.evp_pkey.sign_digest(digest, padding_fn)?;
+        let sig_bytes = self.evp_pkey.sign_digest(digest.as_ref(), padding_fn)?;
 
         signature.copy_from_slice(&sig_bytes);
         Ok(())

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -317,5 +317,5 @@ pub(crate) fn verify_rsa_digest_signature(
         }
     });
 
-    public_key.verify_digest_sig(digest, padding_fn, signature)
+    public_key.verify_digest_sig(digest.as_ref(), padding_fn, signature)
 }

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -317,5 +317,5 @@ pub(crate) fn verify_rsa_digest_signature(
         }
     });
 
-    public_key.verify_digest_sig(digest.as_ref(), padding_fn, signature)
+    public_key.verify_digest_sig(digest.into(), padding_fn, signature)
 }

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -515,6 +515,22 @@ impl ParsedPublicKey {
         &self.key
     }
 
+    /// Returns the `PqdsaVerificationAlgorithm` this key was parsed under, or `None` if the
+    /// key is not a PQDSA key.
+    pub(crate) fn pqdsa_verification_algorithm(
+        &self,
+    ) -> Option<&'static PqdsaVerificationAlgorithm> {
+        if self.algorithm.type_id() != TypeId::of::<PqdsaVerificationAlgorithm>() {
+            return None;
+        }
+        // Same downcast as `parse_public_key` performs when selecting the parse routine.
+        #[allow(clippy::cast_ptr_alignment)]
+        Some(unsafe {
+            &*(self.algorithm as *const dyn VerificationAlgorithm)
+                .cast::<PqdsaVerificationAlgorithm>()
+        })
+    }
+
     /// Constructs a `ParsedPublicKey` directly from an already-built RSA
     /// `EVP_PKEY`, skipping the DER-encode / DER-decode round-trip that
     /// [`parse_public_key`] would otherwise perform. The SubjectPublicKeyInfo

--- a/aws-lc-rs/src/signature.rs
+++ b/aws-lc-rs/src/signature.rs
@@ -28,6 +28,12 @@
 //! the caller the responsibility of ensuring the digest really is the hash of
 //! the intended message.
 //!
+//! ML-DSA does not participate in that flow, because what it signs is not a hash
+//! of the message alone: it is a key-dependent representative `mu` derived from
+//! both the public key and the message, so a [`Digest`] cannot express it. The
+//! equivalent for ML-DSA is the "external mu" variant in [`crate::ml_dsa`],
+//! which also supports deriving `mu` incrementally over a streamed message.
+//!
 //! This module is optimized for signing messages that are available in full,
 //! rather than streaming or incrementally-hashed large messages.
 //!

--- a/aws-lc-rs/tests/ml_dsa_external_mu_test.rs
+++ b/aws-lc-rs/tests/ml_dsa_external_mu_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use aws_lc_rs::encoding::AsDer;
-use aws_lc_rs::ml_dsa::{external_mu_len, ExternalMu, ExternalMuSigner, ExternalMuVerifier};
+use aws_lc_rs::ml_dsa::{ExternalMu, ExternalMuSigner, ExternalMuVerifier, MuContext, MU_LEN};
 use aws_lc_rs::signature::{
     KeyPair, ParsedPublicKey, PqdsaKeyPair, PqdsaSigningAlgorithm, PqdsaVerificationAlgorithm,
     UnparsedPublicKey, ED25519, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING,
@@ -32,20 +32,26 @@ macro_rules! mldsa_external_mu_sigver_test {
 
             // These vectors are pure-mode signatures, which this crate only produces and
             // verifies with an empty context string. A vector with a context could not be
-            // expected to match a `mu` derived with an empty context.
+            // expected to match a `mu` derived with an empty context, so fail loudly rather
+            // than silently skipping if one is ever added to the file.
             assert!(
                 context.is_empty(),
                 "external-mu equivalence assumes an empty context string"
             );
 
             let parsed = ParsedPublicKey::new($verification, public_key.as_slice()).unwrap();
-            let verifier = ExternalMuVerifier::try_from(&parsed).unwrap();
+            let verifier = ExternalMuVerifier::new(&parsed).unwrap();
             let mu = verifier.compute_mu(message.as_ref()).unwrap();
 
             assert_eq!(
                 verifier.verify(&mu, signature.as_ref()).is_ok(),
                 expected_result
             );
+
+            // The streaming derivation must agree with the one-shot one.
+            let mut context = MuContext::new(&parsed).unwrap();
+            context.update(message.as_ref()).unwrap();
+            assert_eq!(context.finish().unwrap().as_ref(), mu.as_ref());
             Ok(())
         });
     };
@@ -73,8 +79,8 @@ fn signer_and_verifier(
     let key_pair = PqdsaKeyPair::generate(signing_alg).expect("keygen");
     let parsed =
         ParsedPublicKey::new(verify_alg, key_pair.public_key().as_ref()).expect("parse public key");
-    let signer = ExternalMuSigner::try_from(&key_pair).expect("signer");
-    let verifier = ExternalMuVerifier::try_from(&parsed).expect("verifier");
+    let signer = ExternalMuSigner::new(&key_pair).expect("signer");
+    let verifier = ExternalMuVerifier::new(&parsed).expect("verifier");
     (key_pair, signer, verifier)
 }
 
@@ -84,12 +90,13 @@ fn test_external_mu_round_trip() {
         let (_key_pair, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
         let message = b"external mu round trip";
 
-        // Signer and verifier derive the same mu.
-        let mu = signer.compute_mu(message).expect("signer compute_mu");
-        let mu_verifier = verifier.compute_mu(message).expect("verifier compute_mu");
-        assert_eq!(mu.as_ref(), mu_verifier.as_ref());
-        assert_eq!(Some(mu.as_ref().len()), external_mu_len(verify_alg));
-        assert!(mu.as_ref().len() <= ExternalMu::MAX_LEN);
+        // Streaming and one-shot derivations agree, and mu has the documented shape.
+        let mut context = verifier.mu_context().expect("context");
+        context.update(message).expect("update");
+        let mu = context.finish().expect("finish");
+        let mu_one_shot = verifier.compute_mu(message).expect("verifier compute_mu");
+        assert_eq!(mu.as_ref(), mu_one_shot.as_ref());
+        assert_eq!(mu.as_ref().len(), MU_LEN);
         assert_eq!(mu.algorithm(), verify_alg);
 
         let mut signature = vec![0u8; signing_alg.signature_len()];
@@ -98,7 +105,7 @@ fn test_external_mu_round_trip() {
         verifier.verify(&mu, &signature).expect("verify");
 
         // A different message yields a different mu, which the signature does not match.
-        let other_mu = signer
+        let other_mu = verifier
             .compute_mu(b"a different message")
             .expect("compute_mu");
         assert_ne!(mu.as_ref(), other_mu.as_ref());
@@ -107,11 +114,80 @@ fn test_external_mu_round_trip() {
 }
 
 #[test]
+fn test_external_mu_streaming_matches_one_shot() {
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (key_pair, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
+        let parsed = ParsedPublicKey::new(verify_alg, key_pair.public_key().as_ref()).unwrap();
+        let message: Vec<u8> = (0..1000u32).map(|i| (i % 251) as u8).collect();
+        let expected = verifier.compute_mu(&message).expect("one-shot");
+
+        // Chunked in a variety of ways, from both entry points.
+        for chunk_size in [1, 7, 64, 333, 1000, 4096] {
+            for mut context in [
+                MuContext::new(&parsed).expect("from public key"),
+                verifier.mu_context().expect("from verifier"),
+            ] {
+                for chunk in message.chunks(chunk_size) {
+                    context.update(chunk).expect("update");
+                }
+                assert_eq!(
+                    context.finish().expect("finish").as_ref(),
+                    expected.as_ref(),
+                    "chunk size {chunk_size}"
+                );
+            }
+        }
+
+        // Zero updates is the empty message, and matches the one-shot over an empty slice.
+        let context = MuContext::new(&parsed).expect("context");
+        assert_eq!(context.algorithm(), verify_alg);
+        assert_eq!(
+            context.finish().expect("finish").as_ref(),
+            verifier.compute_mu(b"").expect("empty one-shot").as_ref()
+        );
+
+        // A streamed mu is a fully-fledged mu: it signs and verifies.
+        let mut context = MuContext::new(&parsed).expect("context");
+        context.update(&message).expect("update");
+        let mu = context.finish().expect("finish");
+        let mut signature = vec![0u8; signing_alg.signature_len()];
+        signer.sign(&mu, &mut signature).expect("sign");
+        verifier.verify(&mu, &signature).expect("verify");
+        UnparsedPublicKey::new(verify_alg, key_pair.public_key().as_ref())
+            .verify(&message, &signature)
+            .expect("streamed-mu signature should verify in pure mode");
+    }
+}
+
+#[test]
+fn test_mu_context_clone_forks_state() {
+    let (_key_pair, _, verifier) = signer_and_verifier(&ML_DSA_44_SIGNING, &ML_DSA_44);
+    let mut context = verifier.mu_context().expect("context");
+    context.update(b"common prefix").expect("update");
+
+    let mut fork = context.clone();
+    context.update(b"-a").expect("update");
+    fork.update(b"-b").expect("update");
+
+    let mu_a = context.finish().expect("finish");
+    let mu_b = fork.finish().expect("finish");
+    assert_ne!(mu_a.as_ref(), mu_b.as_ref());
+    assert_eq!(
+        mu_a.as_ref(),
+        verifier.compute_mu(b"common prefix-a").unwrap().as_ref()
+    );
+    assert_eq!(
+        mu_b.as_ref(),
+        verifier.compute_mu(b"common prefix-b").unwrap().as_ref()
+    );
+}
+
+#[test]
 fn test_external_mu_interchangeable_with_pure_mode() {
     for &(signing_alg, verify_alg) in ALGORITHMS {
         let (key_pair, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
         let message = b"interchangeable with pure mode";
-        let mu = signer.compute_mu(message).expect("compute_mu");
+        let mu = verifier.compute_mu(message).expect("compute_mu");
 
         // An external-mu signature verifies as an ordinary ML-DSA signature over the message.
         let mut external_sig = vec![0u8; signing_alg.signature_len()];
@@ -135,17 +211,21 @@ fn test_external_mu_binds_to_public_key() {
     // produce different mu values for the same message, and signatures do not cross over.
     for &(signing_alg, verify_alg) in ALGORITHMS {
         let (_, signer_a, verifier_a) = signer_and_verifier(signing_alg, verify_alg);
-        let (_, signer_b, verifier_b) = signer_and_verifier(signing_alg, verify_alg);
+        let (_, _, verifier_b) = signer_and_verifier(signing_alg, verify_alg);
         let message = b"bound to the public key";
 
-        let mu_a = signer_a.compute_mu(message).expect("compute_mu");
-        let mu_b = signer_b.compute_mu(message).expect("compute_mu");
+        let mu_a = verifier_a.compute_mu(message).expect("compute_mu");
+        let mu_b = verifier_b.compute_mu(message).expect("compute_mu");
         assert_ne!(mu_a.as_ref(), mu_b.as_ref());
 
         let mut sig_a = vec![0u8; signing_alg.signature_len()];
         signer_a.sign(&mu_a, &mut sig_a).expect("sign");
         verifier_a.verify(&mu_a, &sig_a).expect("verify");
         assert!(verifier_b.verify(&mu_b, &sig_a).is_err());
+
+        // A mu derived under a different key of the same parameter set is caught up front,
+        // rather than silently producing a signature that verifies under no key at all.
+        assert!(signer_a.sign(&mu_b, &mut sig_a).is_err());
         assert!(verifier_a.verify(&mu_b, &sig_a).is_err());
     }
 }
@@ -154,7 +234,7 @@ fn test_external_mu_binds_to_public_key() {
 fn test_external_mu_import_less_safe() {
     for &(signing_alg, verify_alg) in ALGORITHMS {
         let (_, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
-        let mu = signer.compute_mu(b"imported").expect("compute_mu");
+        let mu = verifier.compute_mu(b"imported").expect("compute_mu");
 
         // Round trip through raw bytes.
         let imported = ExternalMu::import_less_safe(mu.as_ref(), verify_alg).expect("import");
@@ -165,9 +245,8 @@ fn test_external_mu_import_less_safe() {
         signer.sign(&imported, &mut signature).expect("sign");
         verifier.verify(&imported, &signature).expect("verify");
 
-        // Only exactly the algorithm's mu length is accepted.
-        let expected_len = external_mu_len(verify_alg).expect("ML-DSA supports external mu");
-        for bad_len in [0, 1, 32, expected_len - 1, expected_len + 1, 128] {
+        // Only exactly MU_LEN bytes are accepted.
+        for bad_len in [0, 1, 32, MU_LEN - 1, MU_LEN + 1, 128] {
             assert!(
                 ExternalMu::import_less_safe(&vec![0u8; bad_len], verify_alg).is_err(),
                 "{bad_len} bytes should be rejected"
@@ -183,14 +262,70 @@ fn test_external_mu_import_less_safe() {
 }
 
 #[test]
+fn test_imported_mu_is_not_key_bound() {
+    // Importing discards the provenance that lets sign/verify reject a mu belonging to
+    // another key of the same parameter set. That is the "less safe" in the name.
+    //
+    // Note carefully what the resulting signature is and is not. External-mu verification
+    // takes mu on faith -- it does not re-derive it -- so the verifier for key A accepts the
+    // signature against the mismatched mu. But it is not a valid signature over the original
+    // message under either key, so nothing outside this one pairing accepts it. That is
+    // exactly the blind-signing hazard `import_less_safe` warns about, and the reason a
+    // derived mu carries its key binding.
+    let message = b"cross key";
+    let key_pair_a = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).expect("keygen");
+    let key_pair_b = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).expect("keygen");
+    let parsed_a =
+        ParsedPublicKey::new(&ML_DSA_44, key_pair_a.public_key().as_ref()).expect("parse");
+    let signer_a = ExternalMuSigner::new(&key_pair_a).expect("signer");
+    let verifier_a = ExternalMuVerifier::new(&parsed_a).expect("verifier");
+    let parsed_b =
+        ParsedPublicKey::new(&ML_DSA_44, key_pair_b.public_key().as_ref()).expect("parse");
+    let mut context_b = MuContext::new(&parsed_b).expect("context");
+    context_b.update(message).expect("update");
+    let mu_b = context_b.finish().expect("finish");
+
+    let mut sig = vec![0u8; ML_DSA_44_SIGNING.signature_len()];
+    assert!(
+        signer_a.sign(&mu_b, &mut sig).is_err(),
+        "a derived mu is key-bound"
+    );
+
+    let imported = ExternalMu::import_less_safe(mu_b.as_ref(), &ML_DSA_44).expect("import");
+    let len = signer_a
+        .sign(&imported, &mut sig)
+        .expect("an imported mu is not key-bound");
+    let sig = &sig[..len];
+
+    // External-mu verification does not re-derive mu, so this pairing is accepted.
+    verifier_a
+        .verify(&imported, sig)
+        .expect("mu taken on faith");
+
+    // It is not a signature over the message under either key.
+    for public_key in [key_pair_a.public_key(), key_pair_b.public_key()] {
+        assert!(
+            UnparsedPublicKey::new(&ML_DSA_44, public_key.as_ref())
+                .verify(message, sig)
+                .is_err(),
+            "not a valid signature over the message"
+        );
+    }
+    // Nor against the mu that key A would actually derive for that message.
+    assert!(verifier_a
+        .verify(&verifier_a.compute_mu(message).unwrap(), sig)
+        .is_err());
+}
+
+#[test]
 fn test_external_mu_algorithm_mismatch_rejected() {
     // A mu computed for one parameter set is meaningless for another; both sign and verify
     // reject it rather than silently operating on the wrong representative.
     let (_, signer_44, verifier_44) = signer_and_verifier(&ML_DSA_44_SIGNING, &ML_DSA_44);
     let (_, signer_65, verifier_65) = signer_and_verifier(&ML_DSA_65_SIGNING, &ML_DSA_65);
 
-    let mu_44 = signer_44.compute_mu(b"mismatch").expect("compute_mu");
-    let mu_65 = signer_65.compute_mu(b"mismatch").expect("compute_mu");
+    let mu_44 = verifier_44.compute_mu(b"mismatch").expect("compute_mu");
+    let mu_65 = verifier_65.compute_mu(b"mismatch").expect("compute_mu");
 
     let mut sig = vec![0u8; ML_DSA_87_SIGNING.signature_len()];
     assert!(signer_44.sign(&mu_65, &mut sig).is_err());
@@ -199,13 +334,19 @@ fn test_external_mu_algorithm_mismatch_rejected() {
     let len = signer_44.sign(&mu_44, &mut sig).expect("sign");
     assert!(verifier_65.verify(&mu_44, &sig[..len]).is_err());
     assert!(verifier_44.verify(&mu_65, &sig[..len]).is_err());
+
+    // Importing under the wrong parameter set is also rejected, even though every ML-DSA
+    // parameter set uses the same mu length.
+    let imported = ExternalMu::import_less_safe(mu_44.as_ref(), &ML_DSA_65).expect("import");
+    assert!(signer_44.sign(&imported, &mut sig).is_err());
+    assert!(verifier_44.verify(&imported, &sig[..len]).is_err());
 }
 
 #[test]
 fn test_external_mu_signature_buffer_too_small() {
     for &(signing_alg, verify_alg) in ALGORITHMS {
-        let (_, signer, _) = signer_and_verifier(signing_alg, verify_alg);
-        let mu = signer.compute_mu(b"short buffer").expect("compute_mu");
+        let (_, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
+        let mu = verifier.compute_mu(b"short buffer").expect("compute_mu");
 
         let mut too_small = vec![0u8; signing_alg.signature_len() - 1];
         assert!(signer.sign(&mu, &mut too_small).is_err());
@@ -221,14 +362,16 @@ fn test_external_mu_signature_buffer_too_small() {
 fn test_external_mu_verifier_accepts_x509_public_key() {
     for &(signing_alg, verify_alg) in ALGORITHMS {
         let key_pair = PqdsaKeyPair::generate(signing_alg).expect("keygen");
-        let signer = ExternalMuSigner::try_from(&key_pair).expect("signer");
+        let signer = ExternalMuSigner::new(&key_pair).expect("signer");
 
         let raw = ParsedPublicKey::new(verify_alg, key_pair.public_key().as_ref()).expect("parse");
         let x509 = AsDer::<aws_lc_rs::encoding::PublicKeyX509Der>::as_der(&raw).expect("as_der");
         let parsed_x509 = ParsedPublicKey::new(verify_alg, x509.as_ref()).expect("parse x509");
 
-        let verifier = ExternalMuVerifier::try_from(&parsed_x509).expect("verifier");
-        let mu = signer.compute_mu(b"x509 encoded key").expect("compute_mu");
+        let verifier = ExternalMuVerifier::new(&parsed_x509).expect("verifier");
+        let mut context = MuContext::new(&raw).expect("context from raw key");
+        context.update(b"x509 encoded key").expect("update");
+        let mu = context.finish().expect("finish");
         assert_eq!(
             mu.as_ref(),
             verifier.compute_mu(b"x509 encoded key").unwrap().as_ref(),
@@ -242,13 +385,83 @@ fn test_external_mu_verifier_accepts_x509_public_key() {
 }
 
 #[test]
-fn test_external_mu_verifier_rejects_non_ml_dsa_key() {
+fn test_external_mu_rejects_non_ml_dsa_key() {
+    // There is deliberately no `ExternalMuSigner` counterpart to this test: every PQDSA
+    // algorithm this crate supports is an ML-DSA parameter set, so a non-ML-DSA
+    // `PqdsaKeyPair` cannot be constructed. `ExternalMuSigner::new` still performs the
+    // check, and `pqdsa::external_representative_len` is an exhaustive match, so adding an
+    // algorithm forces the question to be answered there.
     let ed25519 = ParsedPublicKey::new(
         &ED25519,
         include_bytes!("data/ed25519_test_public_key.bin").as_slice(),
     )
     .expect("parse ed25519 key");
+
+    let err = ExternalMuVerifier::new(&ed25519).expect_err("ed25519 is not ML-DSA");
+    assert_eq!(err.description_(), "WrongAlgorithm");
+    assert_eq!(
+        MuContext::new(&ed25519)
+            .expect_err("ed25519 is not ML-DSA")
+            .description_(),
+        "WrongAlgorithm"
+    );
     assert!(ExternalMuVerifier::try_from(&ed25519).is_err());
+}
+
+#[test]
+fn test_external_mu_signer_outlives_key_pair() {
+    // `ExternalMuSigner` holds its own counted reference to the signing key, as documented.
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (signer, public_key_bytes) = {
+            let key_pair = PqdsaKeyPair::generate(signing_alg).expect("keygen");
+            let public_key_bytes = key_pair.public_key().as_ref().to_vec();
+            (
+                ExternalMuSigner::new(&key_pair).expect("signer"),
+                public_key_bytes,
+            )
+        };
+
+        let parsed = ParsedPublicKey::new(verify_alg, public_key_bytes.as_slice()).expect("parse");
+        let verifier = ExternalMuVerifier::new(&parsed).expect("verifier");
+        let mu = verifier.compute_mu(b"after drop").expect("compute_mu");
+        let mut signature = vec![0u8; signing_alg.signature_len()];
+        signer.sign(&mu, &mut signature).expect("sign");
+        verifier.verify(&mu, &signature).expect("verify");
+    }
+}
+
+#[test]
+fn test_try_from_matches_new() {
+    let key_pair = PqdsaKeyPair::generate(&ML_DSA_65_SIGNING).expect("keygen");
+    let parsed =
+        ParsedPublicKey::new(&ML_DSA_65, key_pair.public_key().as_ref()).expect("parse public key");
+
+    let signer = ExternalMuSigner::try_from(&key_pair).expect("signer");
+    let verifier = ExternalMuVerifier::try_from(&parsed).expect("verifier");
+    let mu = verifier.compute_mu(b"try_from").expect("compute_mu");
+    assert_eq!(
+        mu.as_ref(),
+        ExternalMuVerifier::new(&parsed)
+            .unwrap()
+            .compute_mu(b"try_from")
+            .unwrap()
+            .as_ref()
+    );
+
+    let mut signature = vec![0u8; ML_DSA_65_SIGNING.signature_len()];
+    signer.sign(&mu, &mut signature).expect("sign");
+    verifier.verify(&mu, &signature).expect("verify");
+}
+
+#[test]
+fn test_external_mu_types_are_send_and_sync() {
+    // All three handles carry hand-written `unsafe impl Send`/`Sync` or rely on auto traits
+    // through a raw-pointer-holding field, so pin the property down.
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ExternalMu>();
+    assert_send_sync::<MuContext>();
+    assert_send_sync::<ExternalMuSigner>();
+    assert_send_sync::<ExternalMuVerifier>();
 }
 
 #[test]
@@ -257,13 +470,10 @@ fn test_external_mu_accessors_and_debug() {
     assert_eq!(signer.algorithm(), &ML_DSA_65_SIGNING);
     assert_eq!(verifier.algorithm(), &ML_DSA_65);
 
-    // Every ML-DSA parameter set uses a 64-byte mu, which is also the current maximum.
-    assert_eq!(ExternalMu::MAX_LEN, 64);
-    for alg in [&ML_DSA_44, &ML_DSA_65, &ML_DSA_87] {
-        assert_eq!(external_mu_len(alg), Some(64));
-    }
+    // FIPS 204 fixes mu at 64 bytes for every ML-DSA parameter set.
+    assert_eq!(MU_LEN, 64);
 
-    let mu = signer.compute_mu(b"debug").expect("compute_mu");
+    let mu = verifier.compute_mu(b"debug").expect("compute_mu");
     let mu_debug = format!("{mu:?}");
     assert!(mu_debug.contains("ExternalMu"));
     assert!(mu_debug.contains("ML_DSA_65"));
@@ -272,6 +482,7 @@ fn test_external_mu_accessors_and_debug() {
 
     assert!(format!("{signer:?}").contains("ExternalMuSigner"));
     assert!(format!("{verifier:?}").contains("ExternalMuVerifier"));
+    assert!(format!("{:?}", verifier.mu_context().unwrap()).contains("MuContext"));
 
     // Copy/Clone
     let copied = mu;

--- a/aws-lc-rs/tests/ml_dsa_external_mu_test.rs
+++ b/aws-lc-rs/tests/ml_dsa_external_mu_test.rs
@@ -1,0 +1,279 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+use aws_lc_rs::encoding::AsDer;
+use aws_lc_rs::ml_dsa::{external_mu_len, ExternalMu, ExternalMuSigner, ExternalMuVerifier};
+use aws_lc_rs::signature::{
+    KeyPair, ParsedPublicKey, PqdsaKeyPair, PqdsaSigningAlgorithm, PqdsaVerificationAlgorithm,
+    UnparsedPublicKey, ED25519, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING,
+    ML_DSA_87, ML_DSA_87_SIGNING,
+};
+use aws_lc_rs::{test, test_file};
+
+const ALGORITHMS: &[(&PqdsaSigningAlgorithm, &PqdsaVerificationAlgorithm)] = &[
+    (&ML_DSA_44_SIGNING, &ML_DSA_44),
+    (&ML_DSA_65_SIGNING, &ML_DSA_65),
+    (&ML_DSA_87_SIGNING, &ML_DSA_87),
+];
+
+/// Pins this crate's `mu` derivation against AWS-LC's internal one, using known-good
+/// signatures produced over the message (not over `mu`). If the SHAKE256 composition,
+/// the `tr` binding, or the pure-mode domain separator were wrong, `mu` would differ
+/// from what AWS-LC computes internally and these verifications would fail.
+macro_rules! mldsa_external_mu_sigver_test {
+    ($file:literal, $verification:expr) => {
+        test::run(test_file!($file), |section, test_case| {
+            assert_eq!(section, "");
+            let public_key = test_case.consume_bytes("PUBLIC");
+            let message = test_case.consume_bytes("MESSAGE");
+            let signature = test_case.consume_bytes("SIGNATURE");
+            let context = test_case.consume_bytes("CONTEXT");
+            let expected_result = test_case.consume_bool("RESULT");
+
+            // These vectors are pure-mode signatures, which this crate only produces and
+            // verifies with an empty context string. A vector with a context could not be
+            // expected to match a `mu` derived with an empty context.
+            assert!(
+                context.is_empty(),
+                "external-mu equivalence assumes an empty context string"
+            );
+
+            let parsed = ParsedPublicKey::new($verification, public_key.as_slice()).unwrap();
+            let verifier = ExternalMuVerifier::try_from(&parsed).unwrap();
+            let mu = verifier.compute_mu(message.as_ref()).unwrap();
+
+            assert_eq!(
+                verifier.verify(&mu, signature.as_ref()).is_ok(),
+                expected_result
+            );
+            Ok(())
+        });
+    };
+}
+
+#[test]
+fn mldsa_44_external_mu_sigver_test() {
+    mldsa_external_mu_sigver_test!("data/MLDSA_44_sigVer.txt", &ML_DSA_44);
+}
+
+#[test]
+fn mldsa_65_external_mu_sigver_test() {
+    mldsa_external_mu_sigver_test!("data/MLDSA_65_sigVer.txt", &ML_DSA_65);
+}
+
+#[test]
+fn mldsa_87_external_mu_sigver_test() {
+    mldsa_external_mu_sigver_test!("data/MLDSA_87_sigVer.txt", &ML_DSA_87);
+}
+
+fn signer_and_verifier(
+    signing_alg: &'static PqdsaSigningAlgorithm,
+    verify_alg: &'static PqdsaVerificationAlgorithm,
+) -> (PqdsaKeyPair, ExternalMuSigner, ExternalMuVerifier) {
+    let key_pair = PqdsaKeyPair::generate(signing_alg).expect("keygen");
+    let parsed =
+        ParsedPublicKey::new(verify_alg, key_pair.public_key().as_ref()).expect("parse public key");
+    let signer = ExternalMuSigner::try_from(&key_pair).expect("signer");
+    let verifier = ExternalMuVerifier::try_from(&parsed).expect("verifier");
+    (key_pair, signer, verifier)
+}
+
+#[test]
+fn test_external_mu_round_trip() {
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (_key_pair, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
+        let message = b"external mu round trip";
+
+        // Signer and verifier derive the same mu.
+        let mu = signer.compute_mu(message).expect("signer compute_mu");
+        let mu_verifier = verifier.compute_mu(message).expect("verifier compute_mu");
+        assert_eq!(mu.as_ref(), mu_verifier.as_ref());
+        assert_eq!(Some(mu.as_ref().len()), external_mu_len(verify_alg));
+        assert!(mu.as_ref().len() <= ExternalMu::MAX_LEN);
+        assert_eq!(mu.algorithm(), verify_alg);
+
+        let mut signature = vec![0u8; signing_alg.signature_len()];
+        let len = signer.sign(&mu, &mut signature).expect("sign");
+        assert_eq!(len, signing_alg.signature_len());
+        verifier.verify(&mu, &signature).expect("verify");
+
+        // A different message yields a different mu, which the signature does not match.
+        let other_mu = signer
+            .compute_mu(b"a different message")
+            .expect("compute_mu");
+        assert_ne!(mu.as_ref(), other_mu.as_ref());
+        assert!(verifier.verify(&other_mu, &signature).is_err());
+    }
+}
+
+#[test]
+fn test_external_mu_interchangeable_with_pure_mode() {
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (key_pair, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
+        let message = b"interchangeable with pure mode";
+        let mu = signer.compute_mu(message).expect("compute_mu");
+
+        // An external-mu signature verifies as an ordinary ML-DSA signature over the message.
+        let mut external_sig = vec![0u8; signing_alg.signature_len()];
+        signer.sign(&mu, &mut external_sig).expect("sign");
+        UnparsedPublicKey::new(verify_alg, key_pair.public_key().as_ref())
+            .verify(message, &external_sig)
+            .expect("external-mu signature should verify in pure mode");
+
+        // ...and an ordinary ML-DSA signature verifies against the externally derived mu.
+        let mut pure_sig = vec![0u8; signing_alg.signature_len()];
+        key_pair.sign(message, &mut pure_sig).expect("pure sign");
+        verifier
+            .verify(&mu, &pure_sig)
+            .expect("pure-mode signature should verify against external mu");
+    }
+}
+
+#[test]
+fn test_external_mu_binds_to_public_key() {
+    // mu incorporates tr = SHAKE256(public_key), so two keys of the same parameter set
+    // produce different mu values for the same message, and signatures do not cross over.
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (_, signer_a, verifier_a) = signer_and_verifier(signing_alg, verify_alg);
+        let (_, signer_b, verifier_b) = signer_and_verifier(signing_alg, verify_alg);
+        let message = b"bound to the public key";
+
+        let mu_a = signer_a.compute_mu(message).expect("compute_mu");
+        let mu_b = signer_b.compute_mu(message).expect("compute_mu");
+        assert_ne!(mu_a.as_ref(), mu_b.as_ref());
+
+        let mut sig_a = vec![0u8; signing_alg.signature_len()];
+        signer_a.sign(&mu_a, &mut sig_a).expect("sign");
+        verifier_a.verify(&mu_a, &sig_a).expect("verify");
+        assert!(verifier_b.verify(&mu_b, &sig_a).is_err());
+        assert!(verifier_a.verify(&mu_b, &sig_a).is_err());
+    }
+}
+
+#[test]
+fn test_external_mu_import_less_safe() {
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (_, signer, verifier) = signer_and_verifier(signing_alg, verify_alg);
+        let mu = signer.compute_mu(b"imported").expect("compute_mu");
+
+        // Round trip through raw bytes.
+        let imported = ExternalMu::import_less_safe(mu.as_ref(), verify_alg).expect("import");
+        assert_eq!(imported.as_ref(), mu.as_ref());
+        assert_eq!(imported.algorithm(), verify_alg);
+
+        let mut signature = vec![0u8; signing_alg.signature_len()];
+        signer.sign(&imported, &mut signature).expect("sign");
+        verifier.verify(&imported, &signature).expect("verify");
+
+        // Only exactly the algorithm's mu length is accepted.
+        let expected_len = external_mu_len(verify_alg).expect("ML-DSA supports external mu");
+        for bad_len in [0, 1, 32, expected_len - 1, expected_len + 1, 128] {
+            assert!(
+                ExternalMu::import_less_safe(&vec![0u8; bad_len], verify_alg).is_err(),
+                "{bad_len} bytes should be rejected"
+            );
+        }
+
+        // A tampered mu fails verification.
+        let mut tampered = mu.as_ref().to_vec();
+        tampered[0] ^= 0x01;
+        let tampered = ExternalMu::import_less_safe(&tampered, verify_alg).expect("import");
+        assert!(verifier.verify(&tampered, &signature).is_err());
+    }
+}
+
+#[test]
+fn test_external_mu_algorithm_mismatch_rejected() {
+    // A mu computed for one parameter set is meaningless for another; both sign and verify
+    // reject it rather than silently operating on the wrong representative.
+    let (_, signer_44, verifier_44) = signer_and_verifier(&ML_DSA_44_SIGNING, &ML_DSA_44);
+    let (_, signer_65, verifier_65) = signer_and_verifier(&ML_DSA_65_SIGNING, &ML_DSA_65);
+
+    let mu_44 = signer_44.compute_mu(b"mismatch").expect("compute_mu");
+    let mu_65 = signer_65.compute_mu(b"mismatch").expect("compute_mu");
+
+    let mut sig = vec![0u8; ML_DSA_87_SIGNING.signature_len()];
+    assert!(signer_44.sign(&mu_65, &mut sig).is_err());
+    assert!(signer_65.sign(&mu_44, &mut sig).is_err());
+
+    let len = signer_44.sign(&mu_44, &mut sig).expect("sign");
+    assert!(verifier_65.verify(&mu_44, &sig[..len]).is_err());
+    assert!(verifier_44.verify(&mu_65, &sig[..len]).is_err());
+}
+
+#[test]
+fn test_external_mu_signature_buffer_too_small() {
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let (_, signer, _) = signer_and_verifier(signing_alg, verify_alg);
+        let mu = signer.compute_mu(b"short buffer").expect("compute_mu");
+
+        let mut too_small = vec![0u8; signing_alg.signature_len() - 1];
+        assert!(signer.sign(&mu, &mut too_small).is_err());
+
+        // An oversized buffer is fine; only signature_len bytes are written.
+        let mut oversized = vec![0u8; signing_alg.signature_len() + 64];
+        let len = signer.sign(&mu, &mut oversized).expect("sign");
+        assert_eq!(len, signing_alg.signature_len());
+    }
+}
+
+#[test]
+fn test_external_mu_verifier_accepts_x509_public_key() {
+    for &(signing_alg, verify_alg) in ALGORITHMS {
+        let key_pair = PqdsaKeyPair::generate(signing_alg).expect("keygen");
+        let signer = ExternalMuSigner::try_from(&key_pair).expect("signer");
+
+        let raw = ParsedPublicKey::new(verify_alg, key_pair.public_key().as_ref()).expect("parse");
+        let x509 = AsDer::<aws_lc_rs::encoding::PublicKeyX509Der>::as_der(&raw).expect("as_der");
+        let parsed_x509 = ParsedPublicKey::new(verify_alg, x509.as_ref()).expect("parse x509");
+
+        let verifier = ExternalMuVerifier::try_from(&parsed_x509).expect("verifier");
+        let mu = signer.compute_mu(b"x509 encoded key").expect("compute_mu");
+        assert_eq!(
+            mu.as_ref(),
+            verifier.compute_mu(b"x509 encoded key").unwrap().as_ref(),
+            "mu must be derived from the raw public key regardless of input encoding"
+        );
+
+        let mut signature = vec![0u8; signing_alg.signature_len()];
+        signer.sign(&mu, &mut signature).expect("sign");
+        verifier.verify(&mu, &signature).expect("verify");
+    }
+}
+
+#[test]
+fn test_external_mu_verifier_rejects_non_ml_dsa_key() {
+    let ed25519 = ParsedPublicKey::new(
+        &ED25519,
+        include_bytes!("data/ed25519_test_public_key.bin").as_slice(),
+    )
+    .expect("parse ed25519 key");
+    assert!(ExternalMuVerifier::try_from(&ed25519).is_err());
+}
+
+#[test]
+fn test_external_mu_accessors_and_debug() {
+    let (_, signer, verifier) = signer_and_verifier(&ML_DSA_65_SIGNING, &ML_DSA_65);
+    assert_eq!(signer.algorithm(), &ML_DSA_65_SIGNING);
+    assert_eq!(verifier.algorithm(), &ML_DSA_65);
+
+    // Every ML-DSA parameter set uses a 64-byte mu, which is also the current maximum.
+    assert_eq!(ExternalMu::MAX_LEN, 64);
+    for alg in [&ML_DSA_44, &ML_DSA_65, &ML_DSA_87] {
+        assert_eq!(external_mu_len(alg), Some(64));
+    }
+
+    let mu = signer.compute_mu(b"debug").expect("compute_mu");
+    let mu_debug = format!("{mu:?}");
+    assert!(mu_debug.contains("ExternalMu"));
+    assert!(mu_debug.contains("ML_DSA_65"));
+    // The Debug output renders mu as hex.
+    assert!(mu_debug.contains(&aws_lc_rs::test::to_hex(mu.as_ref())));
+
+    assert!(format!("{signer:?}").contains("ExternalMuSigner"));
+    assert!(format!("{verifier:?}").contains("ExternalMuVerifier"));
+
+    // Copy/Clone
+    let copied = mu;
+    assert_eq!(copied.as_ref(), mu.as_ref());
+}


### PR DESCRIPTION


### Description of changes:
Adds support for the FIPS 204 "external mu" ML-DSA variant in a new public `ml_dsa` module. This lets the 64-byte message representative `mu` be derived by a party holding only the public key -- separately from the signing operation -- which is useful when the message is large, streamed, or not available where the signing key lives. NIST's FIPS 204 FAQ describes the acceptability of this usage.

New API surface:

* `MuContext` -- streaming derivation of `mu` from a `ParsedPublicKey`, mirroring `digest::Context` (`new` / `update` / `finish`).
* `ExternalMu` -- the derived representative; also importable via `import_less_safe`.
* `ExternalMuSigner` / `ExternalMuVerifier` -- sign and verify over a precomputed `mu`. The verifier also offers a one-shot `compute_mu`.

An external-mu signature is interchangeable with an ordinary ML-DSA signature over the same message and context; it is not a different scheme, just a different way of feeding the message in.

The `mu` derivation (`tr = SHAKE256(pk)`, then `mu = SHAKE256(tr || 0x00 || len(ctx) || ctx || msg)`) is implemented in `pqdsa.rs` on top of AWS-LC's SHAKE256 EVP interface, since it must run against public inputs only.

### Call-outs:
* `evp_pkey.rs`'s `sign_digest` / `verify_digest_sig` now take a new `PreHashedInput` wrapper instead of `&Digest`. It is only constructible from a `Digest` or an `ExternalMu`, so a length-validated invariant travels with the value. This matters because the aws-lc-fips-sys pin does not validate `message_len` for ML-DSA digest-mode sign/verify and copies it into a fixed 64-byte stack buffer -- an unchecked over-long input there would be a stack buffer overflow. The ECDSA/RSA call sites only change by a `.into()`.
* `external_representative_len` in `pqdsa.rs` is an exhaustive match with no wildcard, so adding a new PQDSA `AlgorithmID` forces an explicit decision about whether it supports an external representative (SLH-DSA and FN-DSA could not, for example).

### Testing:
* New integration test suite (`ml_dsa_external_mu_test.rs`) covering round-trips for all three parameter sets, streaming vs. one-shot equivalence, `MuContext` cloning, interchangeability with pure-mode signatures, public-key binding of `mu`, algorithm-mismatch and wrong-key rejection, X.509-encoded public keys, buffer-size errors, and `Send`/`Sync`.
* The existing ML-DSA sigver test vectors are re-run through the external-mu path, pinning this crate's `mu` derivation against AWS-LC's internal one: a wrong SHAKE256 composition, `tr` binding, or domain separator would fail verification against known-good signatures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.