### PR TITLE
Fix `-Wa,--debug-prefix-map` probe

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -851,6 +851,100 @@ jobs:
           export ${{ matrix.env_name }}="${{ matrix.env_value }}"
           cargo test -p aws-lc-rs --all-targets --features fips
 
+  builder-tests:
+    if: github.repository_owner == 'aws'
+    # The builder normally compiles only as a build script, so its unit tests run
+    # solely through the builder-test harness crate; no other lane runs them. The
+    # compiler-probe tests need the runner's clang and GCC and only run on Linux.
+    name: builder unit tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - name: Run builder unit tests
+        run: cargo test -p builder-test
+
+  linux-clang-lto:
+    if: github.repository_owner == 'aws'
+    # Guards https://github.com/aws/aws-lc-rs/issues/1211: under `-flto`, clang flag
+    # probes never reach the integrated assembler, so `-Wa,--debug-prefix-map` probed
+    # as supported and `.S` sources failed to assemble. No other lane combined clang,
+    # Linux, and a release opt level; build-only since bitcode needs an LTO-aware link.
+    name: Linux clang LTO - CMake ${{ matrix.cmake }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake: [0, 1]
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      CFLAGS: '-flto=thin'
+      AWS_LC_SYS_CMAKE_BUILDER: ${{ matrix.cmake }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - name: Release build
+        run: cargo build -p aws-lc-sys --release
+
+  linux-clang-path-stripping:
+    if: github.repository_owner == 'aws'
+    # Clang no longer gets `-Wa,--debug-prefix-map`, so `-ffile-prefix-map` alone must
+    # strip `.S` paths (compilers.yml asserts this for GCC only). cc builder only: the
+    # C-side prefix-map never reaches `CMAKE_ASM_FLAGS`. No LTO: bitcode has no DWARF.
+    name: Linux clang path stripping
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_LC_SYS_CMAKE_BUILDER: 0
+      CARGO_PROFILE_RELEASE_DEBUG: 'true'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - name: Install readelf
+        run: sudo apt-get update && sudo apt-get install -y binutils
+      - name: Release build with debug info
+        run: cargo build -p aws-lc-sys --release
+      - name: Verify paths not found in release build with debug info
+        run: |
+          RELEASE_LIBCRYPTO_COUNT=$(find ./target/release -type f -name "libaws_lc_*_crypto.a" | wc -l)
+          if [ "${RELEASE_LIBCRYPTO_COUNT}" -ne 1 ]; then
+            echo "FAIL: expected exactly one release libcrypto archive, found ${RELEASE_LIBCRYPTO_COUNT}:"
+            find ./target/release -type f -name "libaws_lc_*_crypto.a"
+            exit 1
+          fi
+          RELEASE_LIBCRYPTO=$(find ./target/release -type f -name "libaws_lc_*_crypto.a")
+          # Require `.S` DWARF line data, else the path check below passes vacuously.
+          if ! readelf --debug-dump=decodedline "${RELEASE_LIBCRYPTO}" | grep -Eq '\.S[[:space:]]+[0-9]+'; then
+            echo "FAIL: no assembly source line-table entries found; expected DWARF"
+            exit 1
+          fi
+          if strings "${RELEASE_LIBCRYPTO}" | grep "${PWD}/"; then
+            echo "FAIL: build paths leaked into archive (DWARF source paths):"
+            strings "${RELEASE_LIBCRYPTO}" | grep "${PWD}/" | sort -u | head -20
+            exit 1; # FAIL - we did not expect to find "${PWD}" (i.e., a path)
+          fi
+
   windows-hostile-environment:
     if: github.repository_owner == 'aws'
     name: Windows hostile env - CC=${{ matrix.cc }} CFLAGS=${{ matrix.cflags }}

--- a/builder/cc_builder.rs
+++ b/builder/cc_builder.rs
@@ -28,7 +28,7 @@ use crate::{
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[non_exhaustive]
 #[derive(PartialEq, Eq)]
@@ -380,7 +380,7 @@ impl CcBuilder {
         }
 
         let mut cc_build = self.create_builder();
-        let (is_cl_like, build_options) = self.collect_universal_build_options(&cc_build, false);
+        let (_, build_options) = self.collect_universal_build_options(&cc_build, false);
         for option in build_options {
             option.apply_cc(&mut cc_build);
         }
@@ -402,19 +402,8 @@ impl CcBuilder {
 
         // `-ffile-prefix-map` does not reach GNU `as` for `.S` sources, so in
         // release-style builds mirror it with `-Wa,--debug-prefix-map=...`.
-        // Probe first because clang's integrated assembler rejects the flag,
-        // and skip paths with spaces because `-Wa,...` must stay a bare token.
-        let opt_level = cargo_env("OPT_LEVEL");
-        if (target_os() == "linux" || target_os().ends_with("bsd"))
-            && !is_cl_like
-            && !matches!(opt_level.as_str(), "0" | "1" | "2")
-            && !self.manifest_dir.to_string_lossy().contains(' ')
-        {
-            let path_str = self.manifest_dir.display().to_string();
-            let asm_flag = format!("-Wa,--debug-prefix-map={path_str}=");
-            if cc_build.is_flag_supported(&asm_flag).unwrap_or(false) {
-                cc_build.asm_flag(asm_flag);
-            }
+        if let Some(asm_flag) = asm_debug_prefix_map_flag(&self.manifest_dir) {
+            cc_build.asm_flag(asm_flag);
         }
 
         cc_build
@@ -991,8 +980,7 @@ impl CcBuilder {
 
 /// Temporarily removes every `CFLAGS`-family env var the cc crate consults (see its
 /// `target_envs`), so that `cc::Build::get_compiler()` computes only the target's
-/// default flags. Assumes HOST == TARGET (the memcmp probe only runs natively), where
-/// cc consults `HOST_CFLAGS` and never `TARGET_CFLAGS`.
+/// default flags. `cc` concatenates all set variants, so all must go.
 fn cflags_ignore_guards() -> Vec<EnvGuard> {
     let target = target();
     let target_u = target.replace(['-', '.'], "_");
@@ -1000,11 +988,55 @@ fn cflags_ignore_guards() -> Vec<EnvGuard> {
         format!("CFLAGS_{target}"),
         format!("CFLAGS_{target_u}"),
         "HOST_CFLAGS".to_string(),
+        "TARGET_CFLAGS".to_string(),
         "CFLAGS".to_string(),
     ]
     .iter()
     .map(|name| EnvGuard::remove(name))
     .collect()
+}
+
+/// Whether the DWARF path-stripping assembler flag applies to this target and
+/// profile, independent of the compiler: only GNU `as` targets, only release-style
+/// profiles, and `-Wa,...` must stay a single bare token (no spaces).
+fn asm_debug_prefix_map_applies(target_os: &str, opt_level: &str, manifest_dir: &Path) -> bool {
+    (target_os == "linux" || target_os.ends_with("bsd"))
+        && !matches!(opt_level, "0" | "1" | "2")
+        && !manifest_dir.to_string_lossy().contains(' ')
+}
+
+/// The GNU `as` flag that strips `manifest_dir` from DWARF emitted for `.S`
+/// sources, or `None` when it must not be used.
+///
+/// Gated on the compiler family, not a flag probe: GCC does not forward
+/// `-ffile-prefix-map` to `as`, while clang's integrated assembler honors it
+/// directly and rejects `--debug-prefix-map` -- but only diagnoses it when a job
+/// reaches the assembler, which a C probe under `-flto` never does. The remaining
+/// probe, run with user `CFLAGS` suppressed, only guards a GNU `as` predating the
+/// option (binutils 2.26).
+/// See: <https://github.com/aws/aws-lc-rs/issues/1211>
+pub(crate) fn asm_debug_prefix_map_flag(manifest_dir: &Path) -> Option<String> {
+    if !asm_debug_prefix_map_applies(&target_os(), &cargo_env("OPT_LEVEL"), manifest_dir) {
+        return None;
+    }
+
+    let flag = format!("-Wa,--debug-prefix-map={}=", manifest_dir.display());
+
+    let _cflags_guards = cflags_ignore_guards();
+    let probe_build = cc::Build::default();
+    // `try_get_compiler` so an unresolvable compiler cannot panic the build script.
+    let Ok(compiler) = probe_build.try_get_compiler() else {
+        return None;
+    };
+    if !compiler.is_like_gnu() {
+        return None;
+    }
+    if !probe_build.is_flag_supported(&flag).unwrap_or(false) {
+        emit_warning(format!("Assembler does not support flag: {flag}"));
+        return None;
+    }
+    emit_warning(format!("Using assembler flag: {flag}"));
+    Some(flag)
 }
 
 /// Version reported by a GCC-like compiler, if determinable. Prefers `-dumpfullversion`
@@ -1144,9 +1176,8 @@ mod tests {
         assert!(gcc_version_may_have_memcmp_bug("unknown"));
     }
 
-    // The memcmp probe must exclude user CFLAGS (#1132) while `cc` computes the
-    // compiler's default flags; every env var variant `cc` consults must be
-    // suppressed, and all must be restored when the guards drop.
+    // The builder probes must exclude user CFLAGS (#1132, #1211): every env var
+    // variant `cc` consults must be suppressed, and restored when the guards drop.
     #[test]
     fn test_cflags_ignore_guards_suppress_and_restore() {
         let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
@@ -1162,7 +1193,8 @@ mod tests {
             assert!(env::var("CFLAGS_x86_64-unknown-linux-gnu").is_err());
             assert!(env::var("CFLAGS_x86_64_unknown_linux_gnu").is_err());
             assert!(env::var("HOST_CFLAGS").is_err());
-            assert_eq!(env::var("TARGET_CFLAGS").unwrap(), "-ftarget");
+            // `cc` reads this variant instead of `HOST_CFLAGS` when cross-compiling.
+            assert!(env::var("TARGET_CFLAGS").is_err());
         }
         assert_eq!(env::var("CFLAGS").unwrap(), "-flto=thin");
         assert_eq!(
@@ -1174,6 +1206,124 @@ mod tests {
             "-funderscore-variant"
         );
         assert_eq!(env::var("HOST_CFLAGS").unwrap(), "-fhost");
+        assert_eq!(env::var("TARGET_CFLAGS").unwrap(), "-ftarget");
+    }
+
+    // Compiler-independent gating only; the GNU-family gate (#1211) needs a real
+    // compiler and is covered by the test below.
+    #[test]
+    fn test_asm_debug_prefix_map_applies() {
+        use std::path::Path;
+        let dir = Path::new("/tmp/aws-lc-sys");
+
+        // Release-style profiles on GNU `as` targets.
+        assert!(asm_debug_prefix_map_applies("linux", "3", dir));
+        assert!(asm_debug_prefix_map_applies("linux", "s", dir));
+        assert!(asm_debug_prefix_map_applies("linux", "z", dir));
+        assert!(asm_debug_prefix_map_applies("freebsd", "3", dir));
+        assert!(asm_debug_prefix_map_applies("netbsd", "3", dir));
+
+        // Debug-style profiles keep full paths.
+        for opt_level in ["0", "1", "2"] {
+            assert!(!asm_debug_prefix_map_applies("linux", opt_level, dir));
+        }
+
+        // Targets that do not use GNU `as`.
+        for target_os in ["macos", "windows", "ios", "android"] {
+            assert!(!asm_debug_prefix_map_applies(target_os, "3", dir));
+        }
+
+        // `-Wa,...` must stay one bare token, so spaced paths are skipped.
+        assert!(!asm_debug_prefix_map_applies(
+            "linux",
+            "3",
+            Path::new("/tmp/aws lc sys")
+        ));
+    }
+
+    /// Host triple for `TARGET`/`HOST`, which `cc` requires but `cargo test` omits.
+    fn host_triple() -> Option<String> {
+        let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+        let output = std::process::Command::new(rustc).arg("-vV").output().ok()?;
+        String::from_utf8(output.stdout)
+            .ok()?
+            .lines()
+            .find_map(|line| line.strip_prefix("host: ").map(str::to_string))
+    }
+
+    /// Env for natively probing `cc_value` with `-flto=thin` in user CFLAGS, or
+    /// `None` where that cannot run: `cc` panics on a `CARGO_CFG_TARGET_OS`
+    /// contradicting `TARGET`, so only hosts where the flag applies qualify.
+    /// Native TARGET/HOST so the probe reflects the compiler, not a missing sysroot.
+    fn native_lto_probe_guards(cc_value: &str) -> Option<(tempfile::TempDir, Vec<EnvGuard>)> {
+        let host_os = std::env::consts::OS;
+        if !(host_os == "linux" || host_os.ends_with("bsd")) {
+            return None;
+        }
+        let host = host_triple()?;
+        let temp_out = tempfile::tempdir().unwrap();
+        let guards = vec![
+            EnvGuard::new("OUT_DIR", temp_out.path()),
+            EnvGuard::new("TARGET", &host),
+            EnvGuard::new("HOST", &host),
+            EnvGuard::new("CARGO_CFG_TARGET_OS", host_os),
+            EnvGuard::new("OPT_LEVEL", "3"),
+            EnvGuard::new("CC", cc_value),
+            EnvGuard::new("CFLAGS", "-flto=thin"),
+        ];
+        Some((temp_out, guards))
+    }
+
+    // Regression test for https://github.com/aws/aws-lc-rs/issues/1211: clang must
+    // not receive the GNU-only assembler flag when user CFLAGS enables LTO. Pins
+    // end behavior only -- the family gate and the CFLAGS-suppressed probe each
+    // yield `None` here on their own. linux-clang-lto covers the bug end to end.
+    #[test]
+    fn test_asm_debug_prefix_map_flag_withheld_from_clang_under_lto() {
+        use std::path::Path;
+
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(_guards) = native_lto_probe_guards("clang") else {
+            return; // host cannot run the probe; the builder-tests CI lane covers it
+        };
+
+        assert_eq!(
+            asm_debug_prefix_map_flag(Path::new("/tmp/aws-lc-sys")),
+            None,
+            "clang must not receive the GNU-only -Wa,--debug-prefix-map flag"
+        );
+    }
+
+    // Positive-path companion to the test above: real GCC keeps the flag under the
+    // same user LTO CFLAGS, pinning that clang's `None` comes from gating rather
+    // than the helper never returning `Some`. GCC rejects `-flto=thin`, so this
+    // also fails if the probe stops suppressing CFLAGS.
+    #[test]
+    fn test_asm_debug_prefix_map_flag_granted_to_gcc_under_lto() {
+        use std::path::Path;
+
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(_guards) = native_lto_probe_guards("gcc") else {
+            return; // host cannot run the probe; the builder-tests CI lane covers it
+        };
+        // Skip hosts where `gcc` is absent or a clang shim (e.g. BSDs).
+        {
+            let _cflags_guards = cflags_ignore_guards();
+            match cc::Build::default().try_get_compiler() {
+                Ok(compiler) if compiler.is_like_gnu() => {}
+                _ => return,
+            }
+        }
+
+        let manifest_dir = Path::new("/tmp/aws-lc-sys");
+        assert_eq!(
+            asm_debug_prefix_map_flag(manifest_dir),
+            Some(format!(
+                "-Wa,--debug-prefix-map={}=",
+                manifest_dir.display()
+            )),
+            "GCC must keep the assembler flag when user CFLAGS enables LTO"
+        );
     }
 
     // Guards https://github.com/aws/aws-lc-rs/issues/1146: in cl driver mode

--- a/builder/cmake_builder.rs
+++ b/builder/cmake_builder.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
-use crate::cc_builder::CcBuilder;
+use crate::cc_builder::{asm_debug_prefix_map_flag, CcBuilder};
 use crate::OutputLib::{Crypto, Ssl};
 use crate::{
     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
@@ -120,22 +120,10 @@ impl CmakeBuilder {
             option.apply_cmake(cmake_cfg, is_cl_like);
         }
 
-        // CMake seeds `CMAKE_C_FLAGS` and `CMAKE_ASM_FLAGS` separately, so the
-        // C-side prefix-map does not cover `.S` sources. In release-style
-        // builds, mirror it with `asmflag()` when the compiler accepts
-        // `-Wa,--debug-prefix-map=...`, and skip paths with spaces because the
-        // flag must survive CMake and the assembler as one bare token.
-        let opt_level = cargo_env("OPT_LEVEL");
-        if !is_cl_like
-            && (target_os() == "linux" || target_os().ends_with("bsd"))
-            && !matches!(opt_level.as_str(), "0" | "1" | "2")
-            && !self.manifest_dir.to_string_lossy().contains(' ')
-        {
-            let path_str = self.manifest_dir.display().to_string();
-            let asm_flag = format!("-Wa,--debug-prefix-map={path_str}=");
-            if cc_build.is_flag_supported(&asm_flag).unwrap_or(false) {
-                cmake_cfg.asmflag(asm_flag);
-            }
+        // CMake seeds `CMAKE_C_FLAGS` and `CMAKE_ASM_FLAGS` separately, so the C-side
+        // prefix-map does not cover `.S` sources; mirror it via `asmflag()` when needed.
+        if let Some(asm_flag) = asm_debug_prefix_map_flag(&self.manifest_dir) {
+            cmake_cfg.asmflag(asm_flag);
         }
 
         cmake_cfg


### PR DESCRIPTION
### Issues:
Addresses: #1211

### Description of changes:
`-Wa,--debug-prefix-map` mirrors `-ffile-prefix-map` for `.S` sources, since GCC does not forward the C-side flag to `as`. We applied it whenever `cc::Build::is_flag_supported()` accepted it, relying on clang rejecting it -- but clang only diagnoses an unknown `-Wa,` value when a compile job reaches its integrated assembler. With `-flto` in `CFLAGS`, the C probe stops at bitcode and reports the flag as supported; the real `.S` sources do reach the assembler and fail the build.

The compiler family now decides: only GCC gets the flag. That loses nothing for clang, whose integrated assembler honors `-ffile-prefix-map` for `.S` inputs directly. The probe survives only to catch a GNU `as` predating the option (binutils 2.26), and now runs with user `CFLAGS` suppressed.

### Call-outs:
* Two mechanisms here each fix #1211 on their own: the family gate, and the probe no longer seeing `-flto` once `CFLAGS` is suppressed. That redundancy is deliberate -- the gate also covers clangs that enable LTO through default config files rather than `CFLAGS`.
* `cflags_ignore_guards` now also removes `TARGET_CFLAGS`: `cc` reads it instead of `HOST_CFLAGS` when cross-compiling and concatenates every variant that is set, and unlike the memcmp probe this one runs in cross builds.
* Not fixed here: CMake never seeds `CMAKE_ASM_FLAGS` with `-ffile-prefix-map`, so clang + CMake can still record build paths in `.S` DWARF. Predates this change, and is why the new path-stripping job is cc-builder-only. Can file separately.

### Testing:
* New `builder-tests` lane runs `cargo test -p builder-test` on Linux/macOS/Windows -- previously no CI job ran the builder's unit tests at all. The compiler-probe tests among them only execute on Linux, where the runners provide both clang and GCC.
* Unit: gating table test, a clang regression test that the flag is withheld under `-flto`, and a GCC companion test that the flag survives the same `CFLAGS`. The clang test pins end behavior (either mechanism above withholds the flag alone; it fails with both reverted), and the GCC test doubles as a suppression tripwire because GCC rejects `-flto=thin`.
* CI: `linux-clang-lto` reproduces the report end to end for both builders -- no lane combined clang, Linux, and a release opt level before, which is how this slipped through. `linux-clang-path-stripping` proves clang strips `.S` paths via `-ffile-prefix-map` alone, guarding against vacuous passes by requiring `.S` DWARF to be present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
