### PR TITLE
fix: address clippy::assert_is_empty lints in ECB cipher modes

### DIFF
--- a/aws-lc-rs/src/cipher/aes.rs
+++ b/aws-lc-rs/src/cipher/aes.rs
@@ -218,7 +218,7 @@ pub(super) fn encrypt_ecb_mode(
 
     // This is a sanity check that should not happen. We validate in `encrypt` that in_out.len() % block_len == 0
     // for this mode.
-    debug_assert!(in_out_iter.into_remainder().is_empty());
+    debug_assert_eq!(in_out_iter.into_remainder(), []);
 
     Ok(context.into())
 }
@@ -247,9 +247,9 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
             aes_ecb_decrypt(dec_key, block);
         }
 
-        // This is a sanity check hat should not fail. We validate in `decrypt` that in_out.len() % block_len == 0 for
+        // This is a sanity check that should not fail. We validate in `decrypt` that in_out.len() % block_len == 0 for
         // this mode.
-        debug_assert!(in_out_iter.into_remainder().is_empty());
+        debug_assert_eq!(in_out_iter.into_remainder(), []);
     }
 
     Ok(in_out)

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -121,7 +121,7 @@ pub(super) fn encrypt_ecb_mode(
     }
     // Sanity check: `encrypt` validates that `in_out.len() % block_len == 0`
     // for ECB mode before dispatching here.
-    debug_assert!(in_out_iter.into_remainder().is_empty());
+    debug_assert_eq!(in_out_iter.into_remainder(), []);
 
     Ok(context.into())
 }
@@ -138,7 +138,7 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
     // The inner scope ends the mutable borrow of `in_out` held by
     // `in_out_iter` before we return `Ok(in_out)` below. `into_remainder()`
     // would also consume the iterator and release the borrow, but it's inside
-    // a `debug_assert!` and therefore not evaluated in release builds, so we
+    // a `debug_assert_eq!` and therefore not evaluated in release builds, so we
     // can't rely on it for that purpose. `encrypt_ecb_mode` doesn't need this
     // scope because it doesn't return `in_out`.
     {
@@ -158,7 +158,7 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
         }
         // Sanity check: `decrypt` validates that `in_out.len() % block_len == 0`
         // for ECB mode before dispatching here.
-        debug_assert!(in_out_iter.into_remainder().is_empty());
+        debug_assert_eq!(in_out_iter.into_remainder(), []);
     }
 
     Ok(in_out)


### PR DESCRIPTION
### Description of changes: 

Replace debug_assert!(remainder.is_empty()) with the clippy-suggested debug_assert_eq!(remainder, []) in the AES and DES ECB mode functions. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
