### PR TITLE
fix(builder): filter the raw-triple CFLAGS spelling for jitterentropy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -830,6 +830,9 @@ jobs:
             env_value: '-O2'
           - env_name: TARGET_CFLAGS
             env_value: '-O2'
+          # Not exportable by a POSIX shell, but inheritable from a parent process (setenv).
+          - env_name: CFLAGS_x86_64-unknown-linux-gnu
+            env_value: '-O3'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -844,12 +847,10 @@ jobs:
           go-version: '>=1.18'
       - name: Run tests
         run: |
-          export ${{ matrix.env_name }}="${{ matrix.env_value }}"
-          cargo test -p aws-lc-rs --all-targets
+          env "${{ matrix.env_name }}=${{ matrix.env_value }}" cargo test -p aws-lc-rs --all-targets
       - name: Run tests w/ FIPS
         run: |
-          export ${{ matrix.env_name }}="${{ matrix.env_value }}"
-          cargo test -p aws-lc-rs --all-targets --features fips
+          env "${{ matrix.env_name }}=${{ matrix.env_value }}" cargo test -p aws-lc-rs --all-targets --features fips
 
   builder-tests:
     if: github.repository_owner == 'aws'

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -979,12 +979,18 @@ impl CcBuilder {
 /// and `HOST_CFLAGS` otherwise, so callers that may cross-compile need both.
 fn cflags_env_names(include_target_prefixed: bool) -> Vec<String> {
     let target = target();
+    // cc 1.2.26 replaces only `-`, while newer versions replace both `-` and `.`.
+    // Include both spellings because either version may satisfy our dependency range.
+    let target_u_legacy = target.replace('-', "_");
     let target_u = target.replace(['-', '.'], "_");
     let mut names = vec![
         format!("CFLAGS_{target}"),
-        format!("CFLAGS_{target_u}"),
-        "HOST_CFLAGS".to_string(),
+        format!("CFLAGS_{target_u_legacy}"),
     ];
+    if target_u != target_u_legacy {
+        names.push(format!("CFLAGS_{target_u}"));
+    }
+    names.push("HOST_CFLAGS".to_string());
     if include_target_prefixed {
         names.push("TARGET_CFLAGS".to_string());
     }
@@ -1338,17 +1344,19 @@ mod tests {
     #[test]
     fn test_jitter_entropy_cflags_guards_filter_every_cc_variant() {
         let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        let _target_guard = EnvGuard::new("TARGET", "aarch64-apple-darwin");
-        let _g1 = EnvGuard::new("CFLAGS_aarch64-apple-darwin", "-O3 -fdash");
-        let _g2 = EnvGuard::new("CFLAGS_aarch64_apple_darwin", "-O2 -funderscore");
-        let _g3 = EnvGuard::new("HOST_CFLAGS", "-Ofast -fhost");
-        let _g4 = EnvGuard::new("TARGET_CFLAGS", "-Os -ftarget");
-        let _g5 = EnvGuard::new("CFLAGS", "-O1 -fbase");
+        let _target_guard = EnvGuard::new("TARGET", "thumbv8m.main-none-eabi");
+        let _g1 = EnvGuard::new("CFLAGS_thumbv8m.main-none-eabi", "-O3 -fraw");
+        let _g2 = EnvGuard::new("CFLAGS_thumbv8m.main_none_eabi", "-O2 -flegacy");
+        let _g3 = EnvGuard::new("CFLAGS_thumbv8m_main_none_eabi", "-Oz -fcurrent");
+        let _g4 = EnvGuard::new("HOST_CFLAGS", "-Ofast -fhost");
+        let _g5 = EnvGuard::new("TARGET_CFLAGS", "-Os -ftarget");
+        let _g6 = EnvGuard::new("CFLAGS", "-O1 -fbase");
         {
             let _guards = CcBuilder::jitter_entropy_cflags_guards(false);
             for name in [
-                "CFLAGS_aarch64-apple-darwin",
-                "CFLAGS_aarch64_apple_darwin",
+                "CFLAGS_thumbv8m.main-none-eabi",
+                "CFLAGS_thumbv8m.main_none_eabi",
+                "CFLAGS_thumbv8m_main_none_eabi",
                 "HOST_CFLAGS",
                 "TARGET_CFLAGS",
                 "CFLAGS",
@@ -1366,26 +1374,30 @@ mod tests {
                 );
             }
             // Non-optimization flags are preserved.
-            assert!(env::var("CFLAGS_aarch64-apple-darwin")
+            assert!(env::var("CFLAGS_thumbv8m.main-none-eabi")
                 .unwrap()
-                .contains("-fdash"));
+                .contains("-fraw"));
         }
         // Every guarded variable is restored on drop.
         assert_eq!(
-            env::var("CFLAGS_aarch64-apple-darwin").unwrap(),
-            "-O3 -fdash"
+            env::var("CFLAGS_thumbv8m.main-none-eabi").unwrap(),
+            "-O3 -fraw"
         );
         assert_eq!(
-            env::var("CFLAGS_aarch64_apple_darwin").unwrap(),
-            "-O2 -funderscore"
+            env::var("CFLAGS_thumbv8m.main_none_eabi").unwrap(),
+            "-O2 -flegacy"
+        );
+        assert_eq!(
+            env::var("CFLAGS_thumbv8m_main_none_eabi").unwrap(),
+            "-Oz -fcurrent"
         );
         assert_eq!(env::var("HOST_CFLAGS").unwrap(), "-Ofast -fhost");
         assert_eq!(env::var("TARGET_CFLAGS").unwrap(), "-Os -ftarget");
         assert_eq!(env::var("CFLAGS").unwrap(), "-O1 -fbase");
     }
 
-    // cc's `target_envs` replaces both `-` and `.` when forming the underscore
-    // spelling; a dotted triple pins that we match it.
+    // cc 1.2.26 replaces only `-` in `target_envs`, while newer versions replace
+    // both `-` and `.`; a dotted triple pins that we cover both supported forms.
     #[test]
     fn test_cflags_env_names_match_cc_target_envs() {
         let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
@@ -1395,6 +1407,7 @@ mod tests {
             names,
             vec![
                 "CFLAGS_thumbv8m.main-none-eabi",
+                "CFLAGS_thumbv8m.main_none_eabi",
                 "CFLAGS_thumbv8m_main_none_eabi",
                 "HOST_CFLAGS",
                 "TARGET_CFLAGS",

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -574,20 +574,11 @@ impl CcBuilder {
     /// Jitterentropy MUST be compiled with -O0, so we temporarily override
     /// CFLAGS to replace any optimization flags with -O0.
     ///
-    /// The cc crate collects flags from ALL matching CFLAGS env vars (not just
-    /// the highest-priority one), so we must filter every variable it checks:
-    ///   1. `CFLAGS_{target}` (e.g. `CFLAGS_x86_64_unknown_freebsd`)
-    ///   2. `HOST_CFLAGS` or `TARGET_CFLAGS`
-    ///   3. `CFLAGS`
+    /// Every variable cc reads must be filtered (see `cflags_env_names`); missing
+    /// the raw-triple spelling was <https://github.com/aws/aws-lc-rs/issues/1205>.
     fn jitter_entropy_cflags_guards(is_cl_like: bool) -> Vec<EnvGuard> {
-        let target_u = target().to_lowercase().replace('-', "_");
-
-        let cflags_env_names: Vec<String> = vec![
-            format!("CFLAGS_{target_u}"),
-            "HOST_CFLAGS".to_string(),
-            "TARGET_CFLAGS".to_string(),
-            "CFLAGS".to_string(),
-        ];
+        // Jitterentropy may be cross-compiled, so include TARGET_CFLAGS too.
+        let cflags_env_names = cflags_env_names(true);
 
         let filter_cflags = |value: &str| -> String {
             let filtered: String = value
@@ -978,22 +969,37 @@ impl CcBuilder {
     }
 }
 
+/// The `CFLAGS`-family env var names the cc crate consults (its `target_envs`).
+/// cc's `envflags` collects flags from EVERY one that is set, so overriding or
+/// suppressing user flags must handle all of them -- including the raw-triple
+/// spelling (`CFLAGS_aarch64-apple-darwin`), which a shell cannot usually export
+/// but a process can set via `setenv` (#1205).
+///
+/// `include_target_prefixed` adds `TARGET_CFLAGS`: cc reads it when cross-compiling
+/// and `HOST_CFLAGS` otherwise, so callers that may cross-compile need both.
+fn cflags_env_names(include_target_prefixed: bool) -> Vec<String> {
+    let target = target();
+    let target_u = target.replace(['-', '.'], "_");
+    let mut names = vec![
+        format!("CFLAGS_{target}"),
+        format!("CFLAGS_{target_u}"),
+        "HOST_CFLAGS".to_string(),
+    ];
+    if include_target_prefixed {
+        names.push("TARGET_CFLAGS".to_string());
+    }
+    names.push("CFLAGS".to_string());
+    names
+}
+
 /// Temporarily removes every `CFLAGS`-family env var the cc crate consults (see its
 /// `target_envs`), so that `cc::Build::get_compiler()` computes only the target's
 /// default flags. `cc` concatenates all set variants, so all must go.
 fn cflags_ignore_guards() -> Vec<EnvGuard> {
-    let target = target();
-    let target_u = target.replace(['-', '.'], "_");
-    [
-        format!("CFLAGS_{target}"),
-        format!("CFLAGS_{target_u}"),
-        "HOST_CFLAGS".to_string(),
-        "TARGET_CFLAGS".to_string(),
-        "CFLAGS".to_string(),
-    ]
-    .iter()
-    .map(|name| EnvGuard::remove(name))
-    .collect()
+    cflags_env_names(true)
+        .iter()
+        .map(|name| EnvGuard::remove(name))
+        .collect()
 }
 
 /// Whether the DWARF path-stripping assembler flag applies to this target and
@@ -1324,6 +1330,78 @@ mod tests {
             )),
             "GCC must keep the assembler flag when user CFLAGS enables LTO"
         );
+    }
+
+    // Guards https://github.com/aws/aws-lc-rs/issues/1205: an optimization flag in ANY
+    // CFLAGS variant cc reads (including the raw-triple spelling, settable via setenv)
+    // overrides jitterentropy's required -O0, so every variant must be filtered.
+    #[test]
+    fn test_jitter_entropy_cflags_guards_filter_every_cc_variant() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _target_guard = EnvGuard::new("TARGET", "aarch64-apple-darwin");
+        let _g1 = EnvGuard::new("CFLAGS_aarch64-apple-darwin", "-O3 -fdash");
+        let _g2 = EnvGuard::new("CFLAGS_aarch64_apple_darwin", "-O2 -funderscore");
+        let _g3 = EnvGuard::new("HOST_CFLAGS", "-Ofast -fhost");
+        let _g4 = EnvGuard::new("TARGET_CFLAGS", "-Os -ftarget");
+        let _g5 = EnvGuard::new("CFLAGS", "-O1 -fbase");
+        {
+            let _guards = CcBuilder::jitter_entropy_cflags_guards(false);
+            for name in [
+                "CFLAGS_aarch64-apple-darwin",
+                "CFLAGS_aarch64_apple_darwin",
+                "HOST_CFLAGS",
+                "TARGET_CFLAGS",
+                "CFLAGS",
+            ] {
+                let value = env::var(name).unwrap();
+                assert!(
+                    !value
+                        .split_whitespace()
+                        .any(|f| f.starts_with("-O") && f != "-O0"),
+                    "{name} still carries an optimization flag: {value}"
+                );
+                assert!(
+                    value.split_whitespace().any(|f| f == "-O0"),
+                    "{name} must force -O0: {value}"
+                );
+            }
+            // Non-optimization flags are preserved.
+            assert!(env::var("CFLAGS_aarch64-apple-darwin")
+                .unwrap()
+                .contains("-fdash"));
+        }
+        // Every guarded variable is restored on drop.
+        assert_eq!(
+            env::var("CFLAGS_aarch64-apple-darwin").unwrap(),
+            "-O3 -fdash"
+        );
+        assert_eq!(
+            env::var("CFLAGS_aarch64_apple_darwin").unwrap(),
+            "-O2 -funderscore"
+        );
+        assert_eq!(env::var("HOST_CFLAGS").unwrap(), "-Ofast -fhost");
+        assert_eq!(env::var("TARGET_CFLAGS").unwrap(), "-Os -ftarget");
+        assert_eq!(env::var("CFLAGS").unwrap(), "-O1 -fbase");
+    }
+
+    // cc's `target_envs` replaces both `-` and `.` when forming the underscore
+    // spelling; a dotted triple pins that we match it.
+    #[test]
+    fn test_cflags_env_names_match_cc_target_envs() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _target_guard = EnvGuard::new("TARGET", "thumbv8m.main-none-eabi");
+        let names = cflags_env_names(true);
+        assert_eq!(
+            names,
+            vec![
+                "CFLAGS_thumbv8m.main-none-eabi",
+                "CFLAGS_thumbv8m_main_none_eabi",
+                "HOST_CFLAGS",
+                "TARGET_CFLAGS",
+                "CFLAGS",
+            ]
+        );
+        assert!(!cflags_env_names(false).contains(&"TARGET_CFLAGS".to_string()));
     }
 
     // Guards https://github.com/aws/aws-lc-rs/issues/1146: in cl driver mode


### PR DESCRIPTION
### Issues:
Addresses #1205

### Description of changes:
Filter every target-specific `CFLAGS` spelling read by `cc` before compiling jitterentropy so an inherited optimization flag cannot override its required `-O0`. Add hostile-environment CI coverage for the raw target-triple spelling.

### Call-outs:
`cc` accumulates flags from every matching `CFLAGS` variable rather than selecting one by precedence. Raw target-triple names cannot be exported by a POSIX shell, but they can be set by a parent process and inherited. Our supported `cc` range also spans both legacy normalization (`-` to `_`) and current normalization (`-` and `.` to `_`), so dotted targets require both spellings.

### Testing:
- `cargo test -p builder-test`
- `env 'CFLAGS_aarch64-apple-darwin=-O3' cargo test -p aws-lc-rs --all-targets`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
