### PR TITLE
docs: align pull request template with AWS-LC

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,46 @@
-### Issues:
-Resolves #ISSUE-NUMBER1
-Addresses #ISSUE-NUMBER2
+### Related issues
 
-### Description of changes: 
-Describe current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
+<!--
+OPTIONAL: Delete this section if no issue is relevant.
 
-### Call-outs:
-Point out areas that need special attention or support during the review process. Discuss architecture or design changes.
+- Use "Addresses #123" for issues directly addressed by this change.
+- Use "Related to #123" for other relevant issues.
+- Do not use GitHub issue-closing keywords such as "Resolves", "Fixes", or "Closes". Issues should remain open until the change is included in a published release.
+-->
 
-### Testing:
-How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
+### Context and motivation
+
+<!--
+- What current behavior, problem, or limitation motivates this change?
+- What outcome should this change achieve?
+- Keep implementation details for the next section.
+-->
+
+### Description of changes
+
+<!--
+- What changed, and how does it address the context above?
+- What externally observable behavior or non-obvious design decisions should reviewers know about?
+- Avoid a file-by-file summary.
+-->
+
+### Testing
+
+<!--
+- What tests were added or modified, and how do they demonstrate correctness?
+- For a bug fix, how would the tests catch a regression to the buggy behavior?
+- If performance is relevant, what was measured, against what baseline, and with what result?
+- If no tests were added or modified, why is existing coverage sufficient?
+-->
+
+### Review considerations
+
+<!--
+OPTIONAL: Delete this section if there are no special review considerations.
+
+- Does this change affect a public API or ABI?
+- Are there compatibility concerns or FIPS boundary considerations?
+- Are there non-obvious tradeoffs, areas requiring focused review, or follow-up work?
+-->
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.


### PR DESCRIPTION
### Context and motivation

Keep aws-lc-rs pull request guidance aligned with AWS-LC and help authors give reviewers the context, test evidence, and review-sensitive details needed to evaluate a change.

### Description of changes

Update the pull request template to use the AWS-LC structure and guidance, including issue references that do not close issues before a published release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
