### PR TITLE
feat: implement `Eq` for `RsaParameters`

### DIFF
--- a/aws-lc-rs/src/ed25519.rs
+++ b/aws-lc-rs/src/ed25519.rs
@@ -33,7 +33,7 @@ const ED25519_SIGNATURE_LEN: usize = crate::aws_lc::ED25519_SIGNATURE_LEN as usi
 const ED25519_SEED_LEN: usize = 32;
 
 /// Parameters for `EdDSA` signing and verification.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EdDSAParameters;
 
 impl sealed::Sealed for EdDSAParameters {}

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -22,13 +22,18 @@ use untrusted::Input;
 
 #[allow(non_camel_case_types)]
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum RsaPadding {
     RSA_PKCS1_PADDING,
     RSA_PKCS1_PSS_PADDING,
 }
 
 /// Parameters for RSA verification.
+///
+/// Two values are equal when they denote the same verification algorithm, e.g.
+/// `RSA_PKCS1_2048_8192_SHA256`. Algorithms differing in digest algorithm,
+/// padding scheme or modulus size range compare unequal.
+#[derive(Eq, PartialEq)]
 pub struct RsaParameters(
     &'static digest::Algorithm,
     &'static RsaPadding,
@@ -146,18 +151,6 @@ impl Debug for RsaParameters {
         f.write_str(&format!("{{ {:?} }}", self.3))
     }
 }
