### PR TITLE
fix: export `cargo:root` metadata from the system-library path

### DIFF
--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -16,6 +16,10 @@ AWS-LC FIPS build can use the exported `include`, `libdir`, `libcrypto_path`,
 `libssl_path` is also exported. Cargo exposes these values to direct dependents
 as versioned `DEP_AWS_LC_FIPS_*` environment variables.
 
+`root` is also exported for dependents that predate the keys above. It names a
+directory containing the build. It is the output root when built from source,
+or the install prefix for a pre-installed AWS-LC.
+
 `link_kind` is `static` or `dylib`, usable directly as the `<kind>` in a
 `cargo:rustc-link-lib=<kind>=<name>` directive.
 

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -20,6 +20,10 @@ AWS-LC build can use the exported `include`, `libdir`, `libcrypto_path`,
 `libssl_path` is also exported. Cargo exposes these values to direct dependents
 as versioned `DEP_AWS_LC_*` environment variables.
 
+`root` is also exported for dependents that predate the keys above. It names a
+directory containing the build. It is the output root when built from source, 
+or the install prefix for a pre-installed AWS-LC.
+
 `link_kind` is `static` or `dylib`, usable directly as the `<kind>` in a
 `cargo:rustc-link-lib=<kind>=<name>` directive.
 

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -416,6 +416,7 @@ impl SystemLib {
         crate::emit_system_libs_metadata();
 
         println!("cargo:include={}", include_dir.display());
+        println!("cargo:root={}", self.layout.marker_dir.display());
 
         println!("cargo:rerun-if-changed={}", include_dir.display());
         println!("cargo:rerun-if-changed={}", crypto_lib.path.display());


### PR DESCRIPTION

### Issues:

None

### Description of changes: 

`CcBuilder` and `CmakeBuilder` both emit `cargo:root`, but `SystemLib` did not, so pointing a build at a pre-installed AWS-LC dropped the key from the `DEP_AWS_LC_*` surface. Downstreams that read it unconditionally then panic, e.g., `s2n-tls-sys` requires `DEP_AWS_LC_{version}_ROOT` [^1] via `aws-lc-rs`, which re-exports the sys crate's metadata under its own `links` key.

This fix emits the install prefix. Like the source builders' output roots it holds `include/` and the library directory, and it matches the `<prefix>` convention other `-sys` crates use for `root`.

[^1]: https://github.com/aws/s2n-tls/blob/8cbf81ad74968a1d03efbd9352a89abd292232d4/bindings/rust/extended/s2n-tls-sys/build.rs#L314


### Call-outs:

None


### Testing:

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
