### PR TITLE
ci: harden documentation deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,18 +10,23 @@ env:
   # We can pin the version if nightly is too unstable.
   # Otherwise, we test against the latest version.
   RUST_NIGHTLY_TOOLCHAIN: nightly
+  MDBOOK_VERSION: 0.4.34
+  MDBOOK_SHA256: 535a109e6f5a838c644fb0615d34f4c12e588b666f7e4b28fb987e79e2807288
   DEBIAN_FRONTEND: noninteractive
 
 permissions:
-  contents: write
-  pages: write
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy-user-guide:
+  build-user-guide:
     if: github.repository == 'aws/aws-lc-rs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: 'recursive'
@@ -29,12 +34,16 @@ jobs:
         run: |
           rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --no-self-update
           rustup default ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.18'
       - name: Build and Test User Guide
         run: |
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          curl --proto '=https' --tlsv1.2 --fail --location \
+            --output mdbook.tar.gz \
+            "https://github.com/rust-lang/mdBook/releases/download/v${{ env.MDBOOK_VERSION }}/mdbook-v${{ env.MDBOOK_VERSION }}-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' "${{ env.MDBOOK_SHA256 }}" mdbook.tar.gz | sha256sum --check
+          tar xzf mdbook.tar.gz
           ./mdbook build book
           ./mdbook test book
       - name: Build Documentation
@@ -45,7 +54,28 @@ jobs:
         run: |
           mkdir -p "book/book/rustdocs/${REF_NAME}"
           cp --recursive target/doc -t "book/book/rustdocs/${REF_NAME}"
-      - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Validate documentation artifact
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          test -f book/book/index.html
+          test -f "book/book/rustdocs/${REF_NAME}/doc/aws_lc_rs/index.html"
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          folder: book/book
+          path: book/book
+
+  deploy-user-guide:
+    if: github.repository == 'aws/aws-lc-rs'
+    needs: build-user-guide
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy documentation
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
### Description of changes:

Addresses security review finding 2.

- Verifies the pinned mdBook archive before execution and pins all GitHub Actions to immutable revisions.
- Builds documentation in a read-only job and deploys it from a separate job with only `pages: write` and `id-token: write`.
- Replaces the third-party branch deployment action with the official GitHub Pages artifact and deployment actions.
- Preserves and validates the existing `rustdocs/<ref>/doc` artifact layout.

### Call-outs:

GitHub Pages must be configured to use GitHub Actions as its deployment source when this change merges. Deployments continue to replace the existing site rather than retain rustdocs from multiple refs.

### Testing:

- `cargo test`
- mdBook v0.4.34 build and test
- `cargo doc --features fips,unstable --no-deps --workspace`
- Local documentation artifact-layout validation
- `actionlint .github/workflows/deploy-docs.yml`
- `git diff --check`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