-
-/// Two `RsaParameters` are equal when they identify the same verification
-/// algorithm. The remaining fields (digest algorithm, padding and modulus
-/// range) are determined by that identifier, so comparing it is sufficient.
-impl PartialEq for RsaParameters {
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        self.3 == other.3
-    }
-}
-
-impl Eq for RsaParameters {}
 
 impl RsaParameters {
     pub(crate) const fn new(

--- a/aws-lc-rs/src/rsa/signature.rs
+++ b/aws-lc-rs/src/rsa/signature.rs
@@ -147,6 +147,18 @@ impl Debug for RsaParameters {
     }
 }
 
+/// Two `RsaParameters` are equal when they identify the same verification
+/// algorithm. The remaining fields (digest algorithm, padding and modulus
+/// range) are determined by that identifier, so comparing it is sufficient.
+impl PartialEq for RsaParameters {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.3 == other.3
+    }
+}
+
+impl Eq for RsaParameters {}
+
 impl RsaParameters {
     pub(crate) const fn new(
         digest_alg: &'static digest::Algorithm,
@@ -179,7 +191,7 @@ impl RsaParameters {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
 pub(crate) enum RsaVerificationAlgorithmId {
     RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,

--- a/aws-lc-rs/tests/ecdsa_tests.rs
+++ b/aws-lc-rs/tests/ecdsa_tests.rs
@@ -9,8 +9,8 @@ use aws_lc_rs::digest::{
 use aws_lc_rs::encoding::{AsBigEndian, AsDer, EcPrivateKeyRfc5915Der};
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{
-    self, EcdsaKeyPair, KeyPair, ParsedPublicKey, Signature, UnparsedPublicKey,
-    VerificationAlgorithm,
+    self, EcdsaKeyPair, EcdsaSigningAlgorithm, EcdsaVerificationAlgorithm, KeyPair,
+    ParsedPublicKey, Signature, UnparsedPublicKey, VerificationAlgorithm,
 };
 use aws_lc_rs::{digest, test, test_file};
 
@@ -20,6 +20,9 @@ fn ecdsa_traits() {
     test::compile_time_assert_sync::<EcdsaKeyPair>();
     test::compile_time_assert_send::<Signature>();
     test::compile_time_assert_sync::<Signature>();
+
+    test::compile_time_assert_eq::<EcdsaVerificationAlgorithm>();
+    test::compile_time_assert_eq::<EcdsaSigningAlgorithm>();
 }
 
 #[test]

--- a/aws-lc-rs/tests/ed25519_tests.rs
+++ b/aws-lc-rs/tests/ed25519_tests.rs
@@ -6,7 +6,7 @@
 use aws_lc_rs::encoding::{AsBigEndian, AsDer, Curve25519SeedBin};
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{
-    self, Ed25519KeyPair, KeyPair, ParsedPublicKey, VerificationAlgorithm, ED25519,
+    self, Ed25519KeyPair, EdDSAParameters, KeyPair, ParsedPublicKey, VerificationAlgorithm, ED25519,
 };
 use aws_lc_rs::{error, test, test_file};
 
@@ -14,6 +14,10 @@ use aws_lc_rs::{error, test, test_file};
 fn test_ed25519_traits() {
     test::compile_time_assert_send::<Ed25519KeyPair>();
     test::compile_time_assert_sync::<Ed25519KeyPair>();
+
+    test::compile_time_assert_eq::<EdDSAParameters>();
+    // `EdDSAParameters` carries no state, so all values are equal.
+    assert_eq!(&ED25519, &ED25519);
 }
 
 /// Test vectors from `BoringSSL`.

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -50,7 +50,6 @@ fn rsa_traits() {
 
 #[test]
 fn rsa_parameters_equality() {
-    // Reflexive: every verification algorithm equals itself.
     let all = [
         &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
         &signature::RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
@@ -64,26 +63,20 @@ fn rsa_parameters_equality() {
         &signature::RSA_PSS_2048_8192_SHA384,
         &signature::RSA_PSS_2048_8192_SHA512,
     ];
-    for params in all {
-        assert_eq!(params, params);
-    }
 
-    // Every pair of distinct algorithms compares unequal. This also guards the
-    // invariant that `PartialEq` relies on: each `RsaParameters` constant
-    // carries a distinct verification algorithm identifier.
+    // Every algorithm equals itself, and no two distinct algorithms compare
+    // equal.
     for (i, a) in all.iter().enumerate() {
         for (j, b) in all.iter().enumerate() {
             if i == j {
-                continue;
+                assert_eq!(a, b, "params compared unequal to itself: {a:?}");
+            } else {
+                assert_ne!(a, b, "distinct params compared equal: {a:?} vs {b:?}");
             }
-            assert_ne!(a, b, "distinct params compared equal: {a:?} vs {b:?}");
         }
     }
 
-    // An independently constructed value equals the constant it was copied
-    // from, so equality is by algorithm identity rather than by address.
-    let copied = signature::RSA_PKCS1_2048_8192_SHA256;
-    assert_eq!(&copied, &signature::RSA_PKCS1_2048_8192_SHA256);
+    // Each field participates in the comparison.
 
     // Same digest and modulus range, different padding.
     assert_ne!(

--- a/aws-lc-rs/tests/rsa_test.rs
+++ b/aws-lc-rs/tests/rsa_test.rs
@@ -44,6 +44,64 @@ fn rsa_traits() {
     test::compile_time_assert_sync::<Pkcs1PrivateDecryptingKey>();
     test::compile_time_assert_send::<Pkcs1PublicEncryptingKey>();
     test::compile_time_assert_sync::<Pkcs1PublicEncryptingKey>();
+
+    test::compile_time_assert_eq::<RsaParameters>();
+}
+
+#[test]
+fn rsa_parameters_equality() {
+    // Reflexive: every verification algorithm equals itself.
+    let all = [
+        &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY,
+        &signature::RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY,
+        &signature::RSA_PKCS1_1024_8192_SHA512_FOR_LEGACY_USE_ONLY,
+        &signature::RSA_PKCS1_2048_8192_SHA1_FOR_LEGACY_USE_ONLY,
+        &signature::RSA_PKCS1_2048_8192_SHA256,
+        &signature::RSA_PKCS1_2048_8192_SHA384,
+        &signature::RSA_PKCS1_2048_8192_SHA512,
+        &signature::RSA_PKCS1_3072_8192_SHA384,
+        &signature::RSA_PSS_2048_8192_SHA256,
+        &signature::RSA_PSS_2048_8192_SHA384,
+        &signature::RSA_PSS_2048_8192_SHA512,
+    ];
+    for params in all {
+        assert_eq!(params, params);
+    }
+
+    // Every pair of distinct algorithms compares unequal. This also guards the
+    // invariant that `PartialEq` relies on: each `RsaParameters` constant
+    // carries a distinct verification algorithm identifier.
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            assert_ne!(a, b, "distinct params compared equal: {a:?} vs {b:?}");
+        }
+    }
+
+    // An independently constructed value equals the constant it was copied
+    // from, so equality is by algorithm identity rather than by address.
+    let copied = signature::RSA_PKCS1_2048_8192_SHA256;
+    assert_eq!(&copied, &signature::RSA_PKCS1_2048_8192_SHA256);
+
+    // Same digest and modulus range, different padding.
+    assert_ne!(
+        &signature::RSA_PKCS1_2048_8192_SHA256,
+        &signature::RSA_PSS_2048_8192_SHA256
+    );
+
+    // Same digest and padding, different modulus range.
+    assert_ne!(
+        &signature::RSA_PKCS1_2048_8192_SHA256,
+        &signature::RSA_PKCS1_1024_8192_SHA256_FOR_LEGACY_USE_ONLY
+    );
+
+    // Same padding and modulus range, different digest.
+    assert_ne!(
+        &signature::RSA_PKCS1_2048_8192_SHA384,
+        &signature::RSA_PKCS1_2048_8192_SHA512
+    );
 }
 
 #[test]


### PR DESCRIPTION
Implement `Eq` and `PartialEq` for `aws_lc_rs::signature::RsaParameters` to permit discerning `ParsedPublicKey` algorithm. These traits are already implemented on `EcdsaVerificationAlgorithm` and are not required on `EdDSAParamters` as `Ed448` is not supported (only `Ed25519`).

### Issues:
N/A

### Description of changes: 
It currently appears to be impossible to discern the specific variant of RSA via the `algorithm` method on a `ParsedPublicKey` without resorting to its `Debug` trait. Prior to 0c88590, it was possible to use `std::ptr::addr_eq`. While it is technically possible to use a small buffer on the stack to hold the `Debug` identifier, that feels like an anti-pattern and no less brittle or subject to breakage as `ptr::addr_eq`. This change permits discerning the algorithm of a `ParsedPublicKey` in a reliable and straightforward way, and provides tests to ensure there are no unexpected breaking changes. The real world application for this is in [OxiToken](https://github.com/dsykes16/oxiauth/blob/main/oxitoken/src/crypto/aws_lc/verify.rs) (JWT library), which was broken by the changes in 0c88590.

### Call-outs:
This only implements traits on existing types; no breaking changes. 

`Eq` and `PartialEq` are already implemented on `EcdsaVerificationAlgorithm` here https://github.com/aws/aws-lc-rs/blob/main/aws-lc-rs/src/ec/signature.rs#L30

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
