### PR TITLE
docs: document system library trust model

### DIFF
--- a/aws-lc-fips-sys/README.md
+++ b/aws-lc-fips-sys/README.md
@@ -101,8 +101,16 @@ AWS_LC_FIPS_SYS_SYSTEM_DIR=/path/to/aws-lc-fips-install cargo build
 `AWS_LC_FIPS_SYS_SYSTEM_DIR` need not be set explicitly. When it is unset, the
 build script tries to discover a usable AWS-LC FIPS install from common
 OpenSSL-compatible environment variables and pkg-config metadata, and links it
-if found; otherwise it builds the bundled source. Discovery order, highest
-precedence first:
+if found; otherwise it builds the bundled source.
+
+Paths selected by these variables or pkg-config are trusted build inputs.
+Validation may load and execute a candidate before adoption, including
+shared-library initialization and candidates later rejected. The probe runs only
+when the host can launch the target directly or through
+`CARGO_TARGET_<TRIPLE>_RUNNER`. To disable automatic detection, leave
+`AWS_LC_FIPS_SYS_SYSTEM_DIR` unset and set `AWS_LC_FIPS_SYS_USE_SYSTEM=0`.
+
+Discovery order, highest precedence first:
 
 1. `AWS_LC_FIPS_SYS_SYSTEM_DIR` — explicit prefix (above); problems with an
    explicit prefix are fatal, never a silent fallback.

--- a/aws-lc-sys/README.md
+++ b/aws-lc-sys/README.md
@@ -108,7 +108,16 @@ environment variables and pkg-config metadata, and links it if found; otherwise
 it falls back to building the bundled source.
 This makes the crate link against the AWS-LC provided by the surrounding
 environment (for example, the AWS-LC present in a build's dependency closure)
-with no extra configuration. Discovery order, highest precedence first:
+with no extra configuration.
+
+Paths selected by these variables or pkg-config are trusted build inputs. With
+the `fips` feature, validation may load and execute a candidate before adoption,
+including shared-library initialization and candidates later rejected. The
+probe runs only when the host can launch the target directly or through
+`CARGO_TARGET_<TRIPLE>_RUNNER`. To disable automatic detection, leave
+`AWS_LC_SYS_SYSTEM_DIR` unset and set `AWS_LC_SYS_USE_SYSTEM=0`.
+
+Discovery order, highest precedence first:
 
 1. `AWS_LC_SYS_SYSTEM_DIR` — explicit install prefix (above). Any problem with
    an explicit prefix is a hard error, never a silent fallback.

--- a/builder/system_detect.rs
+++ b/builder/system_detect.rs
@@ -24,12 +24,15 @@
 //!    matching `openssl-sys`'s "env vars take precedence over pkg-config"
 //!    ordering while also recognizing AWS-LC's native package names.
 //!
-//! Probing pkg-config on the default path is safe despite not being opt-in:
-//! a candidate is only *adopted* if it carries the `OPENSSL_IS_AWSLC` marker
-//! and ships usable bindings, so a stray system OpenSSL (or a binding-less
-//! AWS-LC) is rejected and the build falls back to source. Cross-compilation is
-//! left to the `pkg_config` crate, which refuses to run unless
-//! `PKG_CONFIG_ALLOW_CROSS=1` (again matching `openssl-sys`).
+//! Treat `OPENSSL_*`, pkg-config metadata, and the paths they select as trusted
+//! build inputs. For FIPS builds, validation may load and execute a candidate
+//! before adoption, including shared-library initialization and candidates later
+//! rejected. Set `<crate>_USE_SYSTEM=0` to skip automatic discovery.
+//!
+//! Cross-compilation discovery is left to the `pkg_config` crate, which refuses
+//! to run unless `PKG_CONFIG_ALLOW_CROSS=1` (again matching `openssl-sys`). The
+//! FIPS probe runs only when the host can launch the target directly or through
+//! `CARGO_TARGET_<TRIPLE>_RUNNER`.
 
 use crate::system_library::{InstallLayout, SystemLib};
 use crate::{

--- a/builder/system_library.rs
+++ b/builder/system_library.rs
@@ -309,9 +309,9 @@ impl SystemLib {
             resolve_bindings(self.layout.bindings_prefix.as_deref(), &self.bindings_file)?;
 
         if is_fips_build() {
-            // Verify the supplied FIPS library is a usable FIPS module before
-            // committing to it. The matching startup self-check link directive
-            // is emitted later, in `link`.
+            // This may execute code from the trusted FIPS candidate before
+            // validation completes. See `system_detect` for the trust model. The
+            // matching startup self-check link directive is emitted in `link`.
             verify_fips_install(
                 self.manifest_dir.as_path(),
                 include_dir,


### PR DESCRIPTION
### Description of changes:

Clarifies that system-library paths and pkg-config results are trusted build inputs and that FIPS validation may execute candidates before adoption. Documents probe execution and the automatic-detection opt-out in both sys-crate READMEs and builder comments.

### Call-outs:

Documentation only; no system detection or FIPS probe behavior changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
