### PR TITLE
ci: harden workflows and release tooling

### DIFF
--- a/.github/workflows/system-lib-tests-fips.yml
+++ b/.github/workflows/system-lib-tests-fips.yml
@@ -27,6 +27,9 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   # ---------------------------------------------------------------------------
   # Single edit point for the AWS-LC refs the workflow fans out over. Each must
@@ -61,18 +64,20 @@ jobs:
         aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
       - name: Checkout AWS-LC (${{ matrix.aws_lc_ref }})
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           repository: aws/aws-lc
           ref: ${{ matrix.aws_lc_ref }}
           submodules: 'recursive'
           path: aws-lc-fips-src
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.18'
 
@@ -84,7 +89,7 @@ jobs:
           cmake --version
 
       - name: Install bindgen-cli
-        run: cargo install --force --locked bindgen-cli
+        run: cargo install --force --locked --version 0.72.1 bindgen-cli
 
       - name: Select FIPS library form
         id: form
@@ -148,7 +153,7 @@ jobs:
           cmake --build build-fips-prefixed --target install -j
 
       - name: Upload install artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: |
@@ -158,7 +163,7 @@ jobs:
 
       - name: Upload prefixed install artifact (Linux)
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-lc-fips-install-prefixed-${{ matrix.aws_lc_ref }}
           path: install-fips-prefixed/
@@ -175,25 +180,29 @@ jobs:
         aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
       - name: Checkout AWS-LC (${{ matrix.aws_lc_ref }})
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           repository: aws/aws-lc
           ref: ${{ matrix.aws_lc_ref }}
           submodules: 'recursive'
           path: aws-lc-fips-src
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: ilammy/setup-nasm@v1
-      - uses: seanmiddleditch/gha-setup-ninja@v6
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+      - uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.18'
 
       - name: Install bindgen-cli
-        run: cargo install --force --locked bindgen-cli
+        run: cargo install --force --locked --version 0.72.1 bindgen-cli
 
       - name: Build and install AWS-LC FIPS (shared, Release, + Rust bindings)
         shell: bash
@@ -224,7 +233,7 @@ jobs:
           cmake --build build-nonfips --target install -j
 
       - name: Upload install artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: |
@@ -259,16 +268,21 @@ jobs:
       # silent regression, and stays robust even if a future actions/checkout
       # starts initializing submodules by default. The version check still runs
       # (it compares against a declared minimum, not submodule headers).
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC FIPS install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: ${{ github.workspace }}/fips-artifacts
@@ -327,30 +341,34 @@ jobs:
     steps:
       # aws-lc-rs checkout WITHOUT the submodule (and remove its working tree),
       # so a from-source fallback is impossible (see test-fips-unix).
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
       - name: Checkout AWS-LC at the declared minimum FIPS version
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           repository: aws/aws-lc
           ref: ${{ env.AWS_LC_FIPS_MIN_REF }}
           submodules: 'recursive'
           path: aws-lc-fips-min-src
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.18'
 
       - name: Install bindgen-cli
-        run: cargo install --force --locked bindgen-cli
+        run: cargo install --force --locked --version 0.72.1 bindgen-cli
 
       - name: Build and install AWS-LC FIPS (static) with Rust bindings
         run: |
@@ -404,16 +422,21 @@ jobs:
     steps:
       # Do not initialize the aws-lc submodule, and remove its working tree
       # outright (see test-fips-unix).
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download prefixed AWS-LC FIPS install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-prefixed-${{ matrix.aws_lc_ref }}
           path: ${{ github.workspace }}/fips-artifacts/install-fips-prefixed
@@ -464,17 +487,22 @@ jobs:
     steps:
       # Do not initialize the aws-lc submodule, and remove its working tree
       # outright (see test-fips-unix).
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Download AWS-LC FIPS install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: ${{ github.workspace }}/fips-artifacts
@@ -522,17 +550,22 @@ jobs:
     steps:
       # Do not initialize the aws-lc submodule (see test-fips-windows): a
       # missed detection cannot fall through to a source build.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Download AWS-LC FIPS install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: ${{ github.workspace }}/fips-artifacts
