### PR TITLE
ci: verify docs.rs build with read-only crate sources

### DIFF
--- a/.github/workflows/misc-tests.yml
+++ b/.github/workflows/misc-tests.yml
@@ -92,11 +92,21 @@ jobs:
       - name: Install cargo-docs-rs
         run: cargo install cargo-docs-rs
 
+      # docs.rs builds from a read-only registry mount, which cargo docs-rs
+      # does not reproduce on its own: a build that writes into its own source
+      # tree passes here but fails there. See aws/aws-lc#3412.
+      - name: Make crate sources read-only, as docs.rs does
+        run: chmod -R a-w aws-lc-rs aws-lc-sys aws-lc-fips-sys
+
       - name: Verify docs.rs build
         run: |
           cargo +nightly docs-rs -p aws-lc-rs
           cargo +nightly docs-rs -p aws-lc-sys
           cargo +nightly docs-rs -p aws-lc-fips-sys
+
+      - name: Restore write permissions for runner cleanup
+        if: always()
+        run: chmod -R u+w aws-lc-rs aws-lc-sys aws-lc-fips-sys || true
 
   dev-tests-only-feature:
     if: github.repository_owner == 'aws'


### PR DESCRIPTION
### Issues:
Addresses the `aws-lc-fips-sys` 0.14.x docs.rs failure fixed upstream by aws/aws-lc#3412.

### Description of changes:
`cargo docs-rs` reproduces docs.rs's features, targets and rustdoc flags, but not its read-only registry mount. Making the crate sources read-only first means a build that writes into its own source tree now fails in CI the way it fails on docs.rs. All three crate dirs are covered, since a docs.rs build of `aws-lc-rs` also reads `aws-lc-sys` from a read-only mount.

### Call-outs:
* **Fails for `aws-lc-fips-sys` until the submodule is bumped** to `699affdf` or later (currently `94879dc`, the commit right before the fix). Needs the bump in this PR or to land after it.
* Nothing we run today catches this: a vendored AWS-LC predating `ENABLE_SOURCE_MODIFICATION` ignores the flag with only an `unused-cli` warning, and the resulting header rewrite is byte-identical, so the source-modification check in `cargo publish --dry-run` is blind to it too.

### Testing:
With the source read-only, `cargo docs-rs -p aws-lc-fips-sys` reproduces the docs.rs error exactly; `aws-lc-sys` (clean build) and `aws-lc-rs` both still succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
