### PR TITLE
ci: replace removed llvm-devel-lite package in FreeBSD jobs

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -490,7 +490,10 @@ jobs:
           usesh: true
           copyback: false
           prepare: |
-            pkg install -y git gmake bash sudo cmake-core llvm-devel-lite curl go ca_root_nss
+            # libclang for bindgen: aws-lc-fips-sys has no pre-generated FreeBSD
+            # bindings. Pinned to a release; llvm-devel-lite is a snapshot package
+            # that periodically vanishes from the pkg repo.
+            pkg install -y git gmake bash sudo cmake-core llvm19-lite curl go ca_root_nss
           run: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
              . "$HOME/.cargo/env"


### PR DESCRIPTION
### Description of changes:
All six FreeBSD jobs in `cross.yml` fail in "Prepare VM" with `pkg: No packages available to install matching 'llvm-devel-lite'`. Nothing here changed -- that line is untouched since #477 and the last green run was 2026-07-16. `devel/llvm-devel` tracks LLVM main as a dated snapshot, and its binary package is no longer published for FreeBSD 14 or 15 (the snapshot rolled to a versioned name, `llvm23`). This pins `llvm19-lite` instead: 19 is the ports default on both 14.3 and 15.0, and it is a release rather than a moving target.

### Call-outs:
* `pkg install` is atomic, so one missing name took out all six jobs. Only the `--features=fips` entry actually needs libclang, since `aws-lc-fips-sys` has no pre-generated `x86_64-unknown-freebsd` bindings and falls back to bindgen.
* Non-obvious: these ports install into `/usr/local/llvm19/lib`, not `/usr/local/lib`, so you would expect `LIBCLANG_PATH` to be needed. It isn't -- `clang-sys` globs `/usr/local/llvm*/lib*` and matches `libclang.so.*` on FreeBSD, which is how `/usr/local/llvm-devel/lib` was found before.
* Pinning means `llvm19` will eventually age out of ports, though that fails loudly. The alternative is deriving the major version from the `llvm` metaport at install time -- happy to switch if preferred.

### Testing:
CI is the verification; the six FreeBSD jobs should go green. Note they never got past `prepare`, so anything after it is unverified by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
