### PR TITLE
Prepare aws-lc-rs v1.18.0

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aws-lc-rs"
 authors = ["AWS-LibCrypto"]
-version = "1.17.3"
+version = "1.18.0"
 # this crate re-exports whatever sys crate that was selected
-links = "aws_lc_rs_1_17_3_sys"
+links = "aws_lc_rs_1_18_0_sys"
 edition = "2021"
 rust-version = "1.71.0"
 keywords = ["crypto", "cryptography", "security"]

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -1666,7 +1666,9 @@ fn rsa_keypair_from_components_rejects_inconsistent() {
 // accepting keys that the public-key APIs go on to reject.
 #[test]
 fn rsa_keypair_from_components_rejects_leading_zero_public_components() {
-    let cases: [(&str, fn(&mut RsaKeyPairComponents<Vec<u8>>)); 4] = [
+    type MutateComponents = fn(&mut RsaKeyPairComponents<Vec<u8>>);
+
+    let cases: [(&str, MutateComponents); 4] = [
         ("leading zero on n", |c| c.public_key.n.insert(0, 0u8)),
         ("leading zero on e", |c| c.public_key.e.insert(0, 0u8)),
         ("empty n", |c| c.public_key.n.clear()),


### PR DESCRIPTION
### Description of changes: 
Prepare aws-lc-rs v1.18.0. Also, silences a clippy warning.

### Call-outs:
~~Pending PRs:~~
* ~~#1187~~
* ~~#1194~~
* ~~#1199~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
