### PR TITLE
fix: tighten AEAD, cipher IV, and digest API contracts

### DIFF
--- a/aws-lc-rs/src/aead/unbound_key.rs
+++ b/aws-lc-rs/src/aead/unbound_key.rs
@@ -402,8 +402,17 @@ impl UnboundKey {
 
         in_out.extend(tag_buffer[..alg_tag_len].iter());
 
-        let mut out_len = MaybeUninit::<usize>::uninit();
+        // Safe `Extend` implementations are not required to grow the buffer,
+        // so derive the FFI capacity from the actual post-extend slice.
         let mut_in_out = in_out.as_mut();
+        let out_capacity = mut_in_out.len();
+        let expected_len = plaintext_len.checked_add(alg_tag_len).ok_or(Unspecified)?;
+        // Only under-growth is unsound; an exact match also fails closed on over-growth.
+        if out_capacity != expected_len {
+            return Err(Unspecified);
+        }
+
+        let mut out_len = MaybeUninit::<usize>::uninit();
 
         {
             let nonce = nonce.as_ref();
@@ -415,7 +424,7 @@ impl UnboundKey {
                     self.ctx.as_ref().as_const_ptr(),
                     mut_in_out.as_mut_ptr(),
                     out_len.as_mut_ptr(),
-                    plaintext_len + alg_tag_len,
+                    out_capacity,
                     nonce.as_ptr(),
                     nonce.len(),
                     mut_in_out.as_ptr(),
@@ -443,21 +452,24 @@ impl UnboundKey {
         let mut tag_buffer = [0u8; MAX_TAG_NONCE_BUFFER_LEN];
 
         let mut out_tag_len = MaybeUninit::<usize>::uninit();
+        let plaintext_len;
 
         {
-            let plaintext_len = in_out.as_mut().len();
-            let in_out = in_out.as_mut();
+            // Derive both the FFI pointer and length from the same slice. `AsMut`
+            // implementations are not required to return the same view across calls.
+            let mut_in_out = in_out.as_mut();
+            plaintext_len = mut_in_out.len();
 
             if 1 != indicator_check!(unsafe {
                 EVP_AEAD_CTX_seal_scatter(
                     self.ctx.as_ref().as_const_ptr(),
-                    in_out.as_mut_ptr(),
+                    mut_in_out.as_mut_ptr(),
                     tag_buffer.as_mut_ptr(),
                     out_tag_len.as_mut_ptr(),
                     tag_buffer.len(),
                     null(),
                     0,
-                    in_out.as_ptr(),
+                    mut_in_out.as_ptr(),
                     plaintext_len,
                     null(),
                     0,
@@ -477,6 +489,11 @@ impl UnboundKey {
         )?);
 
         in_out.extend(&tag_buffer[..tag_len]);
+
+        let expected_len = plaintext_len.checked_add(tag_len).ok_or(Unspecified)?;
+        if in_out.as_mut().len() != expected_len {
+            return Err(Unspecified);
+        }
 
         Ok(nonce)
     }
@@ -596,5 +613,204 @@ impl From<hkdf::Okm<'_, &'static Algorithm>> for UnboundKey {
         let algorithm = *okm.len();
         okm.fill(key_bytes).unwrap();
         Self::new(algorithm, key_bytes).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NormalBuffer(Vec<u8>);
+
+    impl AsMut<[u8]> for NormalBuffer {
+        fn as_mut(&mut self) -> &mut [u8] {
+            self.0.as_mut_slice()
+        }
+    }
+
+    impl<'a> Extend<&'a u8> for NormalBuffer {
+        fn extend<T: IntoIterator<Item = &'a u8>>(&mut self, iter: T) {
+            self.0.extend(iter);
+        }
+    }
+
+    struct NoGrowBuffer(Vec<u8>);
+
+    impl AsMut<[u8]> for NoGrowBuffer {
+        fn as_mut(&mut self) -> &mut [u8] {
+            self.0.as_mut_slice()
+        }
+    }
+
+    impl<'a> Extend<&'a u8> for NoGrowBuffer {
+        fn extend<T: IntoIterator<Item = &'a u8>>(&mut self, _iter: T) {}
+    }
+
+    struct ShortExtendBuffer(Vec<u8>);
+
+    impl AsMut<[u8]> for ShortExtendBuffer {
+        fn as_mut(&mut self) -> &mut [u8] {
+            self.0.as_mut_slice()
+        }
+    }
+
+    impl<'a> Extend<&'a u8> for ShortExtendBuffer {
+        fn extend<T: IntoIterator<Item = &'a u8>>(&mut self, iter: T) {
+            self.0.extend(iter.into_iter().take(1));
+        }
+    }
+
+    struct ShrinkingBuffer(Vec<u8>);
+
+    impl AsMut<[u8]> for ShrinkingBuffer {
+        fn as_mut(&mut self) -> &mut [u8] {
+            self.0.as_mut_slice()
+        }
+    }
+
+    impl<'a> Extend<&'a u8> for ShrinkingBuffer {
+        fn extend<T: IntoIterator<Item = &'a u8>>(&mut self, _iter: T) {
+            let new_len = self.0.len().saturating_sub(1);
+            self.0.truncate(new_len);
+        }
+    }
+
+    fn test_key() -> UnboundKey {
+        UnboundKey::new(&AES_128_GCM, &[0x42u8; 16]).unwrap()
+    }
+
+    fn test_randnonce_key() -> UnboundKey {
+        UnboundKey::from(
+            AeadCtx::aes_128_gcm_randnonce(
+                &[0x42u8; 16],
+                AES_128_GCM.tag_len(),
+                AES_128_GCM.nonce_len(),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn test_nonce() -> Nonce {
+        Nonce::try_assume_unique_for_key(&[0x24u8; NONCE_LEN]).unwrap()
+    }
+
+    #[test]
+    fn seal_combined_normal_extend_succeeds_and_roundtrips() {
+        let key = test_key();
+        let plaintext = b"seal_combined soundness regression test".to_vec();
+        let mut in_out = NormalBuffer(plaintext.clone());
+
+        let nonce = key
+            .seal_combined(test_nonce(), &[], &mut in_out)
+            .expect("a normal, Vec-like Extend impl must succeed");
+
+        assert_eq!(in_out.0.len(), plaintext.len() + key.algorithm().tag_len());
+
+        let opened: &[u8] = key
+            .open_within(nonce, &[], &mut in_out.0, 0..)
+            .expect("the sealed output must open back to the original plaintext");
+        assert_eq!(opened, plaintext.as_slice());
+    }
+
+    #[test]
+    fn seal_combined_rejects_no_grow_extend() {
+        let key = test_key();
+        let plaintext = b"some plaintext".to_vec();
+        let original_len = plaintext.len();
+        let mut in_out = NoGrowBuffer(plaintext);
+
+        let result = key.seal_combined(test_nonce(), &[], &mut in_out);
+
+        assert!(
+            result.is_err(),
+            "a no-op Extend impl must not be trusted to have appended the tag"
+        );
+        assert_eq!(in_out.0.len(), original_len);
+    }
+
+    #[test]
+    fn seal_combined_rejects_short_extend() {
+        let key = test_key();
+        let mut in_out = ShortExtendBuffer(b"some plaintext".to_vec());
+
+        let result = key.seal_combined(test_nonce(), &[], &mut in_out);
+
+        assert!(
+            result.is_err(),
+            "an Extend impl that appends fewer bytes than the tag length must be rejected"
+        );
+    }
+
+    #[test]
+    fn seal_combined_rejects_shrinking_extend() {
+        let key = test_key();
+        let mut in_out = ShrinkingBuffer(b"some plaintext".to_vec());
+
+        let result = key.seal_combined(test_nonce(), &[], &mut in_out);
+
+        assert!(
+            result.is_err(),
+            "an Extend impl that shrinks the collection must be rejected"
+        );
+    }
+
+    #[test]
+    fn seal_combined_randnonce_normal_extend_succeeds_and_roundtrips() {
+        let key = test_randnonce_key();
+        let plaintext = b"seal_combined_randnonce soundness regression test".to_vec();
+        let mut in_out = NormalBuffer(plaintext.clone());
+
+        let nonce = key
+            .seal_combined_randnonce(&[], &mut in_out)
+            .expect("a normal, Vec-like Extend impl must succeed");
+
+        assert_eq!(in_out.0.len(), plaintext.len() + key.algorithm().tag_len());
+
+        let opened = key
+            .open_within(nonce, &[], &mut in_out.0, 0..)
+            .expect("the sealed output must open back to the original plaintext");
+        assert_eq!(opened, plaintext.as_slice());
+    }
+
+    #[test]
+    fn seal_combined_randnonce_rejects_no_grow_extend() {
+        let key = test_randnonce_key();
+        let plaintext = b"some plaintext".to_vec();
+        let original_len = plaintext.len();
+        let mut in_out = NoGrowBuffer(plaintext);
+
+        let result = key.seal_combined_randnonce(&[], &mut in_out);
+
+        assert!(
+            result.is_err(),
+            "a no-op Extend impl must not be trusted to have appended the tag"
+        );
+        assert_eq!(in_out.0.len(), original_len);
+    }
+
+    #[test]
+    fn seal_combined_randnonce_rejects_short_extend() {
+        let key = test_randnonce_key();
+        let mut in_out = ShortExtendBuffer(b"some plaintext".to_vec());
+
+        let result = key.seal_combined_randnonce(&[], &mut in_out);
+
+        assert!(
+            result.is_err(),
+            "an Extend impl that appends fewer bytes than the tag length must be rejected"
+        );
+    }
+
+    #[test]
+    fn seal_combined_randnonce_rejects_shrinking_extend() {
+        let key = test_randnonce_key();
+        let mut in_out = ShrinkingBuffer(b"some plaintext".to_vec());
+
+        let result = key.seal_combined_randnonce(&[], &mut in_out);
+
+        assert!(
+            result.is_err(),
+            "an Extend impl that shrinks the collection must be rejected"
+        );
     }
 }

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -128,6 +128,10 @@ impl StreamingEncryptingKey {
         if !algorithm.supports_mode(mode) {
             return Err(Unspecified);
         }
+        // EVP initialization reads the algorithm's IV length without receiving the slice length.
+        if !algorithm.is_valid_encryption_context(mode, &context) {
+            return Err(Unspecified);
+        }
         // The streaming path passes raw key bytes to the EVP API rather than
         // going through `SymmetricCipherKey` construction.  Validate
         // algorithm-specific key constraints (e.g. DES weak-key / K1!=K2
@@ -459,6 +463,9 @@ impl StreamingDecryptingKey {
         if !algorithm.supports_mode(mode) {
             return Err(Unspecified);
         }
+        if !algorithm.is_valid_decryption_context(mode, &context) {
+            return Err(Unspecified);
+        }
         // See comment in `StreamingEncryptingKey::new`.
         key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
@@ -703,9 +710,13 @@ impl StreamingDecryptingKey {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "legacy-des")]
+    #[allow(deprecated)]
+    use crate::cipher::DES_FOR_LEGACY_USE_ONLY;
     use crate::cipher::{
         DecryptionContext, EncryptionContext, OperatingMode, StreamingDecryptingKey,
-        StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_256, AES_256_KEY_LEN,
+        StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_128_KEY_LEN, AES_256,
+        AES_256_KEY_LEN,
     };
     use crate::iv::{FixedLength, IV_LEN_128_BIT};
     use crate::rand::{SecureRandom, SystemRandom};
@@ -1689,4 +1700,111 @@ mod tests {
         2,
         9
     );
+
+    #[test]
+    fn test_new_rejects_none_context_for_iv_required_modes() {
+        let key_bytes = [0u8; AES_128_KEY_LEN];
+        for mode in [
+            OperatingMode::CBC,
+            OperatingMode::CTR,
+            OperatingMode::CFB128,
+        ] {
+            let key = UnboundCipherKey::new(&AES_128, &key_bytes).unwrap();
+            assert!(
+                StreamingEncryptingKey::new(key, mode, EncryptionContext::None).is_err(),
+                "AES + {mode:?} + EncryptionContext::None should be rejected"
+            );
+
+            let key = UnboundCipherKey::new(&AES_128, &key_bytes).unwrap();
+            assert!(
+                StreamingDecryptingKey::new(key, mode, DecryptionContext::None).is_err(),
+                "AES + {mode:?} + DecryptionContext::None should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_new_accepts_none_context_for_ecb() {
+        let key_bytes = [0u8; AES_128_KEY_LEN];
+
+        let key = UnboundCipherKey::new(&AES_128, &key_bytes).unwrap();
+        assert!(
+            StreamingEncryptingKey::new(key, OperatingMode::ECB, EncryptionContext::None).is_ok()
+        );
+
+        let key = UnboundCipherKey::new(&AES_128, &key_bytes).unwrap();
+        assert!(
+            StreamingDecryptingKey::new(key, OperatingMode::ECB, DecryptionContext::None).is_ok()
+        );
+    }
+
+    #[cfg(feature = "legacy-des")]
+    #[test]
+    fn test_new_rejects_iv64_context_for_aes() {
+        let key_bytes = [0u8; AES_128_KEY_LEN];
+        for mode in [
+            OperatingMode::CBC,
+            OperatingMode::CTR,
+            OperatingMode::CFB128,
+        ] {
+            let key = UnboundCipherKey::new(&AES_128, &key_bytes).unwrap();
+            let context = EncryptionContext::Iv64(FixedLength::new().unwrap());
+            assert!(
+                StreamingEncryptingKey::new(key, mode, context).is_err(),
+                "AES + {mode:?} + EncryptionContext::Iv64 should be rejected"
+            );
+
+            let key = UnboundCipherKey::new(&AES_128, &key_bytes).unwrap();
+            let context = DecryptionContext::Iv64(FixedLength::new().unwrap());
+            assert!(
+                StreamingDecryptingKey::new(key, mode, context).is_err(),
+                "AES + {mode:?} + DecryptionContext::Iv64 should be rejected"
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_new_rejects_iv128_context_for_des() {
+        let key_bytes = from_hex("0123456789abcdef").unwrap();
+
+        let key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        let context = EncryptionContext::Iv128(FixedLength::new().unwrap());
+        assert!(
+            StreamingEncryptingKey::new(key, OperatingMode::CBC, context).is_err(),
+            "DES + CBC + EncryptionContext::Iv128 should be rejected"
+        );
+
+        let key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        let context = DecryptionContext::Iv128(FixedLength::new().unwrap());
+        assert!(
+            StreamingDecryptingKey::new(key, OperatingMode::CBC, context).is_err(),
+            "DES + CBC + DecryptionContext::Iv128 should be rejected"
+        );
+    }
+
+    #[cfg(feature = "legacy-des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_new_accepts_valid_des_contexts() {
+        let key_bytes = from_hex("0123456789abcdef").unwrap();
+
+        let key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        assert!(
+            StreamingEncryptingKey::new(key, OperatingMode::ECB, EncryptionContext::None).is_ok()
+        );
+        let key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        assert!(
+            StreamingDecryptingKey::new(key, OperatingMode::ECB, DecryptionContext::None).is_ok()
+        );
+
+        let key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        let context = EncryptionContext::Iv64(FixedLength::new().unwrap());
+        assert!(StreamingEncryptingKey::new(key, OperatingMode::CBC, context).is_ok());
+
+        let key = UnboundCipherKey::new(&DES_FOR_LEGACY_USE_ONLY, &key_bytes).unwrap();
+        let context = DecryptionContext::Iv64(FixedLength::new().unwrap());
+        assert!(StreamingDecryptingKey::new(key, OperatingMode::CBC, context).is_ok());
+    }
 }

--- a/aws-lc-rs/src/evp_pkey.rs
+++ b/aws-lc-rs/src/evp_pkey.rs
@@ -23,6 +23,7 @@ use crate::ptr::{ConstPointer, LcPtr};
 use crate::{cbs, digest};
 use core::ffi::c_int;
 use std::ptr::{null, null_mut};
+use zeroize::Zeroizing;
 
 impl PartialEq<Self> for LcPtr<EVP_PKEY> {
     /// Only compares params and public key
@@ -507,7 +508,7 @@ impl LcPtr<EVP_PKEY> {
         }
     }
 
-    pub(crate) fn agree(&self, peer_key: &mut Self) -> Result<Box<[u8]>, Unspecified> {
+    pub(crate) fn agree(&self, peer_key: &mut Self) -> Result<Zeroizing<Vec<u8>>, Unspecified> {
         let mut pctx = self.create_EVP_PKEY_CTX()?;
 
         if 1 != unsafe { EVP_PKEY_derive_init(pctx.as_mut_ptr()) } {
@@ -523,15 +524,17 @@ impl LcPtr<EVP_PKEY> {
             return Err(Unspecified);
         }
 
-        let mut secret = vec![0u8; secret_len];
+        // Own the allocation before the fallible derive call so every exit path scrubs it.
+        let mut secret = Zeroizing::new(vec![0u8; secret_len]);
         if 1 != indicator_check!(unsafe {
             EVP_PKEY_derive(pctx.as_mut_ptr(), secret.as_mut_ptr(), &mut secret_len)
         }) {
             return Err(Unspecified);
         }
+        // Preserve the allocation so `Zeroizing` can scrub its full capacity.
         secret.truncate(secret_len);
 
-        Ok(secret.into_boxed_slice())
+        Ok(secret)
     }
 
     pub(crate) fn generate<F>(pkey_type: c_int, params_fn: Option<F>) -> Result<Self, Unspecified>
@@ -572,5 +575,41 @@ impl Clone for LcPtr<EVP_PKEY> {
             "infallible AWS-LC function"
         );
         Self::new(unsafe { self.as_mut_unsafe_ptr() }).expect("non-null AWS-LC EVP_PKEY pointer")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aws_lc::EVP_PKEY_X25519;
+
+    fn generate_ed25519() -> LcPtr<EVP_PKEY> {
+        LcPtr::<EVP_PKEY>::generate(EVP_PKEY_ED25519, No_EVP_PKEY_CTX_consumer)
+            .expect("ed25519 keygen")
+    }
+
+    fn generate_x25519() -> LcPtr<EVP_PKEY> {
+        LcPtr::<EVP_PKEY>::generate(EVP_PKEY_X25519, No_EVP_PKEY_CTX_consumer)
+            .expect("x25519 keygen")
+    }
+
+    #[test]
+    fn agree_computes_matching_shared_secret_from_both_sides() {
+        let mut key_a = generate_x25519();
+        let mut key_b = generate_x25519();
+
+        let secret_ab = key_a.agree(&mut key_b).expect("agree a->b");
+        let secret_ba = key_b.agree(&mut key_a).expect("agree b->a");
+
+        assert!(!secret_ab.is_empty());
+        assert_eq!(secret_ab.as_slice(), secret_ba.as_slice());
+    }
+
+    #[test]
+    fn agree_rejects_mismatched_key_types() {
+        let x25519_key = generate_x25519();
+        let mut ed25519_key = generate_ed25519();
+
+        assert!(x25519_key.agree(&mut ed25519_key).is_err());
     }
 }

--- a/aws-lc-rs/src/hkdf.rs
+++ b/aws-lc-rs/src/hkdf.rs
@@ -194,8 +194,8 @@ impl Salt {
 
 impl From<Okm<'_, Algorithm>> for Salt {
     fn from(okm: Okm<'_, Algorithm>) -> Self {
-        let algorithm = okm.prk.algorithm;
-        let salt_len = okm.len().len();
+        let algorithm = okm.len;
+        let salt_len = okm.len.len();
         let mut salt_bytes = vec![0u8; salt_len];
         okm.fill(&mut salt_bytes).unwrap();
         Self {

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -79,6 +79,7 @@ impl ParsedVerificationAlgorithm for RsaParameters {
     ) -> Result<(), Unspecified> {
         let evp_pkey = public_key.key();
         verify_rsa_digest_signature(
+            self.digest_algorithm(),
             self.padding(),
             evp_pkey,
             digest,
@@ -126,11 +127,9 @@ impl VerificationAlgorithm for RsaParameters {
         digest: &Digest,
         signature: &[u8],
     ) -> Result<(), Unspecified> {
-        if self.digest_algorithm() != digest.algorithm() {
-            return Err(Unspecified);
-        }
         let evp_pkey = parse_rsa_public_key(public_key)?;
         verify_rsa_digest_signature(
+            self.digest_algorithm(),
             self.padding(),
             &evp_pkey,
             digest,
@@ -293,12 +292,18 @@ pub(crate) fn verify_rsa_signature(
 
 #[inline]
 pub(crate) fn verify_rsa_digest_signature(
+    algorithm: &'static digest::Algorithm,
     padding: &'static RsaPadding,
     public_key: &LcPtr<EVP_PKEY>,
     digest: &Digest,
     signature: &[u8],
     allowed_bit_size: &RangeInclusive<u32>,
 ) -> Result<(), Unspecified> {
+    // Enforced here so no caller can omit it; the ctx below is configured from `digest`.
+    if algorithm != digest.algorithm() {
+        return Err(Unspecified);
+    }
+
     if !allowed_bit_size.contains(&public_key.as_const().key_size_bits().try_into()?) {
         return Err(Unspecified);
     }

--- a/aws-lc-rs/tests/hkdf_test.rs
+++ b/aws-lc-rs/tests/hkdf_test.rs
@@ -149,6 +149,46 @@ fn hkdf_key_types() {
 }
 
 #[test]
+fn hkdf_cross_algorithm_salt_from_okm() {
+    let source_alg = hkdf::HKDF_SHA384;
+    let target_alg = hkdf::HKDF_SHA256;
+    assert_ne!(source_alg, target_alg);
+
+    let source_salt = hkdf::Salt::new(source_alg, b"source salt value");
+    let prk = source_salt.extract(b"input keying material");
+    let info: &[&[u8]] = &[b"context"];
+
+    let okm = prk.expand(info, target_alg).unwrap();
+    let derived_salt = hkdf::Salt::from(okm);
+
+    assert_eq!(derived_salt.algorithm(), target_alg);
+
+    // `Okm` is single-use, so derive the bytes again for the explicit control.
+    let mut salt_bytes = [0u8; 32]; // HKDF_SHA256 digest output length.
+    prk.expand(info, target_alg)
+        .unwrap()
+        .fill(&mut salt_bytes)
+        .unwrap();
+    let explicit_salt = hkdf::Salt::new(target_alg, &salt_bytes);
+
+    let secret = b"downstream secret";
+    let downstream_info: &[&[u8]] = &[b"downstream"];
+
+    let My(from_derived) = derived_salt
+        .extract(secret)
+        .expand(downstream_info, My(32))
+        .unwrap()
+        .into();
+    let My(from_explicit) = explicit_salt
+        .extract(secret)
+        .expand(downstream_info, My(32))
+        .unwrap()
+        .into();
+
+    assert_eq!(from_derived, from_explicit);
+}
+
+#[test]
 fn hkdf_clone_tests() {
     for &alg in &[
         hkdf::HKDF_SHA1_FOR_LEGACY_USE_ONLY,

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -1513,6 +1513,65 @@ fn test_wrong_digest() {
     assert!(upk.verify_digest(&digest_sha384, &signature).is_err());
 }
 
+fn check_verify_digest_sig_enforces_digest_pin(
+    signing_256: &'static dyn signature::RsaEncoding,
+    signing_384: &'static dyn signature::RsaEncoding,
+    verify_256: &'static dyn VerificationAlgorithm,
+    verify_384: &'static dyn VerificationAlgorithm,
+) {
+    let keypair = RsaKeyPair::generate(KeySize::Rsa2048).unwrap();
+    let msg = "Hello World!";
+    let digest_sha256 = digest::digest(&SHA256, msg.as_bytes());
+    let digest_sha384 = digest::digest(&SHA384, msg.as_bytes());
+
+    let mut sig_sha256 = vec![0u8; keypair.public_modulus_len()];
+    keypair
+        .sign_digest(signing_256, &digest_sha256, &mut sig_sha256)
+        .unwrap();
+    let mut sig_sha384 = vec![0u8; keypair.public_modulus_len()];
+    keypair
+        .sign_digest(signing_384, &digest_sha384, &mut sig_sha384)
+        .unwrap();
+
+    let public_key_bytes = keypair.public_key().as_ref();
+    let parsed_sha256 = ParsedPublicKey::new(verify_256, public_key_bytes).unwrap();
+    let parsed_sha384 = ParsedPublicKey::new(verify_384, public_key_bytes).unwrap();
+
+    parsed_sha256
+        .verify_digest_sig(&digest_sha256, &sig_sha256)
+        .unwrap();
+    parsed_sha384
+        .verify_digest_sig(&digest_sha384, &sig_sha384)
+        .unwrap();
+
+    assert!(parsed_sha256
+        .verify_digest_sig(&digest_sha384, &sig_sha384)
+        .is_err());
+    assert!(parsed_sha384
+        .verify_digest_sig(&digest_sha256, &sig_sha256)
+        .is_err());
+}
+
+#[test]
+fn test_parsed_public_key_rsa_pkcs1_verify_digest_sig_enforces_digest_pin() {
+    check_verify_digest_sig_enforces_digest_pin(
+        &signature::RSA_PKCS1_SHA256,
+        &signature::RSA_PKCS1_SHA384,
+        &signature::RSA_PKCS1_2048_8192_SHA256,
+        &signature::RSA_PKCS1_2048_8192_SHA384,
+    );
+}
+
+#[test]
+fn test_parsed_public_key_rsa_pss_verify_digest_sig_enforces_digest_pin() {
+    check_verify_digest_sig_enforces_digest_pin(
+        &signature::RSA_PSS_SHA256,
+        &signature::RSA_PSS_SHA384,
+        &signature::RSA_PSS_2048_8192_SHA256,
+        &signature::RSA_PSS_2048_8192_SHA384,
+    );
+}
+
 // Components of the RSA private key in "data/rsa_test_private_key_2048.der",
 // big-endian-encoded without leading zeros.
 mod test_key_components {


### PR DESCRIPTION
### Description of changes:
Hardens a handful of public APIs against inputs that previously succeeded by trusting the caller more than the type system allows.
* AEAD in-place seal now fail-closes if `Extend`/`AsMut` did not actually produce a `plaintext + tag` buffer before the FFI write.
* Streaming cipher constructors apply the same IV-context check the one-shot path already had.
* ECDH shared-secret buffers are owned in `Zeroizing` before the fallible derive.
* `Salt::from(Okm)` now takes the algorithm from the OKM, matching `Prk::from`.
* RSA `verify_digest_sig` pins the digest to the `RsaParameters` algorithm on both the parsed and unparsed paths.

### Call-outs:
- The AEAD check is fail-closed on over-growth as well as under-growth. A custom `AsMut` that returns a different view before vs after `Extend` is still not fully closable without changing the trait bound.
- The ECDSA digest pin already existed; this change brings the RSA parsed-key path in line with it.

### Testing:
Unit tests cover adversarial `Extend` impls and a normal round-trip, streaming IV mismatches (including `legacy-des`), the HKDF cross-algorithm `Salt::from` case, and PKCS#1/PSS digest pinning on `ParsedPublicKey`. `cargo test -p aws-lc-rs --lib --tests` is the intended smoke; I have not re-run the full feature matrix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