@@ -574,7 +607,9 @@ jobs:
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
         aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Remove the submodule working tree so fallback-to-source is impossible
       # (see test-fips-unix).
@@ -582,10 +617,13 @@ jobs:
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: ${{ github.workspace }}/fips-artifacts
@@ -616,7 +654,9 @@ jobs:
       matrix:
         aws_lc_ref: ${{ fromJSON(needs.setup.outputs.refs) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Remove the submodule working tree so fallback-to-source is impossible
       # (see test-fips-unix).
@@ -624,11 +664,14 @@ jobs:
         shell: bash
         run: rm -rf aws-lc-fips-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-windows-latest
           path: ${{ github.workspace }}/fips-artifacts
@@ -684,12 +727,17 @@ jobs:
     steps:
       # Do not initialize the aws-lc submodule (see test-fips-unix): a missed
       # detection cannot fall through to a source build.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC FIPS install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-fips-install-${{ matrix.aws_lc_ref }}-${{ matrix.os }}
           path: ${{ github.workspace }}/fips-artifacts

--- a/.github/workflows/system-lib-tests.yml
+++ b/.github/workflows/system-lib-tests.yml
@@ -12,6 +12,9 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   # ---------------------------------------------------------------------------
   # Build AWS-LC from the submodule into install prefixes that the test jobs
@@ -40,20 +43,22 @@ jobs:
         # system-library path is exercised on both Apple architectures.
         os: [ ubuntu-latest, macos-15-intel, macos-latest ]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.18'
 
       - name: Install bindgen-cli
-        run: cargo install --force --locked bindgen-cli
+        run: cargo install --force --locked --version 0.72.1 bindgen-cli
 
       - name: Build and install AWS-LC (static) with Rust bindings
         run: |
@@ -118,7 +123,7 @@ jobs:
           cmake --build build-dist-pkg --target install -j
 
       - name: Upload install artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-lc-install-${{ matrix.os }}
           path: |
@@ -132,26 +137,28 @@ jobs:
     name: Build AWS-LC (windows-latest)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
 
-      - uses: ilammy/setup-nasm@v1
+      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
 
-      - uses: seanmiddleditch/gha-setup-ninja@v6
+      - uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.18'
 
       - name: Install bindgen-cli
-        run: cargo install --force --locked bindgen-cli
+        run: cargo install --force --locked --version 0.72.1 bindgen-cli
 
       - name: Build and install AWS-LC (static) with Rust bindings
         shell: bash
@@ -201,7 +208,7 @@ jobs:
           cmake --build build-prefixed --target install -j
 
       - name: Upload install artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-lc-install-windows-latest
           path: |
@@ -265,16 +272,21 @@ jobs:
       # even if a future actions/checkout starts initializing submodules by
       # default. The version check still runs (it compares against a declared
       # minimum, not the submodule).
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-${{ matrix.os }}
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -313,16 +325,21 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-${{ matrix.os }}
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -369,16 +386,21 @@ jobs:
     name: "Test: read-only install, repeated builds (windows-latest)"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-windows-latest
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -438,25 +460,29 @@ jobs:
     steps:
       # aws-lc-rs checkout WITHOUT the submodule, so a from-source fallback is
       # impossible (see test-unix).
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-sys/aws-lc
 
       - name: Checkout AWS-LC at the declared minimum version
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           repository: aws/aws-lc
           ref: ${{ env.AWS_LC_MIN_VERSION }}
           path: aws-lc-min-src
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt --no-self-update
+          rustup default stable
 
       - name: Install bindgen-cli
-        run: cargo install --force --locked bindgen-cli
+        run: cargo install --force --locked --version 0.72.1 bindgen-cli
 
       - name: Build and install AWS-LC (static) with Rust bindings
         run: |
@@ -526,16 +552,21 @@ jobs:
       # Intentionally do NOT initialize the aws-lc/ submodule, and remove its
       # working tree outright (see test-unix). The version check still runs
       # against the installed version.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-windows-latest
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -588,16 +619,21 @@ jobs:
             cargo_args: "-p aws-lc-rs --lib"
     steps:
       # No submodule: a missed detection cannot fall through to a source build.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove the AWS-LC submodule working tree
         shell: bash
         run: rm -rf aws-lc-sys/aws-lc
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-windows-latest
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -649,12 +685,17 @@ jobs:
               mechanism: pkgconfig_dist
     steps:
       # No submodule: a missed detection cannot fall through to a source build.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-${{ matrix.os }}
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -731,12 +772,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # No submodule: a missed detection cannot fall through to a source build.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Download AWS-LC install
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aws-lc-install-ubuntu-latest
           path: ${{ github.workspace }}/aws-lc-artifacts
@@ -781,9 +827,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # No submodule and no system AWS-LC: detection must find nothing.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       - name: Assert the build fails when no system AWS-LC is present
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,9 +163,13 @@ jobs:
     if:  github.event_name == 'pull_request'
     name: aws-ls-rs coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           submodules: 'recursive'
           lfs: true
 
@@ -182,10 +186,9 @@ jobs:
       - name: Run FIPS coverage
         run: cargo llvm-cov -p aws-lc-rs --features unstable,fips --no-fail-fast --ignore-filename-regex "aws-lc-(fips-)?sys/.*" --codecov --output-path ./codecov-fips.json
       - name: Upload coverage reports to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          use_oidc: true
           files: ./codecov.json,./codecov-fips.json
           verbose: true
           fail_ci_if_error: true

--- a/scripts/generate/_generation_tools.sh
+++ b/scripts/generate/_generation_tools.sh
@@ -137,8 +137,18 @@ function assert_docker_status {
 
 function parse_version {
   local VERSION="${1}"
-  echo Version: "${VERSION}"
-  echo "${VERSION}" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+$'
+  printf 'Version: %s\n' "${VERSION}"
+  [[ "${VERSION}" != *$'\n'* ]] &&
+    [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+function version_is_greater {
+  local CANDIDATE_VERSION="${1}"
+  local PUBLISHED_VERSION="${2}"
+
+  perl -Mversion -e \
+    'exit !(version->parse($ARGV[0]) > version->parse($ARGV[1]))' \
+    -- "${CANDIDATE_VERSION}" "${PUBLISHED_VERSION}"
 }
 
 function prompt_yes_no {
@@ -166,6 +176,7 @@ function validate_crate_version {
   local CRATE_VERSION
   CRATE_VERSION=$("${REPO_ROOT}"/scripts/tools/cargo-dig.rs -v)
 
+  local PUBLISHED_CRATE_VERSION
   PUBLISHED_CRATE_VERSION=$(cargo search "${CRATE_NAME}" | grep -E "^${CRATE_NAME} " | sed -e 's/.*"\(.*\)".*/\1/')
 
   if ! parse_version "${PUBLISHED_CRATE_VERSION}"; then
@@ -176,7 +187,7 @@ function validate_crate_version {
   echo
   echo "Current published version of ${CRATE_NAME}: ${PUBLISHED_CRATE_VERSION}"
   if parse_version "${CRATE_VERSION}"; then
-    if ! perl -e "exit !(version->parse('${CRATE_VERSION}')>version->parse('${PUBLISHED_CRATE_VERSION}'))"; then
+    if ! version_is_greater "${CRATE_VERSION}" "${PUBLISHED_CRATE_VERSION}"; then
       echo "New version must come after: ${PUBLISHED_CRATE_VERSION}"
       exit 1
     fi


### PR DESCRIPTION
### Description of changes:

- Restricts the system-library workflows to explicit read-only permissions, disables persisted checkout credentials, and pins their actions and installed tooling.
- Replaces the Codecov repository token with OIDC and pins the coverage workflow actions.
- Prevents registry metadata from being interpolated into Perl source and rejects malformed or multiline crate versions.

### Call-outs:

Documentation deployment hardening is intentionally excluded and will be handled in a separate PR. The Codecov upload now depends on Codecov accepting GitHub OIDC for this repository.

### Testing:

- `/tmp/aws-lc-rs-actionlint-1.7.12/actionlint -shellcheck= .github/workflows/tests.yml .github/workflows/system-lib-tests.yml .github/workflows/system-lib-tests-fips.yml`
- `bash -n scripts/generate/_generation_tools.sh`
- `git diff --check upstream/main...HEAD`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
